### PR TITLE
docs(skill): SKILL.md 步骤 2 增加复制前来源比对/重装指引 (#28)

### DIFF
--- a/dsh/skill/SKILL.md
+++ b/dsh/skill/SKILL.md
@@ -42,6 +42,15 @@ cp -R <SKILL_DIR>/roles .agent-runs/$TASK/roles
 
 角色快照进 run 目录而不是让节点 agent 读 skill 目录，原因有二：节点 agent 的文件沙箱按会话工作区授权，工作区外路径可能不可读；快照随 run 归档满足「全程留痕」——本次 run 用的角色版本可溯。
 
+**复制前先比对来源，防止旧模板静默进入 run**：`<SKILL_DIR>` 是安装副本，可能因旧安装而漂移。复制前先比对副本与仓库真源：
+
+```bash
+diff -r <SKILL_DIR>/roles <仓库>/dsh/roles/
+diff    <SKILL_DIR>/SKILL.md <仓库>/dsh/skill/SKILL.md
+```
+
+比对不一致（尤其 roles 或 workflow 有差异）说明安装副本已过时——**先重装再快照**：执行 `<仓库>/dsh/install-skill.sh`；重装后仍不一致则**改源**，直接以仓库 `dsh/roles/` 作为快照源，并记录漂移原因。切忌把旧模板静默带进 run。
+
 ### 3. 调用 workflow 工具
 
 读取 `<SKILL_DIR>/workflow/dev-workflow-2.0.mjs` 全文，原样作为 `script` 参数；`meta` 与 `args` 如下：


### PR DESCRIPTION
## 目标

保证每个新 run 的角色快照与仓库 `dsh/roles/*.md` 最新版一致，旧模板/漂移副本不再静默进入 run（issue #28，范围经 requirements-analysis 修订收窄：真源机制已由 #25/#26 落地，本轮仅剩安装副本同步 + SKILL.md 步骤 2 指引）。

## 改动

- `dsh/skill/SKILL.md` 步骤 2（+9 行）：新增「复制前先比对来源，防止旧模板静默进入 run」子段——两条 diff 比对命令（`<SKILL_DIR>/roles` ↔ 仓库 `dsh/roles/`、`<SKILL_DIR>/SKILL.md` ↔ 仓库 `dsh/skill/SKILL.md`）+「先重装再快照 / 改源」决策路径。
- 安装副本 `~/.agents/skills/dev-workflow-2-0` 已同步（由外部执行体重装，本分支只读 diff 复核逐字节一致）。

## 验收结论（人工验收已通过）

| 验收标准 | 结论 |
|----------|------|
| ① 重装后安装副本与仓库对应文件 diff 为空（无 .tmpdir 残留） | ✅ VERIFIED |
| ② SKILL.md 步骤 2 含来源比对/重装指引（机械检查） | ✅ VERIFIED |
| ③ 重装后 run 快照与仓库 dsh/roles/*.md diff 为空 | ✅ VERIFIED |

审查：APPROVE（2 项 LOW，不阻塞）。测试节点按调度判定跳过（need_integration_test=false，纯文档改动；verify.sh 机械校验全绿）。

## 报告清单

- dev-report.md / review-report.md / accept-report.md / acceptance-summary.md / cleanup-report.md（`.agent-runs/issue-28/`）