### PR TITLE
[dev-workflow-2.0] 人工复现命令补 worktree 缺失兜底（SKILL.md / accept 角色）

### DIFF
--- a/dsh/roles/accept.md
+++ b/dsh/roles/accept.md
@@ -6,7 +6,10 @@
 2. **通俗验收报告**：产出 `acceptance-summary.md`，用通俗易懂的语言说明——
    - 任务目标：一句话说明这个任务原本要解决什么问题
    - 达成情况：逐条验收标准标注 ✅ 已达成 / ⚠️ 部分达成 / ❌ 未达成，每条附人话解释
-   - 人工验收可这样确认：给出可操作的确认方式（打开看 / 动手试 / 跑一下 / 看证据），让不熟悉技术细节的验收人也能独立判断
+   - 人工验收可这样确认：给出可操作的确认方式（打开看 / 动手试 / 跑一下 / 看证据），让不熟悉技术细节的验收人也能独立判断。
+     复现涉及切工作分支时，同步给出 worktree 缺失兜底：`<runDir>/worktree` 不存在时先
+     `git worktree add <runDir>/worktree -b dev2/<taskId> <base分支>`（分支 dev2/<taskId> 也不存在）或
+     `git worktree add <runDir>/worktree dev2/<taskId>`（分支仍在、仅 worktree 缺失），恢复后再复现，不要裸报错。
 3. **严格验收报告**：产出 `accept-report.md`，逐条记录验收标准状态（VERIFIED / PARTIAL / MISSING）与证据来源，裁决 PASS / FAIL / INCOMPLETE。
 4. **人工验收门禁**：汇总两份报告后，等待人工确认通过/不通过。验收通过进入收口环节；不通过则打回开发修复（这是唯一允许从验收环节打回的路径）。
 
@@ -33,6 +36,9 @@
 - 人工验证先切分支：人工复现验证或只读核验前，必须先切到工作分支 dev2/<taskId>（worktree），
   确认 `git -C <worktree> rev-parse --abbrev-ref HEAD` = dev2/<taskId> 且 HEAD 与 worktree 一致后再动手；
   禁止在主工作区（停在 base 分支）上复现验证，避免「验证跑在错误分支」得出相反结论。
+  worktree 缺失时先恢复再切：`<worktree>` 不存在则 `git worktree add <runDir>/worktree -b dev2/<taskId> <base分支>`
+  （分支 dev2/<taskId> 也不存在）或 `git worktree add <runDir>/worktree dev2/<taskId>`（分支仍在、仅 worktree 缺失），
+  恢复后核对 `git -C <worktree> rev-parse --abbrev-ref HEAD` = dev2/<taskId> 再动手，不要裸报错。
 - 验收报告必须通俗：能说"点开设置页能看到新的开关"，就不说"配置面板新增 toggle 组件"。
 - 未达成的项必须如实列出，说明是否阻塞验收，不隐瞒。
 - 验证独立于代码编写过程，不能自己写自己验收。

--- a/dsh/skill/SKILL.md
+++ b/dsh/skill/SKILL.md
@@ -90,6 +90,10 @@ cp -R <SKILL_DIR>/roles .agent-runs/$TASK/roles
    verified_branch = dev2/<taskId>（worktree 分支）、verified_head 与 worktree HEAD 一致；
    验收人若要亲手复现，先 `git -C <runDir>/worktree checkout dev2/<taskId>` 切到工作分支再动手，
    避免在主工作区（停在 base 分支）上复现出相反结论。
+   **worktree 缺失兜底**：若 `<runDir>/worktree` 已不存在（worktree 缺失），先恢复再继续，不要裸报错——
+   · 分支 dev2/<taskId> 也不存在时：`git worktree add <runDir>/worktree -b dev2/<taskId> <base分支>`；
+   · 分支仍在、仅 worktree 缺失时：`git worktree add <runDir>/worktree dev2/<taskId>`。
+   恢复后核对 `git -C <runDir>/worktree rev-parse --abbrev-ref HEAD` = dev2/<taskId> 再动手复现。
 1. 向用户呈现 `<runDir>/acceptance-summary.md` 的核心内容（逐条 ✅/⚠️/❌ + 确认方式）；
 2. 用 ask_user_question 发起裁决：通过 / 不通过（附意见）；
 3. **通过** → 以 `entry=closeout` 续跑（收口会推送分支、合并 PR、关闭 issue、收束本地工作区）；


### PR DESCRIPTION
## 目标

人工复现指引在 worktree 缺失时给出可执行的恢复路径（先 `git worktree add <runDir>/worktree <workBranch>` 再继续），不再裸报错。

来源：issue #23 交付后 follow-up（review-report LOW 项 → cleanup-report 后续事项 3）。

## 范围

- `dsh/skill/SKILL.md`：人工门禁复现命令加「worktree 缺失兜底」（分支缺失 `-b`、分支仍在直接 add，恢复后核对 HEAD 分支）
- `dsh/roles/accept.md`：「人工可以这样确认」模板与人工验证硬规则同步加兜底提示
- 非目标达成：编排脚本 `dev-workflow-2.0.mjs` 零改动

## 验收结论

- 机械检查：verify-issue-29.sh 全绿（worktree 内重跑 ALL PASS，退出码 0）
- 模拟验证：场景 A（分支缺失）/ 场景 B（分支仍在、仅 worktree 缺失）均恢复成功，无残留
- 审核：APPROVE，2 条 LOW 可选打磨项，不阻塞
- 人工验收：PASS（两条验收标准均 VERIFIED，范围约束满足，无阻塞项）

## 报告清单

| 产物 | 路径 |
|------|------|
| 开发交接 | .agent-runs/issue-29/dev-report.md |
| 审核报告 | .agent-runs/issue-29/review-report.md |
| 验收报告 | .agent-runs/issue-29/accept-report.md |
| 验收摘要 | .agent-runs/issue-29/acceptance-summary.md |
| 收口报告 | .agent-runs/issue-29/cleanup-report.md |
