### PR TITLE
fix(vwf): Minke 旧 dist 导致 harness is not defined（对齐 DSH v0.1.1-rc.2）

### DIFF
--- a/packages/dsh-visual-workflow/README.md
+++ b/packages/dsh-visual-workflow/README.md
@@ -9,11 +9,17 @@ packages/dsh-visual-workflow/
 ├── src/
 │   ├── host.js            # 宿主半：DSL 校验（Gold-Band 同构规则）+ 编译 + RPC + wf_run 工具 + 运行状态跟踪
 │   └── client.js          # 客户端半：模板库 + 大抽屉编辑器（画布/配置面板/校验弹窗/JSON tab）+ 运行看板
+├── scripts/
+│   ├── build-bundle.mjs   # src → dist + .src-stamp.json
+│   └── check-dist-fresh.mjs
 ├── tests/
-│   ├── host.test.mjs      # 34 个 node 单测（双根加载/校验/编译/撞名/RPC/回退/异源）
-│   └── client.smoke.mjs   # 8 个 jsdom 冒烟用例（渲染/增删节点/拖拽连线/边面板/JSON tab/校验弹窗/保存）
-├── docs/EDITOR-MIGRATION.md  # 迁移分析报告（架构对照 + 适配决策）
-└── package.json           # 仅测试用 devDependencies（react/jsdom），插件本体零依赖
+│   ├── host.test.mjs      # host 单测（双根加载/校验/编译/撞名/RPC/回退/异源）
+│   ├── client.smoke.mjs   # jsdom 冒烟
+│   ├── static-bundle.test.mjs  # 无 harness 静态 Host / dist apply
+│   └── dist-fresh.test.mjs     # dist 新鲜度 + dsh-tools 版本对齐
+├── verify.sh              # 本地质量闸门（build + 新鲜度 + 版本 + 包测试）
+├── docs/EDITOR-MIGRATION.md
+└── package.json           # @deepseek-ai/dsh-tools 对齐宿主 DSH v0.1.1-rc.2
 ```
 
 ## 使用方式
@@ -21,8 +27,9 @@ packages/dsh-visual-workflow/
 ### 方式 A：组合包安装（产品形态）
 
 ```bash
-# 构建 bundle 产物（dist/host-entry.mjs + dist/client.js）
-cd packages/dsh-visual-workflow && npm run build
+# 构建 bundle 产物（dist/host-entry.mjs + dist/client.js + dist/.src-stamp.json）
+# npm install / prepare 会自动重建；改 src 后必须再跑一次，否则 link 安装仍加载旧 dist
+cd packages/dsh-visual-workflow && npm run build && npm run check:dist
 
 # link 安装到 profile（路径用绝对路径；目标 profile 以实际为准）
 dsh plugin --profile web add link:/Users/chris/workspace/workflow-manager/packages/dsh-visual-workflow
@@ -73,9 +80,17 @@ cordis_define:
 
 ```bash
 cd packages/dsh-visual-workflow
-npm install --cache <本地缓存目录>   # 仅安装测试 devDependencies
-npm test                              # 45 个用例（host 37 + client 8）
+npm install --cache <本地缓存目录>   # prepare 会重建 dist
+npm test                              # host + client 冒烟 + 静态 bundle + dist 新鲜度
+bash verify.sh                        # Gate1–4：版本对齐 + 构建 + 新鲜度 + 包测试
 ```
+
+## 版本策略（dsh-tools ↔ 宿主）
+
+- 插件 `@deepseek-ai/dsh-tools` **固定 `0.1.1-rc.2`**，与本地/官方最新宿主 **DSH v0.1.1-rc.2** 对齐（npm dist-tag `next`）。
+- 用途仅限静态 bundle 的 `defineTool` 兜底（动态模式走 `harness.defineTool`）。`defineTool` 工厂签名自 rc.7 / rc.8 / 0.1.1-rc.2 保持兼容。
+- Minke 0.2.0 宿主本体仍内嵌 `dsh-tools@0.1.0-rc.8`。插件不再把 rc.7 混入 rc.8/0.1.1 宿主闭包；静态模式用本包自己的 0.1.1-rc.2 副本整形工具对象，再经 `ctx.tools.register` 交给宿主。
+- 改 `src/` 后若未 `npm run build`，`npm run check:dist` / `verify.sh` / 包测试会失败，避免再出现 issue-33 的过期 `dist/host-entry.mjs`。
 
 ## 与 pkg-19 的主要差异
 

--- a/packages/dsh-visual-workflow/package.json
+++ b/packages/dsh-visual-workflow/package.json
@@ -7,7 +7,10 @@
   "main": "./dist/host-entry.mjs",
   "scripts": {
     "build": "node scripts/build-bundle.mjs",
-    "test": "node --test tests/host.test.mjs tests/client.smoke.mjs"
+    "check:dist": "node scripts/check-dist-fresh.mjs",
+    "prepare": "node scripts/build-bundle.mjs",
+    "test": "node --test tests/host.test.mjs tests/client.smoke.mjs tests/static-bundle.test.mjs tests/dist-fresh.test.mjs",
+    "verify": "bash verify.sh"
   },
   "dsh": {
     "bundle": {
@@ -30,7 +33,7 @@
     "src/"
   ],
   "dependencies": {
-    "@deepseek-ai/dsh-tools": "0.1.0-rc.7"
+    "@deepseek-ai/dsh-tools": "0.1.1-rc.2"
   },
   "devDependencies": {
     "jsdom": "^26.0.0",

--- a/packages/dsh-visual-workflow/pnpm-lock.yaml
+++ b/packages/dsh-visual-workflow/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@deepseek-ai/dsh-tools':
-        specifier: 0.1.0-rc.7
-        version: 0.1.0-rc.7(ac9081d1e007de8a90a707560a8ae1c3)
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(ac9081d1e007de8a90a707560a8ae1c3)
     devDependencies:
       jsdom:
         specifier: ^26.0.0
@@ -144,18 +144,18 @@ packages:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
 
-  '@deepseek-ai/dsh-tools@0.1.0-rc.7':
-    resolution: {integrity: sha512-7Kq3EEv354aNcxbS0NRfxxyJiZhCsvFV/03a3MdkYO/gG2eM9+E4xQum0N2FL5bw7JiGlgw8jdLMkcNGmavEaA==}
+  '@deepseek-ai/dsh-tools@0.1.1-rc.2':
+    resolution: {integrity: sha512-0GGL4D55MwYDepzZMOI3L0ycu5b2qr96GL0Y7snwhAnpK2Di61rbX3fJE+PB3ZrovGX0csIRdt9n3iJZDVtDrw==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
-      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
-      '@deepseek-ai/dsh-code-runtime': ^0.1.0-rc.7
-      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
-      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
-      '@deepseek-ai/dsh-scope': ^0.1.0-rc.7
-      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
-      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.7
-      '@deepseek-ai/dsh-user-approval': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-code-runtime': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-system-prompt': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-user-approval': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.8':
     resolution: {integrity: sha512-scwEAefRBL7gRpaXiEdiHRMvlr8dLmUbiEvy0LOAX/8X3FZBd/5tHQ/8lCppAQNTDZMI/LSiSMpu5XrFId+7cQ==}
@@ -437,7 +437,7 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-tools@0.1.0-rc.7(ac9081d1e007de8a90a707560a8ae1c3)':
+  '@deepseek-ai/dsh-tools@0.1.1-rc.2(ac9081d1e007de8a90a707560a8ae1c3)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
       '@deepseek-ai/dsh-agent': 0.1.0-rc.8(92f269661ea5e195fab72177f1a12db7)

--- a/packages/dsh-visual-workflow/scripts/build-bundle.mjs
+++ b/packages/dsh-visual-workflow/scripts/build-bundle.mjs
@@ -2,7 +2,9 @@
 // 把 src/ 的动态插件闭包体（return {name, inject?, apply}）编译为 bundle 安装产物：
 //   dist/host-entry.mjs — ESM 入口（cordis.patch.yml 的 name 经包 main/exports 解析）
 //   dist/client.js      — 自包含经典脚本（CJS：module.exports = 插件对象），供浏览器 /plugins/<id>/client.js 加载
+//   dist/.src-stamp.json — 源码哈希戳，供 check-dist-fresh 校验「源码变更后必须重建」
 // 单一事实源仍是 src/*.js；本脚本只做形态包装，不做逻辑转换。
+import { createHash } from 'node:crypto'
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -11,8 +13,16 @@ const root = dirname(dirname(fileURLToPath(import.meta.url)))
 const dist = join(root, 'dist')
 mkdirSync(dist, { recursive: true })
 
-const hostBody = readFileSync(join(root, 'src', 'host.js'), 'utf8')
-const clientBody = readFileSync(join(root, 'src', 'client.js'), 'utf8')
+const hostPath = join(root, 'src', 'host.js')
+const clientPath = join(root, 'src', 'client.js')
+const hostBody = readFileSync(hostPath, 'utf8')
+const clientBody = readFileSync(clientPath, 'utf8')
+const sha256 = (buf) => createHash('sha256').update(buf).digest('hex')
+const stamp = {
+  host: sha256(hostBody),
+  client: sha256(clientBody),
+  builtAt: new Date().toISOString(),
+}
 
 writeFileSync(
   join(dist, 'host-entry.mjs'),
@@ -43,5 +53,8 @@ function pluginHasInject(body) {
   return /^\s*inject\s*:/m.test(body)
 }
 
+writeFileSync(join(dist, '.src-stamp.json'), JSON.stringify(stamp, null, 2) + '\n')
+
 console.log('built:', join(dist, 'host-entry.mjs'))
 console.log('built:', join(dist, 'client.js'))
+console.log('stamp:', stamp.host.slice(0, 12), stamp.client.slice(0, 12))

--- a/packages/dsh-visual-workflow/scripts/check-dist-fresh.mjs
+++ b/packages/dsh-visual-workflow/scripts/check-dist-fresh.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// 安装/开发闭环：dist 必须由当前 src 重新生成。
+// 失败即阻断——避免 link 安装继续加载过期 host-entry.mjs（issue-33）。
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
+const hostPath = join(root, 'src', 'host.js')
+const clientPath = join(root, 'src', 'client.js')
+const stampPath = join(root, 'dist', '.src-stamp.json')
+const distHost = join(root, 'dist', 'host-entry.mjs')
+const distClient = join(root, 'dist', 'client.js')
+
+const sha256 = (file) => createHash('sha256').update(readFileSync(file)).digest('hex')
+const fail = (msg) => {
+  console.error('❌ dist 与源码不一致：' + msg)
+  console.error('   请在 packages/dsh-visual-workflow 运行：npm run build')
+  process.exit(1)
+}
+
+if (!existsSync(distHost) || !existsSync(distClient) || !existsSync(stampPath)) {
+  fail('缺少 dist/host-entry.mjs、dist/client.js 或 dist/.src-stamp.json')
+}
+
+let stamp
+try {
+  stamp = JSON.parse(readFileSync(stampPath, 'utf8'))
+} catch (e) {
+  fail('dist/.src-stamp.json 无法解析')
+}
+
+const host = sha256(hostPath)
+const client = sha256(clientPath)
+if (stamp.host !== host || stamp.client !== client) {
+  fail('源码哈希与 stamp 不符（host ' + host.slice(0, 12) + ' / client ' + client.slice(0, 12) + '）')
+}
+
+const body = readFileSync(distHost, 'utf8')
+if (!body.includes("typeof harness !== 'undefined'") || !body.includes('webServer')) {
+  fail('dist/host-entry.mjs 缺少双模式守卫（疑似旧产物）')
+}
+
+console.log('✅ dist 与 src 一致（builtAt ' + (stamp.builtAt || 'unknown') + '）')

--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -57,6 +57,7 @@ return {
     // ── 双模式 RPC 注册（动态会话=harness.handle / 静态 bundle=webServer 路由）──
     // 动态插件运行时提供 harness 内建；静态组合包没有，改经 webServer 前缀路由
     // （POST /dsh-visual-workflow/<method>，信封 {rpcId,method,payload}→{rpcId,result}）
+    // 必须用 typeof 探测未声明标识符：静态 IIFE / Minke 无 harness 全局，直接读会 ReferenceError。
     const isDynamicHost = typeof harness !== 'undefined'
     const rpcRoutes = new Map()
     function registerRpc(method, fn) {

--- a/packages/dsh-visual-workflow/tests/dist-fresh.test.mjs
+++ b/packages/dsh-visual-workflow/tests/dist-fresh.test.mjs
@@ -1,0 +1,43 @@
+// issue-33 / T2+T4：dist 与源码一致性 + dsh-tools 与宿主版本对齐
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const pkgRoot = join(here, '..')
+const HOST = join(pkgRoot, 'src', 'host.js')
+const CLIENT = join(pkgRoot, 'src', 'client.js')
+const STAMP = join(pkgRoot, 'dist', '.src-stamp.json')
+const DIST_HOST = join(pkgRoot, 'dist', 'host-entry.mjs')
+const PKG = join(pkgRoot, 'package.json')
+
+function sha256(file) {
+  return createHash('sha256').update(readFileSync(file)).digest('hex')
+}
+
+test('T2：dist/.src-stamp.json 与 src/host.js + src/client.js 哈希一致', () => {
+  assert.ok(existsSync(STAMP), '缺少 dist/.src-stamp.json：请运行 npm run build')
+  const stamp = JSON.parse(readFileSync(STAMP, 'utf8'))
+  assert.equal(stamp.host, sha256(HOST), 'host.js 已变更但 dist 未重建')
+  assert.equal(stamp.client, sha256(CLIENT), 'client.js 已变更但 dist 未重建')
+})
+
+test('T2：重建后的 dist 含双模式守卫，不再无条件调用 harness.handle', () => {
+  assert.ok(existsSync(DIST_HOST), '缺少 dist/host-entry.mjs')
+  const body = readFileSync(DIST_HOST, 'utf8')
+  assert.match(body, /typeof harness !== 'undefined'/, 'bundle 必须保留 typeof harness 守卫')
+  assert.match(body, /webServer/, 'bundle 必须含静态 webServer 路由')
+  assert.match(body, /const isDynamicHost = typeof harness !== 'undefined'/, 'harness.handle 仅允许出现在 isDynamicHost 守卫之后')
+})
+
+test('T4：@deepseek-ai/dsh-tools 对齐最新宿主 DSH v0.1.1-rc.2', () => {
+  const pkg = JSON.parse(readFileSync(PKG, 'utf8'))
+  assert.equal(
+    pkg.dependencies['@deepseek-ai/dsh-tools'],
+    '0.1.1-rc.2',
+    '插件 dsh-tools 必须与宿主 DSH v0.1.1-rc.2 对齐，消除 rc.7 混用',
+  )
+})

--- a/packages/dsh-visual-workflow/tests/helpers/load-host.mjs
+++ b/packages/dsh-visual-workflow/tests/helpers/load-host.mjs
@@ -25,3 +25,25 @@ export function loadHost(overrides = {}) {
   plugin.apply(ctx)
   return { handlers, definedTools, events, ctx }
 }
+
+// 静态 Host / Minke bundle：不注入 harness 自由变量，走 webServer 前缀路由。
+export function loadStaticHost(overrides = {}) {
+  const registered = []
+  const definedTools = []
+  const events = new Map()
+  const defaultWebServer = {
+    register(route, label) { registered.push({ route, label }) },
+  }
+  const ctx = {
+    get: (name) => {
+      if (name === 'webServer' && overrides.webServer === undefined) return defaultWebServer
+      return overrides[name] === undefined ? undefined : overrides[name]
+    },
+    on: (name, fn) => { events.set(name, fn) },
+    effect: (fn) => { fn(); return () => {} },
+  }
+  const fn = new Function('ctx', `${src}`)
+  const plugin = fn(ctx)
+  plugin.apply(ctx)
+  return { registered, definedTools, events, ctx }
+}

--- a/packages/dsh-visual-workflow/tests/static-bundle.test.mjs
+++ b/packages/dsh-visual-workflow/tests/static-bundle.test.mjs
@@ -1,0 +1,59 @@
+// issue-33 / T3：无 harness 全局的静态 Host / bundle 场景
+// 断言 apply() 不抛 ReferenceError，并走 webServer 前缀路由（而非 harness.handle）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { loadStaticHost, loadHost } from './helpers/load-host.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const distEntry = join(here, '..', 'dist', 'host-entry.mjs')
+
+test('T3：源码静态 Host 无 harness 时 apply() 不抛 ReferenceError，并注册 webServer 路由', async () => {
+  assert.equal(typeof globalThis.harness, 'undefined', '测试进程不得预置 harness 全局')
+  let plugin
+  assert.doesNotThrow(() => { plugin = loadStaticHost() })
+  const routes = plugin.registered.map((r) => r.route)
+  assert.equal(routes.length, 1, '静态模式应注册恰好一条 webServer 路由')
+  assert.equal(routes[0].kind, 'prefix')
+  assert.equal(routes[0].path, '/dsh-visual-workflow')
+  assert.equal(typeof routes[0].handler, 'function')
+})
+
+test('T3：动态 Host 仍走 harness.handle（回归：双模式互不抢占）', async () => {
+  const { handlers, registered } = (() => {
+    const loaded = loadHost()
+    return { handlers: loaded.handlers, registered: loaded.registered }
+  })()
+  assert.ok(handlers.has('vwf.workflows.list'), '动态模式 RPC 仍经 harness.handle 注册')
+  assert.equal(registered, undefined, '动态加载器不暴露 webServer 注册面')
+})
+
+test('T3：静态 bundle dist/host-entry.mjs 在无 harness 时 apply() 走 webServer', async (t) => {
+  assert.ok(existsSync(distEntry), 'dist/host-entry.mjs 必须存在（源码变更后须重新 build）')
+  try {
+    await import('@deepseek-ai/dsh-tools')
+  } catch {
+    t.skip('未安装 @deepseek-ai/dsh-tools，跳过真实 ESM 加载（源码静态 Host 用例仍覆盖无 harness 路径）')
+    return
+  }
+  const { apply } = await import(pathToFileURL(distEntry).href + '?t=' + Date.now())
+  const registered = []
+  const ctx = {
+    get(name) {
+      if (name === 'webServer') {
+        return { register(route) { registered.push(route) } }
+      }
+      return undefined
+    },
+    on() {},
+    effect(fn) { fn(); return () => {} },
+  }
+  assert.equal(typeof globalThis.harness, 'undefined')
+  assert.doesNotThrow(() => apply(ctx))
+  assert.equal(registered.length, 1)
+  assert.equal(registered[0].kind, 'prefix')
+  assert.equal(registered[0].path, '/dsh-visual-workflow')
+})

--- a/packages/dsh-visual-workflow/verify.sh
+++ b/packages/dsh-visual-workflow/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# 本地质量闸门（issue-33 / QUALITY_GATES Gate1-4）
+# Gate1 知识/API 来源可追溯：dsh-tools 版本与宿主 DSH v0.1.1-rc.2 对齐
+# Gate2 本地化：本脚本与包内中文说明保持一致（不引入未翻译对外文案）
+# Gate3 构建：npm run build
+# Gate4 一致性 + 包测试：check-dist-fresh + node --test
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo '—— Gate3 构建 ——'
+node scripts/build-bundle.mjs
+
+echo '—— Gate4 dist 新鲜度 ——'
+node scripts/check-dist-fresh.mjs
+
+echo '—— Gate1 dsh-tools 版本 ——'
+node --input-type=module -e "
+import { readFileSync } from 'node:fs'
+const pkg = JSON.parse(readFileSync('./package.json','utf8'))
+const v = pkg.dependencies['@deepseek-ai/dsh-tools']
+if (v !== '0.1.1-rc.2') {
+  console.error('❌ @deepseek-ai/dsh-tools=' + v + '，期望 0.1.1-rc.2（对齐 DSH v0.1.1-rc.2）')
+  process.exit(1)
+}
+console.log('✅ @deepseek-ai/dsh-tools=' + v + '（对齐 DSH v0.1.1-rc.2）')
+"
+
+echo '—— Gate4 包测试 ——'
+node --test tests/host.test.mjs tests/client.smoke.mjs tests/static-bundle.test.mjs tests/dist-fresh.test.mjs
+
+echo
+echo '✅ verify.sh 全绿'

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -61,9 +61,11 @@ try {
 } catch (e) {
   fail('引擎层测试失败：' + String(e.stdout || e.message).split('\n').slice(-4).join('\n'));
 }
-console.log('—— ③′ 包测试（packages/dsh-visual-workflow：host 双根/异源 + client 冒烟）——');
+console.log('—— ③′ 包测试（packages/dsh-visual-workflow：host 双根/异源 + client 冒烟 + 静态 bundle）——');
 try {
-  execFileSync(process.execPath, ['--test', 'tests/host.test.mjs', 'tests/client.smoke.mjs'], { cwd: path.join(root, 'packages', 'dsh-visual-workflow'), stdio: 'pipe', shell: true });
+  const pkg = path.join(root, 'packages', 'dsh-visual-workflow');
+  execFileSync(process.execPath, ['scripts/build-bundle.mjs'], { cwd: pkg, stdio: 'pipe' });
+  execFileSync('npm', ['test'], { cwd: pkg, stdio: 'pipe', shell: true });
   pass('包测试全绿');
 } catch (e) {
   fail('包测试失败：' + String(e.stdout || e.message).split('\n').slice(-4).join('\n'));


### PR DESCRIPTION
## Summary
- 为 `dsh-visual-workflow` 建立「改 src 必须重建 dist」闭环：`prepare` 自动 build、`.src-stamp.json` + `check-dist-fresh` 拦截过期 bundle，避免 Minke/静态 Profile 继续加载旧 `host-entry.mjs` 并抛 `harness is not defined`。
- 回归覆盖无 harness 全局的静态 Host / 真实 dist `apply()`，确认走 `webServer` 前缀路由；动态模式仍走 `harness.handle`。
- `@deepseek-ai/dsh-tools` 从 `0.1.0-rc.7` 精确对齐到宿主 **DSH v0.1.1-rc.2**。Minke 0.2.0 仍内嵌 rc.8，`defineTool` 签名兼容；真实 Minke readiness 留给测试节点做集成验证。

## Test plan
- [x] `packages/dsh-visual-workflow/verify.sh` 全绿（build + stamp + 版本 + 50 通过 / 1 skip）
- [ ] 测试节点：Minke 0.2.0 + 原 `~/.dsh` + visual-workflow 完成 Harness readiness
- [ ] 测试节点：原生 DSH 动态插件模式 RPC 回归


Made with [Cursor](https://cursor.com)