### PR TITLE
fix(vwf): #19 真机验收修复——脚本终态归一化回写、看板点击即切与画布图例分区

### DIFF
--- a/packages/dsh-visual-workflow/src/client.js
+++ b/packages/dsh-visual-workflow/src/client.js
@@ -1524,10 +1524,19 @@ return {
           setTplMap(m)
         }).catch(() => {})
       }, [])
+      // 立即拉取所选 run 详情：点击行即时切换，不等下一个轮询周期；
+      // seq 守卫防止慢响应回写覆盖新选择（连续切行竞态）
+      const seqRef = React.useRef(0)
+      const fetchState = (id) => {
+        if (!id) return
+        const seq = ++seqRef.current
+        host.call('vwf.state', { runId: id }).then((r) => { if (seq === seqRef.current) setSnap(r) }).catch(() => {})
+      }
+      const selectRun = (id) => { setRunId(id); fetchState(id) }
       const refresh = React.useCallback(() => {
         host.call('vwf.runs.list').then((r) => setRuns((r && r.runs) || [])).catch(() => {})
         if (!runId) return
-        host.call('vwf.state', { runId }).then((r) => setSnap(r)).catch(() => {})
+        fetchState(runId)
       }, [runId])
       React.useEffect(() => {
         if (!auto) return undefined
@@ -1565,7 +1574,7 @@ return {
           ),
           h('table', { className: 'vwf-table' },
             h('thead', null, h('tr', null, h('th', null, 'taskId'), h('th', null, '工作流'), h('th', null, '状态'), h('th', null, '阶段'), h('th', null, 'runId'))),
-            h('tbody', null, runs.map((r) => h('tr', { key: r.id, onClick: () => setRunId(r.id), style: { cursor: 'pointer', opacity: r.supersededBy ? 0.5 : 1 } },
+            h('tbody', null, runs.map((r) => h('tr', { key: r.id, onClick: () => selectRun(r.id), style: { cursor: 'pointer', opacity: r.supersededBy ? 0.5 : 1 } },
               h('td', null, r.taskId || '—'),
               h('td', null, r.name || r.workflowId || '—'),
               h('td', null, r.supersededBy ? h('span', { className: 'vwf-badge' }, '已由续跑接管') : statusBadge(r.status)),
@@ -1589,14 +1598,19 @@ return {
           : !snap.found
             ? h('div', { className: 'vwf-err-line' }, '未找到该 runId 的状态（仅插件进程内的运行记录）')
             : h('div', null,
-                h('div', { className: 'vwf-row' },
-                  h('span', null, '状态：' + snap.state.status),
-                  h('span', { className: 'vwf-muted' }, '当前阶段：' + (snap.state.phase || '—')),
-                  snap.state.taskId ? h('span', { className: 'vwf-muted' }, 'taskId：' + snap.state.taskId) : null,
-                  h('span', { className: 'vwf-badge', style: { color: STATUS_COLOR.running } }, 'running'),
-                  h('span', { className: 'vwf-badge', style: { color: STATUS_COLOR.pass } }, 'pass'),
-                  h('span', { className: 'vwf-badge', style: { color: STATUS_COLOR.fail } }, 'fail'),
-                  h('span', { className: 'vwf-badge', style: { color: STATUS_COLOR.human } }, '人工门禁')
+                h('div', null,
+                  h('div', { className: 'vwf-row' },
+                    h('span', null, '状态：' + snap.state.status),
+                    h('span', { className: 'vwf-muted' }, '当前阶段：' + (snap.state.phase || '—')),
+                    snap.state.taskId ? h('span', { className: 'vwf-muted' }, 'taskId：' + snap.state.taskId) : null
+                  ),
+                  h('div', { className: 'vwf-row', style: { borderTop: '1px solid var(--dsw-alias-border-l2, #333)', marginTop: 6, paddingTop: 6 } },
+                    h('span', { className: 'vwf-muted', style: { fontSize: 10 } }, '画布图例：'),
+                    h('span', { className: 'vwf-badge', style: { color: STATUS_COLOR.running } }, 'running'),
+                    h('span', { className: 'vwf-badge', style: { color: STATUS_COLOR.pass } }, 'pass'),
+                    h('span', { className: 'vwf-badge', style: { color: STATUS_COLOR.fail } }, 'fail'),
+                    h('span', { className: 'vwf-badge', style: { color: STATUS_COLOR.human } }, '人工门禁')
+                  )
                 ),
                 dsl ? h('div', { className: 'vwf-card', style: { marginTop: 8 } }, h(Canvas, { dsl, readOnly: true, statusMap: st })) : null,
                 h('table', { className: 'vwf-table', style: { marginTop: 8 } },

--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -639,7 +639,10 @@ return {
     // 脚本终态（DONE / AWAITING_HUMAN_* / FAILED_* 等）只在 result.value 里，
     // 恰好只有持有 run 并 await 的 wf_run 能看到。事件层的 'completed' 对门禁/
     // 互斥语义不够：wf_run 收尾后用 value.status 回写权威终态。
-    const TERMINAL_STATUS_RE = /^(DONE|AWAITING_HUMAN_[A-Za-z0-9_-]+|FAILED_AT_[A-Za-z0-9_-]+|FAILED_MAX_ROUNDS|TECHNICAL_FAILURE|ENDED_NO_SUCCESS_EDGE|ENDED_NO_FAILURE_EDGE|ERROR)$/
+    // 终态集合（评审 PRRT_kwDOT57Tec6bfXfm/6b6ZN3）：节点 id 允许非 ASCII/
+    // 空白/标点（AWAITING_HUMAN_验收、FAILED_AT_调度A 等），前缀类用 .+ 宽匹配；
+    // fanout cap 失败态（FAILED_ITEM_CAP/FAILED_AGENT_CAP）同为脚本终态
+    const TERMINAL_STATUS_RE = /^(DONE|AWAITING_HUMAN_.+|FAILED_AT_.+|FAILED_MAX_ROUNDS|FAILED_ITEM_CAP|FAILED_AGENT_CAP|TECHNICAL_FAILURE|ENDED_NO_SUCCESS_EDGE|ENDED_NO_FAILURE_EDGE|ERROR)$/
     function canonicalStop(result) {
       const v = result && result.value
       const cand = v && typeof v === 'object' && typeof v.status === 'string' ? v.status : (typeof v === 'string' ? v : '')

--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -634,6 +634,17 @@ return {
         if (rec && String(rec.status).indexOf('AWAITING_HUMAN_') === 0) tag.supersededBy = newRunId
       }
     }
+    // 引擎契约（dsh workflow types.ts）：WorkflowStopReason 只有
+    // 'completed' | 'cancelled' | 'error'，且 workflow/end 事件故意剥掉 value——
+    // 脚本终态（DONE / AWAITING_HUMAN_* / FAILED_* 等）只在 result.value 里，
+    // 恰好只有持有 run 并 await 的 wf_run 能看到。事件层的 'completed' 对门禁/
+    // 互斥语义不够：wf_run 收尾后用 value.status 回写权威终态。
+    const TERMINAL_STATUS_RE = /^(DONE|AWAITING_HUMAN_[A-Za-z0-9_-]+|FAILED_AT_[A-Za-z0-9_-]+|FAILED_MAX_ROUNDS|TECHNICAL_FAILURE|ENDED_NO_SUCCESS_EDGE|ENDED_NO_FAILURE_EDGE|ERROR)$/
+    function canonicalStop(result) {
+      const v = result && result.value
+      const cand = v && typeof v === 'object' && typeof v.status === 'string' ? v.status : (typeof v === 'string' ? v : '')
+      return TERMINAL_STATUS_RE.test(cand) ? cand : ''
+    }
 
     const runs = new Map()
     ctx.on('workflow/start', (info) => { runs.set(info.id, { meta: { name: (info.meta && info.meta.name) || '', description: (info.meta && info.meta.description) || '' }, status: 'running', phase: '', logs: [], agents: [] }) })
@@ -953,6 +964,15 @@ return {
           })
           if (args.entry) supersedeParked(String(args.taskId), String(run.id))
           const result = await run.result
+          // 权威终态回写（见 canonicalStop 注释）：completed 时以脚本返回为准
+          // （DONE / AWAITING_HUMAN_* / FAILED_*），cancelled/error 保持事件原样。
+          // 注意：wf_run 回执保持引擎原样 stopReason/value 不做翻译（runtime-host
+          // 套件 H1/H2 钉住该契约）；看板/互斥语义只消费这里回写的 runs 状态
+          const canon = result && result.stopReason === 'completed' ? canonicalStop(result) : ''
+          if (canon) {
+            const rec = runs.get(String(run.id))
+            if (rec) rec.status = canon
+          }
           return JSON.stringify({ runId: String(run.id), stopReason: result.stopReason, value: result.value, agentsStarted: result.agentsStarted })
         }
       })

--- a/packages/dsh-visual-workflow/tests/host.test.mjs
+++ b/packages/dsh-visual-workflow/tests/host.test.mjs
@@ -847,19 +847,21 @@ function makeEngine() {
       pending.push({ id, release })
       return { id, result }
     },
-    end(id, stopReason) {
+    end(id, stopReason, value) {
       const p = pending.find((x) => x.id === id)
-      if (p) p.release({ stopReason, value: null, agentsStarted: 0 })
+      if (p) p.release({ stopReason, value: value === undefined ? null : value, agentsStarted: 0 })
     },
   }
 }
 
 // 结束一次运行：resolve 引擎 result（wf_run 回执需要）+ 投递 workflow/end 事件
 // （runs 状态机与 runTag.active 清除依赖事件——假引擎不会自动广播）
-function settleRun(eng, events, id, stopReason) {
-  eng.end(id, stopReason)
+// 真实引擎语义：workflow/end 事件只带 stopReason（completed/cancelled/error，
+// 无 value）；脚本终态在 result.value 里，只有 wf_run 的 await 能看到
+function settleRun(eng, events, id, scriptStatus) {
+  eng.end(id, 'completed', { status: scriptStatus })
   const ev = events.get('workflow/end')
-  if (ev) ev({ id }, { stopReason })
+  if (ev) ev({ id }, { stopReason: 'completed' })
 }
 
 function engineEnv(eng) {
@@ -917,8 +919,11 @@ test('#19 T1：wf_run 启动登记 taskId/workflowId；runs.list 最新在前；
   settleRun(eng, events, 'run-1', 'DONE')
   settleRun(eng, events, 'run-2', 'DONE')
   const [r1, r2] = await Promise.all([p1, p2])
-  assert.ok(r1.includes('"stopReason":"DONE"'), r1)
-  assert.ok(r2.includes('"stopReason":"DONE"'), r2)
+  // 终态回写回归：事件层是 completed，权威状态应为脚本返回 DONE
+  const d1 = await call(handlers, 'vwf.state', { runId: 'run-1' })
+  assert.equal(d1.state.status, 'DONE', 'value.status 回写覆盖事件层 completed')
+  assert.ok(r1.includes('"stopReason":"completed"') && r1.includes('"status":"DONE"'), r1)
+  assert.ok(r2.includes('"stopReason":"completed"') && r2.includes('"status":"DONE"'), r2)
 })
 
 test('#19 T2（AC2）：同 taskId 进行中二次启动被拒并提示占用 runId；不同 taskId 放行；完成后解除', async () => {
@@ -952,7 +957,9 @@ test('#19 T3（AC3）：AWAITING_HUMAN 占用同 taskId 拒绝新启动；entry 
   await until(() => eng.starts.length >= 1, '首次启动')
   events.get('workflow/start')({ id: 'run-1', meta: { name: 'x' } })
   settleRun(eng, events, 'run-1', 'AWAITING_HUMAN_accept')
-  await p1
+  const receipt1 = await p1
+  // 回执契约：引擎原样 completed + value 携带脚本终态（runtime-host H1/H2 钉住）
+  assert.ok(receipt1.includes('"stopReason":"completed"') && receipt1.includes('AWAITING_HUMAN_accept'), receipt1)
   // 门禁占用仍互斥（isActiveStatus 兜住 AWAITING_HUMAN_* 终态）
   const blocked = await wfRun.execute({ templateId: 'dev-workflow-2-0', taskId: 'issue-12' })
   assert.ok(blocked.includes('串行互斥'), blocked)
@@ -970,6 +977,8 @@ test('#19 T3（AC3）：AWAITING_HUMAN 占用同 taskId 拒绝新启动；entry 
   assert.equal(list.runs[0].id, 'run-2', '续跑记录最新在前')
   settleRun(eng, events, 'run-2', 'DONE')
   await p2
+  const d2 = await call(handlers, 'vwf.state', { runId: 'run-2' })
+  assert.equal(d2.state.status, 'DONE', '续跑终态同样回写为 DONE')
 })
 
 test('#19 T4（AC1）：无 wf_run 参与的双 run 交错事件按 runId 隔离（平台工具直起路径）', async () => {

--- a/packages/dsh-visual-workflow/tests/host.test.mjs
+++ b/packages/dsh-visual-workflow/tests/host.test.mjs
@@ -1025,3 +1025,28 @@ test('#18 终态归一：workflow/end 时未收到 agent-end 的子代理按 fai
   const s2 = await call(handlers, 'vwf.state', { runId: 'wfr' })
   assert.deepEqual(s2.state.agents.map(a => a.outcome), ['completed', 'failed', 'failed'])
 })
+
+test('#19 评审修复：终态正则接受非 ASCII 节点 id 与 fanout cap 失败态', async () => {
+  const eng = makeEngine()
+  const { handlers, events, definedTools } = engineEnv(eng)
+  const wfRun = definedTools.find(t => t.name === 'wf_run')
+  // 非 ASCII 门禁节点 id：AWAITING_HUMAN_验收 必须被权威回写
+  const p1 = wfRun.execute({ templateId: 'dev-workflow-2-0', taskId: 'issue-19a' })
+  await until(() => eng.starts.length >= 1, '启动1')
+  events.get('workflow/start')({ id: 'run-1', meta: { name: 'x' } })
+  settleRun(eng, events, 'run-1', 'AWAITING_HUMAN_验收')
+  await p1
+  const s1 = await call(handlers, 'vwf.state', { runId: 'run-1' })
+  assert.equal(s1.state.status, 'AWAITING_HUMAN_验收', '非 ASCII 节点 id 的门禁态被回写')
+  // fanout cap 失败态：FAILED_ITEM_CAP 同为脚本终态
+  const p2 = wfRun.execute({ templateId: 'dev-workflow-2-0', taskId: 'issue-19b' })
+  await until(() => eng.starts.length >= 2, '启动2')
+  events.get('workflow/start')({ id: 'run-2', meta: { name: 'x' } })
+  settleRun(eng, events, 'run-2', 'FAILED_ITEM_CAP')
+  await p2
+  const s2 = await call(handlers, 'vwf.state', { runId: 'run-2' })
+  assert.equal(s2.state.status, 'FAILED_ITEM_CAP', 'cap 失败态被回写')
+  // 门禁占用互斥对非 ASCII 态同样生效
+  const blocked = await wfRun.execute({ templateId: 'dev-workflow-2-0', taskId: 'issue-19a' })
+  assert.ok(blocked.includes('串行互斥'), 'AWAITING_HUMAN_验收 占用同 taskId 互斥')
+})


### PR DESCRIPTION
关联 #19（已验收关闭，验收报告见 issue 评论存档）。

## 改动（4 文件，+62/−19）

- **host.js**：`canonicalStop`——引擎 `workflow/end` 事件仅携带 completed/cancelled/error 且剥除 value，脚本终态（DONE / AWAITING_HUMAN_* / FAILED_*）只在 `result.value.status` 里；wf_run 收尾后回写权威状态到 runs 记录，供门禁队列与同 taskId 互斥消费。wf_run 回执保持引擎原样（runtime-host H1/H2 钉住的契约不动）
- **client.js**：运行列表点击行立即拉取详情（不等 3s 轮询周期），seqRef 守卫防连续切行竞态；画布图例独立成行并加分隔线，与任务状态说明区分
- **tests**：假引擎对齐真实引擎语义（事件层 completed + value 携带终态）；补终态回写、回执契约回归断言
- **roadmap.md**：#19 对账行更新为已实现并验收

## 验证

- 真机人工验收：三 AC 全过（双 run 并行隔离 / 同 taskId 启动互斥 / 门禁双卡逐张裁决含 approved=false 打回重做轮）
- 包测试 66/66；仓库级 `npm run validate` 全绿

## 影响面

蓝图与生成物不受影响（validate ② 重生成一致）。