### PR TITLE
fix(ci): validate 工作流在 generate 前安装依赖

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: install（workspace 提升 packages/* 依赖）
+        run: npm install
       - name: generate（生产物供校验与 vwf 加载）
         run: npm run generate
       - name: validate（蓝图校验 + 重生成一致性 + 引擎/包测试（含运行时排练厅））


### PR DESCRIPTION
## Summary
- 修复 #51：`.github/workflows/validate.yml` 在 `generate` / `validate` 之前增加根目录 `npm install`，通过 npm workspace 提升 `packages/*` 依赖，消除 CI 包测试因缺少 `node_modules` 必挂的基线红灯。
- 未开启 `setup-node` npm cache（根目录无 lockfile）；未改校验语义、测试逻辑与业务代码。

## 验收结论
人工验收已通过。本地在 `dev2/issue-51` 上 `npm install && npm run generate && npm run validate` 全绿。远端 PR / main 的 validate 绿灯在本 PR 合并后核验。

## 报告清单
- `.agent-runs/issue-51/dev-report.md`
- `.agent-runs/issue-51/review-report.md`（APPROVE）
- `.agent-runs/issue-51/accept-report.md` / `acceptance-summary.md`

## Test plan
- [x] 本地 worktree：`npm install && npm run generate && npm run validate` 退出码 0
- [ ] 本 PR 的 GitHub Actions `validate` 为绿色
- [ ] 合并后 `main` 的 `validate` 为绿色

Closes #51

Made with [Cursor](https://cursor.com)