### PR TITLE
docs: 定稿 v0.1 正式工作流规格并重排 Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,102 @@
 # workflow-manager
 
-面向复杂软件研发的 **AI 协作工作流系统**。
+面向复杂软件研发与通用知识工作的 **AI 协作工作流系统**。
 
-Workflow Manager 不只负责“按顺序调用 Agent”。它希望解决更核心的问题：在一个真实软件研发任务里，让正确的角色在正确阶段获得最小且权威的上下文，明确自己的责任与权限，用可验证证据完成交接，并把范围变更、最终验收、合并发布等关键决策保留给人。
+Workflow Manager 不只是“按顺序调用 Agent”。它希望把 Workflow、Role、模型、人工决策、运行快照、正式成果和验证证据组织成一个可配置、可运行、可干预、可恢复、可追溯的协作系统。
 
-当前以 DSH 作为首个运行环境，后续再逐步支持 Codex、Claude Code 等 Coding Agent。跨 Agent 是执行能力，不是项目最高层目标。
+当前以 DeepSeek Harness（DSH）作为首个运行环境。Codex、Claude Code 等 Coding Agent 属于后续执行器扩展，不反向定义 Workflow Manager 的产品模型。
 
-## 项目目标
+## 当前状态
 
-项目长期围绕五类能力演进：
+项目处于 **v0.1 正式工作流体系收敛阶段**。
 
-1. **Context Pointer（上下文指针）**：节点按需引用需求、设计、项目规则、角色规则、Skill 与历史证据，而不是复制整份项目知识。
-2. **责任与证据契约**：每个角色明确输入、输出、非目标、可修改范围和必须提交的验证证据。
-3. **人工授权边界**：局部开发 / 测试 / 审核尽量自主推进；范围变化、高风险实施、最终验收、合并发布等动作由人授权。
-4. **多角色协作**：不仅支持多个独立任务并行，还要支持同一需求中的开发轨、测试轨等不同责任角色并行并在 Gate 汇合。
-5. **执行器可替换**：协作规则稳定后，同一 Workflow 可以逐步交给不同 Coding Agent 执行。
+必须区分两件事：
 
-完整版本规划见 [`roadmap.md`](./roadmap.md)。
+- **当前 main 已实现基线**：现有 Blueprint/Skill/VWF Runtime 能力；
+- **v0.1 目标规格**：正在按 #76–#83 实施的正式 Workflow/Run/Role 模型。
 
-## 当前已具备
+目标规格不是“main 已经具备”的能力清单。实现、Review 和验收必须同时核对实际代码与目标规格。
 
-截至 2026-08-25，项目已经具备第一阶段可用底座：
+权威目标规格：[`docs/design/workflow-manager-v0.1-final-product-spec.md`](./docs/design/workflow-manager-v0.1-final-product-spec.md)  
+完整版本规划：[`roadmap.md`](./roadmap.md)
 
-- Blueprint 作为具体 Workflow 的唯一事实源；
-- 单一编译与校验语义；
-- runtime harness 行为回归；
-- DSH / vwf 双入口统一；
-- 可视化模板库与编辑器；
-- 保存 Blueprint 后同步生成可运行 Skill；
-- 工作分支隔离与验证分支 / HEAD 留痕；
-- 测试、审核、人工验收与失败打回；
-- 多 run 并行、同 taskId 互斥、人工门禁排队；
-- `fanOut` 受限并行子任务与结果聚合；
-- DSH 静态组合包基础安装形态；
-- 默认工作流与角色自包含分发。
+## 当前 main 已具备
 
-当前下一阶段重点不是继续扩大量执行器或独立分发，而是补齐 **上下文、责任、权限、证据和同需求多角色协作**。
+截至 2026-08-30，已经形成的可用底座包括：
 
-## 协作模型
+- `templates/*.json` Blueprint 作为具体 Workflow 的唯一事实源；
+- 单一校验/生成链和行为回归；
+- 可视化模板库、画布编辑器和配置面板；
+- 保存 Blueprint 后生成/更新可运行 Skill；
+- Built-in / Custom Role Library 基础能力（#58 / PR #61）；
+- Git worktree 工作隔离与验证分支/HEAD 留痕；
+- 测试、审核、人工门禁与失败回路；
+- 受限 Fan-out 与结果聚合（#18 / PR #38）；
+- 多 run 并行、同 taskId 互斥、人工门禁排队（#19 / PR #41、#44）；
+- legacy engine-run 运行历史跨 DSH 重启持久化（#40 / PR #50）；
+- DSH 静态组合包产品形态；
+- 版本内开发模式 / 发布前产品模式的长期双轨规则。
 
-```text
-权威上下文
-需求 / 设计 / AGENTS / 决策 / Skill / 历史证据
-        │
-        ▼
-协作契约
-责任 / 输入 / 输出 / Evidence / 权限 / Gate / 状态
-        │
-        ▼
-协作执行
-开发轨 / 测试轨 / Review / 人工裁决 / 汇合
-        │
-        ▼
-执行器
-DSH / Codex / Claude Code / Other Agent
-```
+这些能力仍包含早期契约，例如 `success/failure` 二态业务路由、`AWAITING_HUMAN_*` / `FAILED_MAX_ROUNDS` 等字符串状态，以及旧 Built-in Workflow/Role 集合。它们是当前兼容基线，不是 v0.1 新设计目标。
 
-核心原则：
+## v0.1 正式目标
 
-> **上下文 → 责任 → 权限 → 证据 → 协作 → 执行器。**
+### 四套正式 Built-in Workflow
+
+1. **建设 · 完整功能开发**  
+   需求分析 → 方案设计 → 开发 → 独立审核 → 独立测试 → 人工验收 → 收口
+2. **优化 · 快速迭代**  
+   目标确认 → 执行 → 评估 → 收口
+3. **诊断 · 缺陷修复**  
+   缺陷诊断 → 修复 → 审核 → 回归验证 → 收口
+4. **探索 · 多视角探索**  
+   探索统筹 → 专家研究 Fan-out → 综合分析 → 结论评估
+
+探索模板总研究轮次最多 **3 轮（包含首次 BROAD）**；自动 TARGETED 补充最多 2 轮。
+
+历史 `default-workflow` 和 `dev-workflow-2-0` 将迁移为 Custom Workflow，不继续作为系统正式标准。
+
+### 12 个正式 Built-in Role
+
+通用能力：
+
+- `requirements` — 需求分析
+- `designer` — 方案设计
+- `dev` — 开发
+- `review` — 审核
+- `test` — 测试
+- `evaluator` — 评估
+- `accept` — 验收助手
+- `closeout` — 收口
+
+专业能力：
+
+- `diagnose` — 缺陷诊断
+- `orchestrator` — 探索统筹
+- `researcher` — 专家研究
+- `synthesizer` — 综合分析
+
+旧 `dispatcher` 迁移为 Custom Role。
+
+### 统一 Runtime/契约
+
+v0.1 的核心升级包括：
+
+- Business Outcome Routing：合法业务结果不再伪装成 failure；
+- Completion Mapping：终态业务原因来自节点结构化结果；
+- Formal Records / Revision / Provenance；
+- Logical Run / Execution Segment；
+- 固定 Lifecycle：`READY / RUNNING / WAITING_HUMAN / PAUSED / BLOCKED / COMPLETED / STOPPED / FAILED`；
+- Run Snapshot Revision；v0.1 运行中只允许修改 Provider / Model；
+- Human Decision；
+- Pause / Interrupt / Run Guidance / Resume；
+- `maxRounds` 统一为自动回退额度，回退路径通过 `countRound` 决定是否消耗；
+- Static Validation + Provider/Model Preflight Probe；
+- Skill/Chat/未来插件入口共享同一 Logical Run Runtime。
 
 ## 单一事实源架构
 
-具体 Workflow 仍以 Blueprint 为唯一事实源：
+当前实现仍遵循：
 
 ```text
 templates/<id>.json
@@ -75,33 +109,55 @@ templates/<id>.json
    ├── SKILL.md
    └── meta.json
    │
-   ├─ vwf：可视化编辑 / 保存 / 运行观测
+   ├─ VWF：可视化编辑 / 保存 / 运行观测
    └─ DSH：生成 Skill 执行
 ```
 
 约束：
 
-- 人工只修改 Blueprint 或对应的权威规则文件；
-- `.generated/` 永远是生成物，不作为人工修改源；
-- 同一 Blueprint 不允许由多套不同业务语义解释；
-- Workflow / Contract 变更必须有行为回归保护。
+- 人工只修改 Blueprint 或对应权威规则文件；
+- `.generated/` 是生成物，不作为人工修改源；
+- 同一 Blueprint 不允许多套业务解释；
+- Blueprint / Contract 变更必须有行为回归保护；
+- v0.1 Runtime 升级必须向后兼容现有 Custom Workflow，不能要求所有用户资产一次性迁移后才能运行。
 
-## 当前与下一阶段
+## 当前实施主线
 
-| 能力 | 状态 |
-|---|---|
-| Blueprint / 编译 / 校验 / 行为测试 | ✅ 已完成基线 |
-| 可视化编辑与 Skill 闭环 | ✅ 已完成基线 |
-| 工作分支隔离 / Review / 人工门禁 | ✅ 已完成基线 |
-| 多 run 并行 | ✅ 已完成（#19） |
-| fanOut 同类子任务并行 | ✅ 已完成（#18 / PR #38） |
-| 运行历史跨进程恢复 | ⚠️ Reality Reconciliation（#40 当前 GitHub 状态仍为 open） |
-| 节点级 Context Pointer | ⏳ v0.2 |
-| 责任 / 权限 / Evidence 正式契约 | ⏳ v0.2 |
-| S / M / L 实施准入 | ⏳ v0.2 |
-| 同一需求多角色并行协作 | ⏳ v0.3 |
-| Codex / Claude Code 等执行器 | ⏳ v0.4 |
-| ACP / 动态规划 / 独立分发 | 后置 |
+```text
+#71 全局原则
+  ↓
+#77 Outcome Routing / Completion
+#72 Human Decision
+#73 自动回退额度
+#78 Formal Records / Provenance
+  ↓
+#79 Logical Run / Snapshot / Lifecycle
+#80 Pause / Guidance / Resume
+#74 Preflight Probe
+  ↓
+#81 12 Roles
+#82 四正式 Built-in Workflows
+#83 Skill/Chat Invocation
+  ↓
+#75 UI/交互实施拆分
+```
+
+实施总览：#76。
+
+Draft PR #70 已关闭且未合并。`feat/multi-perspective-exploration` 分支只作为 #81/#82 的素材库，不得整包直接合入 main。
+
+## 独立分发后置
+
+早期 P2 Epic #6 已关闭为 superseded。以下课题继续保留，但不属于当前 v0.1 frontier：
+
+- #21 独立仓库 + GitHub 分发；
+- #45–#48 独立分发相关决策。
+
+这些 Issue 必须在正式 Workflow/Runtime/资产边界稳定后重新基于届时 main 取证，不能直接按旧目录和打包假设实施。
+
+## 外部兼容性
+
+#35 跟踪 Minke / DSH 版本兼容问题。它与 Workflow Runtime 产品设计分离：只有当某个版本明确把 Minke 列为支持宿主时，才进入该版本发布门槛。
 
 ## 常用命令
 
@@ -111,60 +167,57 @@ npm run validate   # 蓝图校验 + 测试 + 重生成一致性检查
 npm test           # 引擎层行为与契约测试
 ```
 
+发布前还必须遵循 `AGENTS.md` 的开发模式 / 产品模式双轨：开发态验证不是发布证据，正式发布必须重建产物、完整重启 DSH 并执行真实 E2E。
+
 ## 目录
 
 | 路径 | 说明 |
 |---|---|
-| `templates/` | 具体 Workflow Blueprint，唯一事实源 |
+| `templates/` | 当前具体 Workflow Blueprint，唯一事实源 |
 | `.generated/` | 生成物，禁止手改 |
 | `scripts/` | 编译、校验、行为测试与生成流程 |
 | `packages/dsh-visual-workflow/` | 可视化编辑与运行观测入口 |
 | `dsh/` | DSH 侧角色与 Skill 真源 |
-| `docs/design/` | 当前契约与设计文档 |
+| `docs/design/` | 当前/目标 Contract 与设计文档 |
 | `docs/research/` | 调研结论 |
 | `specs/` | 已形成的规格 / OpenSpec |
 | `wayfinder/` | 决策地图与历史决策 |
-| `AGENTS.md` | 项目共同规则 |
-| `CONTEXT.md` | 项目统一术语 |
+| `AGENTS.md` | 项目共同硬规则 |
+| `CONTEXT.md` | 当前实现领域术语；目标语义以 v0.1 最终规格为准 |
 | `roadmap.md` | 产品 / 架构路线图 |
 
 ## 文档权威性
 
-当文档、Issue 和实际实现存在冲突时，不允许默默选一个继续施工。
-
-当前约定：
+不同类型文档承担不同职责：
 
 1. `AGENTS.md`：项目共同硬规则；
-2. `CONTEXT.md`：统一术语；
-3. `docs/design/`：当前 Contract / 设计语义；
-4. `templates/`：具体 Workflow 的唯一事实源；
-5. `specs/` / `wayfinder/`：需求、设计决策与历史上下文；
-6. GitHub Issue / PR：施工与验收状态；
+2. `docs/design/workflow-manager-v0.1-final-product-spec.md`：v0.1 正式产品目标规格；
+3. `CONTEXT.md`：当前实现术语与兼容语义；
+4. `templates/`：当前 main 中具体 Workflow 的唯一事实源；
+5. `roadmap.md`：版本顺序和实施依赖；
+6. GitHub Issue / PR：施工范围、迁移和验收状态；
 7. `main`：实际已经进入产品基线的实现。
 
-发现冲突时先做 Reality Reconciliation，再继续实现。过时设计应显式标记 Historical / Superseded，而不是继续作为 Agent 上下文。
+当目标规格与当前实现不同，这是正常的“迁移中状态”；Agent 必须明确自己是在维护兼容基线还是实施 v0.1 目标，不能把两者静默混合。
 
-## 开发指引
+过时设计应显式标记 Historical / Superseded / Deferred，而不是继续作为新施工依据。
 
-1. 新增或修改 Workflow：修改 `templates/` 中 Blueprint → 生成 → `npm run validate` → 用生成 Skill 或 vwf 做行为验证。
-2. 修改协作规则：同时检查 Contract、角色、行为测试与文档是否需要同步，不允许只改其中一份解释。
-3. 大型需求先完成需求分析和决策收敛；后续 Roadmap 将把 S / M / L 实施准入正式纳入 Workflow。
-4. 新增执行器前，优先确认现有协作契约是否已经能够表达该执行器需要承担的责任；不要为了某个 Agent 新复制一套 Workflow。
-
-## 路线图原则
-
-当前资源优先级：
+## 路线图
 
 ```text
-v0.1 可信基线与现实对账
+v0.1  Formal Workflow Foundation
+      Blueprint / Outcome / Formal Records / Logical Run / Snapshot / 12 Roles / 四模板
   ↓
-v0.2 Context / Responsibility / Authorization / Evidence
+v0.2  Product Interaction & Governance
+      UI / Context / Responsibility / Permission / Evidence / S-M-L
   ↓
-v0.3 同需求多角色协作
+v0.3  同一需求多角色协作
   ↓
-v0.4 多 Coding Agent 执行器
+v0.4  多 Coding Agent 执行器
   ↓
-v0.5+ 专业 Profile / ACP / 动态规划 / 分发
+v0.5+ 专业 Profile / 动态规划 / 协议与生态
+  ↓
+Later  独立分发（#21 / #45–#48 重新评估）
 ```
 
 详见 [`roadmap.md`](./roadmap.md)。

--- a/docs/design/workflow-manager-v0.1-final-product-spec.md
+++ b/docs/design/workflow-manager-v0.1-final-product-spec.md
@@ -1,0 +1,526 @@
+# Workflow Manager v0.1 正式工作流产品规格与实施拆解
+
+> 状态：统一审查定稿基线  
+> 日期：2026-08-30  
+> 范围：建设 / 优化 / 诊断 / 探索四套正式工作流，以及共享 Blueprint、Logical Run、角色、版本、人工交互、模型配置和执行入口能力。
+
+## 1. 产品定位
+
+Workflow Manager 是一套可配置、可运行、可干预、可恢复、可追溯的工作流系统，而不只是可视化串联 Agent 的流程编辑器。
+
+四套正式 Built-in Workflow 代表四种解决问题机制：
+
+1. **建设 · 完整功能开发**：正式、完整或较高风险的功能建设；
+2. **优化 · 快速迭代**：目标基本明确的小型优化、文档/配置/Prompt 等快速修改；
+3. **诊断 · 缺陷修复**：先建立根因证据，再修复和回归；
+4. **探索 · 多视角探索**：复杂开放问题，多视角独立研究后综合与评估。
+
+它们不是“复杂度四档”。用户选择模板的核心问题是“我现在面对哪一种问题”。
+
+## 2. 产品七层模型
+
+### 2.1 Workflow Asset
+
+长期资产分为：
+
+- Workflow：Built-in / Custom；
+- Role：Built-in / Custom。
+
+Built-in 是系统当前维护的正式标准。被新标准替代的历史试验资产迁移为 Custom，不继续占据 Built-in 身份。
+
+### 2.2 Workflow Blueprint
+
+Blueprint 定义工作流如何运行，至少包括：
+
+- nodes / edges；
+- role bindings；
+- provider / model bindings；
+- node goals；
+- input / output schema；
+- Business Outcome Routing；
+- Completion Mapping；
+- Human Decision rules；
+- automatic rollback budget；
+- fan-out / aggregation；
+- formal artifact declarations。
+
+核心规则：**节点只报告专业结果，Blueprint 负责解释结果和决定流向。** 节点不得通过 `next_node` 等字段耦合工作流拓扑。
+
+### 2.3 Invocation / Skill
+
+当前正式入口仍以 Skill / Chat 为核心：Workflow 保存后生成或更新 Skill，用户在会话中调用 Skill 或通过触发词加载工作流。
+
+未来插件侧若增加“使用此工作流 / 运行”等入口，只能作为新的 Invocation Adapter，最终进入同一个 Logical Run Runtime，不能形成第二套运行体系。
+
+### 2.4 Logical Workflow Run
+
+一个 Logical Run 代表用户从开始到结束的一次完整任务，不等同于底层 Workflow Engine 的一次 `start()`。
+
+同一 Run 可以包含多个 Execution Segment，以及 WAITING_HUMAN、PAUSED、BLOCKED、Snapshot Revision、Guidance、Decision 等事件。
+
+### 2.5 Run Snapshot
+
+每次 Run 启动时生成独立 Snapshot，冻结本次运行使用的 Workflow、Role、Provider/Model 等关键定义。
+
+v0.1 运行中只允许修改：
+
+- Provider；
+- Model。
+
+修改产生新的 Snapshot Revision，不无痕覆盖；只影响当前 Run，不修改来源 Workflow，也不影响其他 Run。
+
+Role / Goal / Schema / Routing / Node / Edge / Topology 等运行中修改暂不开放，后续完成影响分析能力后再评估。
+
+### 2.6 Run Lifecycle
+
+框架固定以下状态，不开放自定义：
+
+- `READY`
+- `RUNNING`
+- `WAITING_HUMAN`
+- `PAUSED`
+- `BLOCKED`
+- `COMPLETED`
+- `STOPPED`
+- `FAILED`
+
+仅 `COMPLETED / STOPPED / FAILED` 为终态。
+
+### 2.7 Formal Records / Provenance
+
+正式记录统一抽象为三类语义：
+
+- 输入 / 基准：需求基线、评估契约、诊断结论、研究任务书等；
+- 成果：代码、文档、修复、专家观点、综合报告等；
+- 证明：Review、Test、Evaluator、Human Acceptance / Decision 等。
+
+Formal Record 不覆盖修改；变化产生 Revision。每个正式结果记录自己依赖的输入/成果版本。
+
+旧记录保留历史事实，但依赖旧版本的证明不再能证明当前版本。
+
+## 3. Workflow 三层结果模型
+
+### 3.1 Workflow Lifecycle
+
+表示整个 Logical Run 的运行状态，仅由框架定义。
+
+### 3.2 Node Business Outcome
+
+表示节点自己的专业判断和路由依据，可由模板或自定义工作流定义。例如：
+
+- `PASS / OPTIMIZE / CONFIRM`
+- `PASS / NEEDS_RESEARCH / INSUFFICIENT`
+- `APPROVE / REQUEST_CHANGES`
+
+框架可提供常用 Outcome Preset，但不能把字段硬编码为 `outcome`。自定义工作流可配置自己的结果字段路径和枚举。
+
+技术执行成功与业务 Outcome 必须分离：Agent 正常返回合法结构化结果，不代表业务结果必须 PASS。
+
+### 3.3 Completion Type
+
+表示一个 `COMPLETED` Run 以什么业务原因完成，例如：
+
+- `EVALUATION_PASSED`
+- `USER_ACCEPTED`
+- `INSUFFICIENT`
+- `DELIVERED`
+- `COMPLETED_OBSERVING`
+- `NO_FIX_NEEDED`
+
+权威事实来自终态节点结构化产出；Run 层镜像摘要用于搜索/筛选/看板；正式中文报告提供用户可读表达。
+
+## 4. 全局设计原则 R1–R6 与扩展规则
+
+1. **R1**：Node 报告专业结果，不报告 next node；
+2. **R2**：Blueprint 把业务结果映射为路由；
+3. **R3**：正式记录采用不可覆盖 Revision；
+4. **R4**：Proof 绑定具体输入/成果 Revision；旧 Proof 保留，但对新版本变为 stale；
+5. **R5**：失效按真实依赖判断，不机械重跑全部下游；
+6. **R6**：每次 Workflow Run 冻结 Workflow / Role /关键配置快照；v0.1 当前 Run 只允许 Provider/Model Snapshot Revision。
+
+同时遵循：
+
+- 角色能力与节点场景分离；
+- 执行与独立证明分离；
+- 问题返回真正根因来源；
+- 不确定性是一等信息，`INSUFFICIENT` 可合法完成；
+- Human Decision 是框架能力，不是通用角色；
+- `maxRounds` = 自动回退额度，不是失败/重试总次数；
+- 机器结构英文，正式用户文档中文；
+- 系统记录公共交接元数据，节点保留专业业务 Schema，不建立超级 JSON；
+- 收口是质量循环终点，不重新做开发/审核/测试/评估；
+- 收口与事项关闭分离；观察和后续跟踪不要求 Run 长期运行；
+- Invocation 与 Runtime 分离。
+
+## 5. 生命周期与异常路径
+
+### 5.1 WAITING_HUMAN
+
+用于系统已经知道需要人做什么决定的场景，例如：
+
+- 需求基线确认；
+- 最终验收；
+- Evaluator `CONFIRM`；
+- 达到自动回退额度。
+
+达到自动回退额度后进入：
+
+`WAITING_HUMAN + reason=MAX_ROUNDS_REACHED`
+
+而不是 `FAILED_MAX_ROUNDS`。系统必须展示完整上下文、历史尝试、剩余问题、风险、成本/收益和可选方向。
+
+### 5.2 PAUSED
+
+当前可以继续，但用户主动暂停。
+
+支持：
+
+- **Safe Pause**：当前 Node Attempt 到安全点后暂停；
+- **Interrupt**：立即中断当前 Node Attempt，该 Attempt 标记 `INTERRUPTED`，不产生正式 PASS 结果。
+
+### 5.3 Run Guidance
+
+暂停期间用户可补充上下文、指出理解错误、纠正方向，并进行必要的多轮沟通。
+
+沟通结果形成 Guidance Record，恢复后的 Node Attempt 读取该指导。
+
+必须区分：
+
+- execution guidance：不改变正式基线；
+- baseline change：改变目标/范围/硬要求时，必须返回负责基线的业务节点，生成正式 Revision，并重新判断下游证明有效性。
+
+### 5.4 BLOCKED
+
+系统希望继续，但必要外部条件不存在，例如 Provider quota、模型不可用、鉴权失效、测试环境不可用。
+
+推荐恢复路径：
+
+`BLOCKED -> 修改当前 Run 的 Provider/Model -> Snapshot Revision -> Probe -> Resume`
+
+### 5.5 FAILED
+
+只用于无法安全恢复的框架/运行完整性异常，例如状态损坏、必要 checkpoint 无法恢复、框架无法解释的非法运行态。
+
+### 5.6 OBSERVING
+
+`OBSERVING` 不是 Workflow Lifecycle，也不是 Agent 节点。
+
+缺陷可在 `COMPLETED` 后通过 Completion Type / 后续事项显示“已完成 · 观察中”；观察期复发创建新的缺陷 Run，不重新打开旧 Run。
+
+## 6. Snapshot、Built-in Override 与模型可用性
+
+### 6.1 Built-in Workflow Model Override
+
+Built-in Workflow 的结构只读，但允许用户持久设置自己的 Provider / Model Override：
+
+`Built-in Workflow + User Model Override -> Effective Workflow -> Run Snapshot`
+
+修改 Node、Edge、Role、Goal、Schema、Outcome、Human Decision、回退规则或 Topology 时，必须“基于此模板创建自定义工作流”。
+
+### 6.2 Backup Provider
+
+v0.1 不增加自动 Backup Provider / Failover Policy。
+
+模型不可用时由用户显式修改当前 Run Snapshot 的 Provider/Model，再 Probe、Resume。未来可增加推荐替代模型，但不静默自动切换 Provider。
+
+### 6.3 Preflight Probe
+
+验证分两层：
+
+1. Static Validation：蓝图是否合法；
+2. Runtime Probe：当前 Provider / Model 是否能完成最小真实请求。
+
+Probe 只代表当前时点可用性，不保证整个长 Run 持续可用。
+
+## 7. 统一交接与证明链
+
+Node Result 由两部分组成：
+
+1. 系统元数据：logical run、node、attempt、snapshot revision、输入版本、产物版本、依赖关系、实际 provider/model 等；
+2. 节点专业结果：由当前节点 Output Schema 定义。
+
+示例：
+
+`Requirement R1 -> Design D1 -> Implementation I1 -> Review RV1 -> Test T1`
+
+若产生 `Implementation I2`，RV1/T1 仍是 I1 的历史证明，但不再证明 I2。
+
+探索补充研究也按依赖式失效：新增专家证据保留原专家结果，只重新综合和评估依赖该证据集合的结论，不机械重跑全部专家。
+
+## 8. 12 个正式 Built-in Role
+
+通用基础能力：
+
+1. `requirements` — 需求分析
+2. `designer` — 方案设计
+3. `dev` — 开发
+4. `review` — 审核
+5. `test` — 测试
+6. `evaluator` — 评估
+7. `accept` — 验收助手
+8. `closeout` — 收口
+
+专业能力：
+
+9. `diagnose` — 缺陷诊断
+10. `orchestrator` — 探索统筹
+11. `researcher` — 专家研究
+12. `synthesizer` — 综合分析
+
+旧 `dispatcher` 迁移为 Custom Role。
+
+复用规则：
+
+- `dev`：建设“开发”、优化“执行”、诊断“修复”；
+- `test`：建设“独立测试”、诊断“回归验证”；
+- `evaluator`：优化“评估”、探索“结论评估”，但节点级评价契约不同；
+- `review` 与 `evaluator` 保持不同能力；
+- `researcher` + 动态专家任务书生成 3–5 个运行期专家，不创建永久 Expert A/B/C/D。
+
+## 9. 四套正式 Built-in Workflow
+
+### 9.1 建设 · 完整功能开发
+
+流程：
+
+`需求分析 -> 方案设计 -> 开发 -> 独立审核 -> 独立测试 -> 人工验收 -> 收口`
+
+关键规则：
+
+- 需求最终确认是强 Human Gate；
+- 方案阶段仅重大未决问题条件触发 Human Decision；
+- Dev -> Review -> Test 固定顺序；
+- 实现/方案/需求问题分别返回真正上游；
+- 正式变化后重新执行因依赖变化而失效的证明；
+- 自动回退额度默认 3；超限转人工；
+- Human Acceptance 是正式业务阶段，由验收助手准备证据、人最终签字。
+
+### 9.2 优化 · 快速迭代
+
+流程：
+
+`目标确认 -> 执行 -> 评估 -> 收口`
+
+方法：Evaluator–Optimizer。
+
+关键规则：
+
+- 目标确认生成并冻结 evaluation contract；
+- 执行采用最小必要修改并保护已满足部分；
+- Evaluator 输出 `PASS / OPTIMIZE / CONFIRM`；
+- `OPTIMIZE -> execute` 消耗自动回退额度；
+- `RECONFIRM_REQUIRED` 不消耗；
+- 自动回退额度默认 3；
+- `CONFIRM` 或超限进入 Human Decision；
+- Completion Type 区分 `EVALUATION_PASSED / USER_ACCEPTED`。
+
+### 9.3 诊断 · 缺陷修复
+
+流程：
+
+`缺陷诊断 -> 修复 -> 审核 -> 回归验证 -> 收口`
+
+方法：Evidence-driven Debugging。
+
+关键规则：
+
+- 先诊断、后修复；
+- 原始 feedback signal 贯穿诊断、修复、回归；
+- 证据不足且不可复现时 BLOCKED，不猜根因；
+- 不稳定复现但证据足够时允许高可信根因路径，同时保留不确定性；
+- 审核/回归发现修复问题回修复，证据推翻根因回诊断；
+- 修改后必须重新审核和回归；
+- 默认不增加独立人工验收；高风险条件式人工确认由 Human Decision 承载；
+- **默认自动回退额度具体数值尚未最终确认**；推荐 3，但实施前必须单独确认。
+
+### 9.4 探索 · 多视角探索
+
+流程：
+
+`探索统筹 -> 专家研究(Fan-out 3–5) -> 综合分析 -> 结论评估 -> END`
+
+方法：Orchestrator–Workers + Synthesis + Evaluation。
+
+关键规则：
+
+- Orchestrator 设计互补认知视角，不拆报告章节；
+- 第一轮专家上下文隔离；
+- 专家区分事实/推断/未知，并提供证据、反证、假设、不确定性和 confidence；
+- Synthesis 构建共识/分歧/证据地图，不多数投票；
+- Evaluator 输出 `PASS / NEEDS_RESEARCH / INSUFFICIENT`；
+- `INSUFFICIENT` 是合法 `COMPLETED`；
+- 补充研究只做 Targeted；新证据必须重新综合和评估；
+- 默认无人工节点；
+- 不增加 Closeout Agent，Evaluator 直接进入统一完成协议；
+- **总研究轮次最多 3 轮，包含首次 BROAD**；不是“首次 + 3 次补充”；
+- 自动研究最多为第 1 轮 BROAD + 最多第 2、3 轮 TARGETED；
+- 若以 `maxRounds / countRound` 承载该限制，因为初次执行不计自动回退额度，最多允许 **2 次 `NEEDS_RESEARCH -> orchestrate` 自动回退**；
+- 第 3 轮结束后不得自动开启第 4 轮；Evaluator 应基于现有证据形成 `PASS` 或 `INSUFFICIENT` 等受控终结结果。
+
+## 10. Built-in / Custom 规则
+
+正式 Built-in Workflow 只保留上述四套新标准。
+
+历史 `default-workflow` 与 `dev-workflow-2-0` 退出 Built-in 身份，迁移为 Custom Workflow，并尽量保留用户引用、Skill 触发兼容和历史运行可追溯性。
+
+Built-in Workflow 支持：
+
+- 查看结构；
+- 修改用户级 Provider / Model Override；
+- 验证配置；
+- 基于此模板创建 Custom Workflow。
+
+Built-in 不允许原地修改 Node、Edge、Role、Goal、Schema、Outcome Routing、Human Decision、自动回退规则和 Topology。
+
+Custom Workflow 可完整编辑。
+
+## 11. UI / 交互边界
+
+当前真实基线：
+
+`模板库 -> 工作流编辑器（画布 + 配置面板）-> 保存生成/更新 Skill -> Chat 调用 Skill`
+
+后续 #75 需要统一设计：
+
+- Skill/Chat/插件入口关系；
+- Template Library Built-in/Custom 信息架构；
+- Outcome Preset / Completion Mapping 渐进式配置；
+- Logical Run Dashboard / Timeline / 流程视图；
+- 成果与证据视图；
+- Run Guidance；
+- BLOCKED 恢复与 Snapshot Provider/Model 切换。
+
+UI 不得另造第二套 Runtime。
+
+## 12. 当前唯一模板未决项
+
+仅保留：**诊断模板默认自动回退额度具体数值**。
+
+探索模板轮次已经锁定为总共最多 3 轮；按自动回退额度映射时最多允许 2 次 `NEEDS_RESEARCH -> orchestrate` 自动回退。
+
+## 13. 实施依赖
+
+```text
+#71 全局原则
+  |
+  +--> #77 Business Outcome Routing / Completion Mapping
+  +--> #78 Formal Records / Provenance
+  +--> #72 Human Decision
+  +--> #73 自动回退额度
+              |
+              v
+        #79 Logical Run / Lifecycle / Snapshot
+              |
+              +--> #80 Pause / Interrupt / Guidance / Resume
+              +--> #74 Preflight Probe
+              +--> 在 #40 已交付的持久化层上演进 Logical Run persistence
+
+#58 Role Library 基础能力 --> #81 12 个正式 Built-in Role
+
+#77 + #78 + #72 + #73 + #79 + #81
+              |
+              v
+#82 四套正式 Built-in Workflow + 历史模板迁移 + Built-in Model Override
+              |
+              +--> #83 Skill / Chat Invocation -> Logical Run Runtime
+
+#75 横向消费上述契约，定稿后再拆具体 UI 施工任务。
+```
+
+## 14. GitHub Issue 归属
+
+### 总览 / 原则
+
+- #71：全局设计原则；
+- #76：v0.1 正式工作流体系实施总览。
+
+### Blueprint / 结果 / 证据
+
+- #77：Business Outcome Routing + Completion Mapping；
+- #78：Formal Records / Version / Provenance；
+- #72：Human Decision；
+- #73：自动回退额度；
+- #69：多格式正式 Artifact，在 #78 契约上实现。
+
+### Runtime
+
+- #79：Logical Run / Execution Segment / Lifecycle / Snapshot Revision；
+- #80：Pause / Interrupt / Guidance / Resume；
+- #74：Preflight Probe；
+- #40：legacy engine-run persistence 已由 PR #50 完成；Logical Run persistence 演进归 #79。
+
+### 资产 / Invocation
+
+- #58：Role Library 基础能力已由 PR #61 完成；
+- #81：12 个正式 Built-in Role + 历史角色迁移；
+- #82：四套正式 Built-in Workflow + 历史模板迁移；
+- #83：Skill / Chat Invocation 接入统一 Logical Run Runtime。
+
+### UI
+
+- #75：整体 UI/交互架构设计。
+
+### 已退出实施依赖
+
+- #64–#68 已关闭为 Superseded；仍有价值的语义已分别迁入 #73/#77/#78/#81/#82；
+- #5 保留为早期编辑器/运行看板历史背景，不再作为正式状态模型依据。
+
+## 15. 分阶段实施清单
+
+### Phase A — Blueprint 契约底座
+
+- [ ] #71 方法论补充收口；
+- [ ] #77 Outcome Routing / Completion Mapping；
+- [ ] #72 Human Decision / Decision Record；
+- [ ] #73 自动回退额度；
+- [ ] #78 Formal Records / Provenance；
+- [ ] #69 多格式 Artifact 接入 Formal Record。
+
+### Phase B — Logical Run Runtime
+
+- [ ] #79 Logical Run / Lifecycle / Snapshot Revision；
+- [ ] #80 Pause / Interrupt / Guidance / Resume；
+- [x] #40 legacy engine-run persistence（PR #50）；
+- [ ] #79 在既有持久化层上升级 Logical Run / Segment / Snapshot Revision persistence；
+- [ ] #74 Snapshot Preflight Probe。
+
+### Phase C — 正式资产
+
+- [x] #58 Built-in / Custom Role Library 基础能力（PR #61）；
+- [ ] #81 12 个正式角色及历史迁移；
+- [ ] #82 四套 Built-in Workflow、历史模板迁移、Built-in Model Override；
+- [ ] #78/#82 正式 Built-in artifact/file 契约随 Formal Record 与当前 Built-in 集合演进；
+- [ ] #83 Skill / Chat Invocation 接入 Logical Run。
+
+### Phase D — UI / 产品呈现
+
+- [ ] #75 UI/交互方案定稿；
+- [ ] Template Library Built-in/Custom 信息架构；
+- [ ] Outcome / Completion / Human Decision 渐进式配置；
+- [ ] Skill/Chat/插件入口关系；
+- [ ] Logical Run Dashboard / Timeline / 成果与证据；
+- [ ] Run Guidance / BLOCKED 恢复 / Snapshot 模型切换。
+
+## 16. 发布门槛
+
+四模板进入 Built-in 之前至少满足：
+
+- Blueprint 能表达专业 Outcome 和自定义结果字段；
+- 多结果路由不依赖把业务结果伪装成 failure；
+- Human Decision 可等待/恢复并持久化 Decision Record；
+- 自动回退额度可按业务回退路径独立计数；
+- Logical Run 能跨多个 Execution Segment 保持同一 Run；
+- Run Snapshot 可冻结，并只对当前 Run 修改 Provider/Model Revision；
+- Provider/Model Preflight 可实际验证；
+- Formal Records 和版本依赖可追溯；
+- 12 个正式 Role 和四套 Workflow 正确生成 Skill；
+- 旧 Built-in 资产完成兼容迁移；
+- 产品模式下完成真实 E2E。
+
+## 17. 迁移与实现素材
+
+- Draft PR #70（`feat/multi-perspective-exploration`）已关闭且未合并；分支保留为探索模板素材库；
+- 后续 Agent 不得 reopen/rebase #70 作为正式实现，也不得整包 cherry-pick；
+- `orchestrator/researcher/synthesizer` 与探索业务 Schema 可在 #81/#82 选择性复用；旧 success/failure 路由、10-role registry 和数量测试必须按 #77/#81/#82 重做；
+- #40 的 legacy engine-run persistence 已完成；v0.1 不重新打开 #40，而是在 #79 中把既有持久化层升级为 Logical Run / Execution Segment / Snapshot Revision 模型；
+- #65–#68 已关闭为 superseded，后续只引用迁移后的正式承接 Issue。

--- a/docs/design/workflow-manager-v0.1-final-product-spec.md
+++ b/docs/design/workflow-manager-v0.1-final-product-spec.md
@@ -21,82 +21,37 @@ Workflow Manager 是一套可配置、可运行、可干预、可恢复、可追
 
 ### 2.1 Workflow Asset
 
-长期资产分为：
-
-- Workflow：Built-in / Custom；
-- Role：Built-in / Custom。
-
-Built-in 是系统当前维护的正式标准。被新标准替代的历史试验资产迁移为 Custom，不继续占据 Built-in 身份。
+长期资产分为 Workflow（Built-in / Custom）与 Role（Built-in / Custom）。Built-in 是系统当前维护的正式标准；被新标准取代的历史试验资产迁移为 Custom，不继续占据 Built-in 身份。
 
 ### 2.2 Workflow Blueprint
 
-Blueprint 定义工作流如何运行，至少包括：
+Blueprint 至少定义 nodes / edges、role bindings、provider / model bindings、node goals、input / output schema、Business Outcome Routing、Completion Mapping、Human Decision rules、automatic rollback budget、fan-out / aggregation 与 formal artifact declarations。
 
-- nodes / edges；
-- role bindings；
-- provider / model bindings；
-- node goals；
-- input / output schema；
-- Business Outcome Routing；
-- Completion Mapping；
-- Human Decision rules；
-- automatic rollback budget；
-- fan-out / aggregation；
-- formal artifact declarations。
-
-核心规则：**节点只报告专业结果，Blueprint 负责解释结果和决定流向。** 节点不得通过 `next_node` 等字段耦合工作流拓扑。
+核心规则：**Node 只报告专业结果，Blueprint 负责解释结果并决定流向。** Node 不得通过 `next_node` 等字段耦合拓扑。
 
 ### 2.3 Invocation / Skill
 
-当前正式入口仍以 Skill / Chat 为核心：Workflow 保存后生成或更新 Skill，用户在会话中调用 Skill 或通过触发词加载工作流。
-
-未来插件侧若增加“使用此工作流 / 运行”等入口，只能作为新的 Invocation Adapter，最终进入同一个 Logical Run Runtime，不能形成第二套运行体系。
+当前正式入口仍以 Skill / Chat 为核心。未来插件侧如增加“使用此工作流 / 运行”等入口，也只能作为新的 Invocation Adapter，最终进入同一个 Logical Run Runtime，不能形成第二套运行体系。
 
 ### 2.4 Logical Workflow Run
 
-一个 Logical Run 代表用户从开始到结束的一次完整任务，不等同于底层 Workflow Engine 的一次 `start()`。
-
-同一 Run 可以包含多个 Execution Segment，以及 WAITING_HUMAN、PAUSED、BLOCKED、Snapshot Revision、Guidance、Decision 等事件。
+一个 Logical Run 代表用户从开始到结束的一次完整任务，不等同于底层 Workflow Engine 的一次 `start()`。同一 Run 可以包含多个 Execution Segment，以及 WAITING_HUMAN、PAUSED、BLOCKED、Snapshot Revision、Guidance、Decision 等事件。
 
 ### 2.5 Run Snapshot
 
-每次 Run 启动时生成独立 Snapshot，冻结本次运行使用的 Workflow、Role、Provider/Model 等关键定义。
-
-v0.1 运行中只允许修改：
-
-- Provider；
-- Model。
-
-修改产生新的 Snapshot Revision，不无痕覆盖；只影响当前 Run，不修改来源 Workflow，也不影响其他 Run。
-
-Role / Goal / Schema / Routing / Node / Edge / Topology 等运行中修改暂不开放，后续完成影响分析能力后再评估。
+Run 创建时冻结 Workflow、Role、Provider / Model 与关键运行配置。v0.1 运行中只允许修改 Provider / Model，并产生 Snapshot Revision；只影响当前 Run，不修改来源 Workflow 或其他 Run。
 
 ### 2.6 Run Lifecycle
 
-框架固定以下状态，不开放自定义：
+框架固定以下 Lifecycle，不开放自定义：
 
-- `READY`
-- `RUNNING`
-- `WAITING_HUMAN`
-- `PAUSED`
-- `BLOCKED`
-- `COMPLETED`
-- `STOPPED`
-- `FAILED`
+`READY / RUNNING / WAITING_HUMAN / PAUSED / BLOCKED / COMPLETED / STOPPED / FAILED`
 
 仅 `COMPLETED / STOPPED / FAILED` 为终态。
 
 ### 2.7 Formal Records / Provenance
 
-正式记录统一抽象为三类语义：
-
-- 输入 / 基准：需求基线、评估契约、诊断结论、研究任务书等；
-- 成果：代码、文档、修复、专家观点、综合报告等；
-- 证明：Review、Test、Evaluator、Human Acceptance / Decision 等。
-
-Formal Record 不覆盖修改；变化产生 Revision。每个正式结果记录自己依赖的输入/成果版本。
-
-旧记录保留历史事实，但依赖旧版本的证明不再能证明当前版本。
+正式记录分为：输入/基准、成果、证明/决策。Formal Record 不覆盖修改；变化产生 Revision，并记录依赖的具体 Record Revision 与产生时的 Snapshot / Provider / Model。
 
 ## 3. Workflow 三层结果模型
 
@@ -106,150 +61,92 @@ Formal Record 不覆盖修改；变化产生 Revision。每个正式结果记录
 
 ### 3.2 Node Business Outcome
 
-表示节点自己的专业判断和路由依据，可由模板或自定义工作流定义。例如：
+表示 Node 自己的专业判断和路由依据，例如：
 
-- `PASS / OPTIMIZE / CONFIRM`
-- `PASS / NEEDS_RESEARCH / INSUFFICIENT`
-- `APPROVE / REQUEST_CHANGES`
+- 优化 Evaluator：`PASS / OPTIMIZE / CONFIRM`
+- 探索 Evaluator：`PASS / NEEDS_RESEARCH / INSUFFICIENT`
+- Review：`APPROVE / REQUEST_CHANGES`
 
-框架可提供常用 Outcome Preset，但不能把字段硬编码为 `outcome`。自定义工作流可配置自己的结果字段路径和枚举。
+框架可提供 Preset，但不能强制字段固定叫 `outcome`。自定义 Workflow 可配置自己的结果字段路径和枚举。
 
 技术执行成功与业务 Outcome 必须分离：Agent 正常返回合法结构化结果，不代表业务结果必须 PASS。
 
 ### 3.3 Completion Type
 
-表示一个 `COMPLETED` Run 以什么业务原因完成，例如：
+表示一个 `COMPLETED` Run 以什么业务原因完成，例如 `EVALUATION_PASSED / USER_ACCEPTED / INSUFFICIENT / DELIVERED / COMPLETED_OBSERVING / NO_FIX_NEEDED`。
 
-- `EVALUATION_PASSED`
-- `USER_ACCEPTED`
-- `INSUFFICIENT`
-- `DELIVERED`
-- `COMPLETED_OBSERVING`
-- `NO_FIX_NEEDED`
+权威事实来自终态 Node 的结构化结果；Run 层只镜像摘要用于搜索、筛选和看板。
 
-权威事实来自终态节点结构化产出；Run 层镜像摘要用于搜索/筛选/看板；正式中文报告提供用户可读表达。
-
-## 4. 全局设计原则 R1–R6 与扩展规则
+## 4. 全局设计原则 R1–R6
 
 1. **R1**：Node 报告专业结果，不报告 next node；
-2. **R2**：Blueprint 把业务结果映射为路由；
-3. **R3**：正式记录采用不可覆盖 Revision；
+2. **R2**：Blueprint 把 Business Outcome 映射为路由；
+3. **R3**：Formal Record 使用不可覆盖 Revision；
 4. **R4**：Proof 绑定具体输入/成果 Revision；旧 Proof 保留，但对新版本变为 stale；
 5. **R5**：失效按真实依赖判断，不机械重跑全部下游；
-6. **R6**：每次 Workflow Run 冻结 Workflow / Role /关键配置快照；v0.1 当前 Run 只允许 Provider/Model Snapshot Revision。
+6. **R6**：每次 Run 冻结 Workflow / Role /关键配置；v0.1 当前 Run 只允许 Provider / Model Snapshot Revision。
 
-同时遵循：
+同时遵循：角色能力化、节点场景化；执行与独立证明分离；问题返回真正根因来源；不确定性是一等信息；Human Decision 是框架能力；机器结构英文、正式用户文档中文；Invocation 与 Runtime 分离；收口是质量循环终点。
 
-- 角色能力与节点场景分离；
-- 执行与独立证明分离；
-- 问题返回真正根因来源；
-- 不确定性是一等信息，`INSUFFICIENT` 可合法完成；
-- Human Decision 是框架能力，不是通用角色；
-- `maxRounds` = 自动回退额度，不是失败/重试总次数；
-- 机器结构英文，正式用户文档中文；
-- 系统记录公共交接元数据，节点保留专业业务 Schema，不建立超级 JSON；
-- 收口是质量循环终点，不重新做开发/审核/测试/评估；
-- 收口与事项关闭分离；观察和后续跟踪不要求 Run 长期运行；
-- Invocation 与 Runtime 分离。
+## 5. Lifecycle 与异常路径
 
-## 5. 生命周期与异常路径
+### WAITING_HUMAN
 
-### 5.1 WAITING_HUMAN
+用于系统已经知道需要人做什么决定的场景，例如需求基线确认、最终验收、Evaluator `CONFIRM`、自动回退额度耗尽。
 
-用于系统已经知道需要人做什么决定的场景，例如：
-
-- 需求基线确认；
-- 最终验收；
-- Evaluator `CONFIRM`；
-- 达到自动回退额度。
-
-达到自动回退额度后进入：
+达到额度后进入：
 
 `WAITING_HUMAN + reason=MAX_ROUNDS_REACHED`
 
-而不是 `FAILED_MAX_ROUNDS`。系统必须展示完整上下文、历史尝试、剩余问题、风险、成本/收益和可选方向。
+而不是 `FAILED_MAX_ROUNDS`。
 
-### 5.2 PAUSED
+**关键规则：自动回退额度限制的是自动流转能力，不得改写已经形成的 Node Business Outcome。**
 
-当前可以继续，但用户主动暂停。
+### PAUSED / Run Guidance
 
-支持：
+PAUSED 表示条件具备但用户主动暂停。支持 Safe Pause、Interrupt 和多轮 Guidance。普通 Guidance 不改变正式 Baseline；若用户改变目标、范围或硬要求，必须回负责 Baseline 的业务节点生成新 Revision。
 
-- **Safe Pause**：当前 Node Attempt 到安全点后暂停；
-- **Interrupt**：立即中断当前 Node Attempt，该 Attempt 标记 `INTERRUPTED`，不产生正式 PASS 结果。
+### BLOCKED
 
-### 5.3 Run Guidance
+系统想继续但必要外部条件缺失，例如 Provider quota、鉴权失效、模型不可用、测试环境不可用。可恢复后继续同一个 Logical Run。
 
-暂停期间用户可补充上下文、指出理解错误、纠正方向，并进行必要的多轮沟通。
+### FAILED
 
-沟通结果形成 Guidance Record，恢复后的 Node Attempt 读取该指导。
+只用于无法安全恢复的框架/运行完整性错误。
 
-必须区分：
+### OBSERVING
 
-- execution guidance：不改变正式基线；
-- baseline change：改变目标/范围/硬要求时，必须返回负责基线的业务节点，生成正式 Revision，并重新判断下游证明有效性。
+OBSERVING 不是 Lifecycle。缺陷可 `COMPLETED` 后显示“已完成 · 观察中”；复发创建新缺陷 Run，不重新打开旧 Run。
 
-### 5.4 BLOCKED
+## 6. Snapshot、Model Override 与 Preflight
 
-系统希望继续，但必要外部条件不存在，例如 Provider quota、模型不可用、鉴权失效、测试环境不可用。
+Built-in Workflow 原始结构只读，但用户可以保存 Provider / Model Override：
 
-推荐恢复路径：
+`Built-in Workflow + User Override -> Effective Workflow -> Run Snapshot`
 
-`BLOCKED -> 修改当前 Run 的 Provider/Model -> Snapshot Revision -> Probe -> Resume`
+修改 Node、Edge、Role、Goal、Schema、Outcome Routing、Human Decision、回退规则或拓扑时，必须“基于此模板创建自定义工作流”。
 
-### 5.5 FAILED
+v0.1 不做静默 Backup Provider / Failover。模型不可用时：
 
-只用于无法安全恢复的框架/运行完整性异常，例如状态损坏、必要 checkpoint 无法恢复、框架无法解释的非法运行态。
+`BLOCKED -> 用户修改当前 Run Provider/Model -> Snapshot Revision -> Probe -> Resume`
 
-### 5.6 OBSERVING
+验证分两层：Static Validation + Runtime Preflight Probe。Probe 只验证当前 Provider / Model 能否完成最小真实调用，不评价回答质量，也不能替代产品模式真实 E2E。
 
-`OBSERVING` 不是 Workflow Lifecycle，也不是 Agent 节点。
+## 7. Formal Record / Proof Chain
 
-缺陷可在 `COMPLETED` 后通过 Completion Type / 后续事项显示“已完成 · 观察中”；观察期复发创建新的缺陷 Run，不重新打开旧 Run。
-
-## 6. Snapshot、Built-in Override 与模型可用性
-
-### 6.1 Built-in Workflow Model Override
-
-Built-in Workflow 的结构只读，但允许用户持久设置自己的 Provider / Model Override：
-
-`Built-in Workflow + User Model Override -> Effective Workflow -> Run Snapshot`
-
-修改 Node、Edge、Role、Goal、Schema、Outcome、Human Decision、回退规则或 Topology 时，必须“基于此模板创建自定义工作流”。
-
-### 6.2 Backup Provider
-
-v0.1 不增加自动 Backup Provider / Failover Policy。
-
-模型不可用时由用户显式修改当前 Run Snapshot 的 Provider/Model，再 Probe、Resume。未来可增加推荐替代模型，但不静默自动切换 Provider。
-
-### 6.3 Preflight Probe
-
-验证分两层：
-
-1. Static Validation：蓝图是否合法；
-2. Runtime Probe：当前 Provider / Model 是否能完成最小真实请求。
-
-Probe 只代表当前时点可用性，不保证整个长 Run 持续可用。
-
-## 7. 统一交接与证明链
-
-Node Result 由两部分组成：
-
-1. 系统元数据：logical run、node、attempt、snapshot revision、输入版本、产物版本、依赖关系、实际 provider/model 等；
-2. 节点专业结果：由当前节点 Output Schema 定义。
+系统自动记录 logical_run_id、node / attempt、snapshot revision、record revision、dependencies、actual provider/model、Node Outcome 与相关 Decision / Guidance。
 
 示例：
 
 `Requirement R1 -> Design D1 -> Implementation I1 -> Review RV1 -> Test T1`
 
-若产生 `Implementation I2`，RV1/T1 仍是 I1 的历史证明，但不再证明 I2。
+若产生 `Implementation I2`，RV1/T1 仍保留为 I1 的历史证明，但不能证明 I2。
 
-探索补充研究也按依赖式失效：新增专家证据保留原专家结果，只重新综合和评估依赖该证据集合的结论，不机械重跑全部专家。
+探索增加 Targeted 专家证据时保留原专家结果，只重新生成依赖旧证据集合的 Synthesis / Evaluation。
 
 ## 8. 12 个正式 Built-in Role
 
-通用基础能力：
+通用：
 
 1. `requirements` — 需求分析
 2. `designer` — 方案设计
@@ -260,267 +157,143 @@ Node Result 由两部分组成：
 7. `accept` — 验收助手
 8. `closeout` — 收口
 
-专业能力：
+专业：
 
 9. `diagnose` — 缺陷诊断
 10. `orchestrator` — 探索统筹
 11. `researcher` — 专家研究
 12. `synthesizer` — 综合分析
 
-旧 `dispatcher` 迁移为 Custom Role。
-
-复用规则：
-
-- `dev`：建设“开发”、优化“执行”、诊断“修复”；
-- `test`：建设“独立测试”、诊断“回归验证”；
-- `evaluator`：优化“评估”、探索“结论评估”，但节点级评价契约不同；
-- `review` 与 `evaluator` 保持不同能力；
-- `researcher` + 动态专家任务书生成 3–5 个运行期专家，不创建永久 Expert A/B/C/D。
+旧 `dispatcher` 迁移为 Custom Role。共享 Role 不代表共享 Node Outcome Schema；例如优化和探索都使用 evaluator，但各自评价契约与枚举由节点定义。
 
 ## 9. 四套正式 Built-in Workflow
 
 ### 9.1 建设 · 完整功能开发
 
-流程：
-
 `需求分析 -> 方案设计 -> 开发 -> 独立审核 -> 独立测试 -> 人工验收 -> 收口`
 
-关键规则：
-
 - 需求最终确认是强 Human Gate；
-- 方案阶段仅重大未决问题条件触发 Human Decision；
 - Dev -> Review -> Test 固定顺序；
-- 实现/方案/需求问题分别返回真正上游；
-- 正式变化后重新执行因依赖变化而失效的证明；
-- 自动回退额度默认 3；超限转人工；
-- Human Acceptance 是正式业务阶段，由验收助手准备证据、人最终签字。
+- 实现 / 方案 / 需求问题分别返回真正上游；
+- 上游正式变化只让依赖它的 Proof 失效；
+- 自动回退额度默认 3；
+- Human Acceptance 是正式业务阶段。
 
 ### 9.2 优化 · 快速迭代
 
-流程：
-
 `目标确认 -> 执行 -> 评估 -> 收口`
-
-方法：Evaluator–Optimizer。
-
-关键规则：
 
 - 目标确认生成并冻结 evaluation contract；
 - 执行采用最小必要修改并保护已满足部分；
-- Evaluator 输出 `PASS / OPTIMIZE / CONFIRM`；
+- Evaluator 只输出 `PASS / OPTIMIZE / CONFIRM`；
 - `OPTIMIZE -> execute` 消耗自动回退额度；
-- `RECONFIRM_REQUIRED` 不消耗；
-- 自动回退额度默认 3；
-- `CONFIRM` 或超限进入 Human Decision；
-- Completion Type 区分 `EVALUATION_PASSED / USER_ACCEPTED`。
+- `RECONFIRM_REQUIRED` **不是 Evaluator 裁决**。当执行节点发现冻结的 evaluation contract / Baseline 因新事实、约束或环境变化已不再可执行时，由执行节点输出 `RECONFIRM_REQUIRED`；
+- `RECONFIRM_REQUIRED -> 目标确认`，`countRound=false`，重新确认/修订 evaluation contract；
+- Completion 区分 `EVALUATION_PASSED / USER_ACCEPTED`；
+- 自动回退额度默认 3。
 
 ### 9.3 诊断 · 缺陷修复
 
-流程：
-
 `缺陷诊断 -> 修复 -> 审核 -> 回归验证 -> 收口`
-
-方法：Evidence-driven Debugging。
-
-关键规则：
 
 - 先诊断、后修复；
 - 原始 feedback signal 贯穿诊断、修复、回归；
 - 证据不足且不可复现时 BLOCKED，不猜根因；
-- 不稳定复现但证据足够时允许高可信根因路径，同时保留不确定性；
-- 审核/回归发现修复问题回修复，证据推翻根因回诊断；
+- 修复问题回修复，证据推翻根因回诊断；
 - 修改后必须重新审核和回归；
-- 默认不增加独立人工验收；高风险条件式人工确认由 Human Decision 承载；
-- **默认自动回退额度具体数值尚未最终确认**；推荐 3，但实施前必须单独确认。
+- 默认无独立人工验收；
+- 默认自动回退额度具体数值尚未最终确认，推荐 3 但未锁定。
 
 ### 9.4 探索 · 多视角探索
 
-流程：
-
 `探索统筹 -> 专家研究(Fan-out 3–5) -> 综合分析 -> 结论评估 -> END`
 
-方法：Orchestrator–Workers + Synthesis + Evaluation。
-
-关键规则：
-
-- Orchestrator 设计互补认知视角，不拆报告章节；
+- Orchestrator–Workers + Synthesis + Evaluation；
 - 第一轮专家上下文隔离；
-- 专家区分事实/推断/未知，并提供证据、反证、假设、不确定性和 confidence；
-- Synthesis 构建共识/分歧/证据地图，不多数投票；
+- 专家区分事实 / 推断 / 未知并提供证据、反证、假设、不确定性；
+- Synthesis 构建共识 / 分歧 / 证据地图，不多数投票；
 - Evaluator 输出 `PASS / NEEDS_RESEARCH / INSUFFICIENT`；
-- `INSUFFICIENT` 是合法 `COMPLETED`；
-- 补充研究只做 Targeted；新证据必须重新综合和评估；
-- 默认无人工节点；
-- 不增加 Closeout Agent，Evaluator 直接进入统一完成协议；
-- **总研究轮次最多 3 轮，包含首次 BROAD**；不是“首次 + 3 次补充”；
-- 自动研究最多为第 1 轮 BROAD + 最多第 2、3 轮 TARGETED；
-- 若以 `maxRounds / countRound` 承载该限制，因为初次执行不计自动回退额度，最多允许 **2 次 `NEEDS_RESEARCH -> orchestrate` 自动回退**；
-- 第 3 轮结束后不得自动开启第 4 轮；Evaluator 应基于现有证据形成 `PASS` 或 `INSUFFICIENT` 等受控终结结果。
+- `INSUFFICIENT` 是合法完成；
+- 后续研究只做 TARGETED，新证据必须重新 Synthesis / Evaluation；
+- 不增加 Closeout Agent；
+- **总研究轮次最多 3 轮，包含首次 BROAD**；
+- 自动流程最多为 Round 1 BROAD + Round 2 TARGETED + Round 3 TARGETED；
+- 因初次执行不计自动回退额度，最多只有 **2 次 `NEEDS_RESEARCH -> orchestrate` 自动回退**；
+- 第 3 轮后不得自动启动第 4 轮；
+- 如果第 3 轮 Evaluator 仍输出 `NEEDS_RESEARCH`，必须保留该 Outcome，并进入 `WAITING_HUMAN + reason=MAX_ROUNDS_REACHED`；**不得为了结束流程把它改写成 `PASS` 或 `INSUFFICIENT`**；
+- Human Decision 展示三轮研究历史、未解决缺口、继续研究的价值 / 成本 / 风险。用户可接受当前不确定性并受控完成、停止，或基于新目标 / 新范围派生新 Run。
 
-## 10. Built-in / Custom 规则
+## 10. Built-in / Custom 迁移
 
-正式 Built-in Workflow 只保留上述四套新标准。
+正式 Built-in Workflow 只保留四套新标准。
 
-历史 `default-workflow` 与 `dev-workflow-2-0` 退出 Built-in 身份，迁移为 Custom Workflow，并尽量保留用户引用、Skill 触发兼容和历史运行可追溯性。
+历史 `default-workflow` 与 `dev-workflow-2-0` 迁为 Custom Workflow；旧 `dispatcher` 迁为 Custom Role。迁移应保留用户引用、Skill 兼容和历史可追溯性。
 
-Built-in Workflow 支持：
-
-- 查看结构；
-- 修改用户级 Provider / Model Override；
-- 验证配置；
-- 基于此模板创建 Custom Workflow。
-
-Built-in 不允许原地修改 Node、Edge、Role、Goal、Schema、Outcome Routing、Human Decision、自动回退规则和 Topology。
-
-Custom Workflow 可完整编辑。
+Draft PR #70 已关闭且未合并；`feat/multi-perspective-exploration` 仅作为 #81/#82 实现素材库。允许选择性复用探索 Prompt / Schema 思路，但不得 reopen/rebase #70，也不得整包 cherry-pick 旧 success/failure 路由、10-role registry 或旧数量测试。
 
 ## 11. UI / 交互边界
 
-当前真实基线：
+当前真实路径仍是：模板库 -> 编辑器 -> 保存生成/更新 Skill -> Chat 调用 Skill。
 
-`模板库 -> 工作流编辑器（画布 + 配置面板）-> 保存生成/更新 Skill -> Chat 调用 Skill`
+#75 负责正式 UI/交互架构。必须保证 Lifecycle / Node Outcome / Completion Type 分层表达；一个 Logical Run 跨多个 Execution Segment 仍显示为一个 Run；Chat / Skill / 插件入口共享同一 Runtime。
 
-后续 #75 需要统一设计：
+## 12. 实施依赖
 
-- Skill/Chat/插件入口关系；
-- Template Library Built-in/Custom 信息架构；
-- Outcome Preset / Completion Mapping 渐进式配置；
-- Logical Run Dashboard / Timeline / 流程视图；
-- 成果与证据视图；
-- Run Guidance；
-- BLOCKED 恢复与 Snapshot Provider/Model 切换。
+### Phase A — Blueprint / 结果 / 证明契约
 
-UI 不得另造第二套 Runtime。
+- #71 全局工作流设计原则
+- #77 Business Outcome Routing / Completion Mapping
+- #72 Human Decision
+- #73 自动回退额度 / countRound
+- #78 Formal Records / Provenance
+- #69 多格式 Formal Artifact
 
-## 12. 当前唯一模板未决项
+### Phase B — Logical Run Runtime / 发布底座
 
-仅保留：**诊断模板默认自动回退额度具体数值**。
+- #79 Logical Run / Execution Segment / Lifecycle / Snapshot Revision
+- #80 Pause / Interrupt / Guidance / Resume
+- #74 Preflight Probe
+- #40 legacy engine-run persistence 已由 PR #50 完成；Logical Run persistence 在 #79 基于既有持久化层演进
+- **#53 开发模式 / 产品模式双轨与发布闸门**
 
-探索模板轮次已经锁定为总共最多 3 轮；按自动回退额度映射时最多允许 2 次 `NEEDS_RESEARCH -> orchestrate` 自动回退。
+### Phase C — 正式资产 / Invocation
 
-## 13. 实施依赖
+- #58 Built-in / Custom Role Library 基础能力已完成
+- #81 12 个正式 Built-in Role
+- #82 四套正式 Built-in Workflow + 历史模板迁移 + Built-in Model Override
+- #83 Skill / Chat Invocation -> Logical Run Runtime
 
-```text
-#71 全局原则
-  |
-  +--> #77 Business Outcome Routing / Completion Mapping
-  +--> #78 Formal Records / Provenance
-  +--> #72 Human Decision
-  +--> #73 自动回退额度
-              |
-              v
-        #79 Logical Run / Lifecycle / Snapshot
-              |
-              +--> #80 Pause / Interrupt / Guidance / Resume
-              +--> #74 Preflight Probe
-              +--> 在 #40 已交付的持久化层上演进 Logical Run persistence
+### Phase D — UI
 
-#58 Role Library 基础能力 --> #81 12 个正式 Built-in Role
+- #75 整体 UI / 交互架构，定稿后再拆前端施工任务。
 
-#77 + #78 + #72 + #73 + #79 + #81
-              |
-              v
-#82 四套正式 Built-in Workflow + 历史模板迁移 + Built-in Model Override
-              |
-              +--> #83 Skill / Chat Invocation -> Logical Run Runtime
+## 13. 发布门槛
 
-#75 横向消费上述契约，定稿后再拆具体 UI 施工任务。
-```
+四套正式模板进入 Built-in 并发布 v0.1 前至少满足：
 
-## 14. GitHub Issue 归属
-
-### 总览 / 原则
-
-- #71：全局设计原则；
-- #76：v0.1 正式工作流体系实施总览。
-
-### Blueprint / 结果 / 证据
-
-- #77：Business Outcome Routing + Completion Mapping；
-- #78：Formal Records / Version / Provenance；
-- #72：Human Decision；
-- #73：自动回退额度；
-- #69：多格式正式 Artifact，在 #78 契约上实现。
-
-### Runtime
-
-- #79：Logical Run / Execution Segment / Lifecycle / Snapshot Revision；
-- #80：Pause / Interrupt / Guidance / Resume；
-- #74：Preflight Probe；
-- #40：legacy engine-run persistence 已由 PR #50 完成；Logical Run persistence 演进归 #79。
-
-### 资产 / Invocation
-
-- #58：Role Library 基础能力已由 PR #61 完成；
-- #81：12 个正式 Built-in Role + 历史角色迁移；
-- #82：四套正式 Built-in Workflow + 历史模板迁移；
-- #83：Skill / Chat Invocation 接入统一 Logical Run Runtime。
-
-### UI
-
-- #75：整体 UI/交互架构设计。
-
-### 已退出实施依赖
-
-- #64–#68 已关闭为 Superseded；仍有价值的语义已分别迁入 #73/#77/#78/#81/#82；
-- #5 保留为早期编辑器/运行看板历史背景，不再作为正式状态模型依据。
-
-## 15. 分阶段实施清单
-
-### Phase A — Blueprint 契约底座
-
-- [ ] #71 方法论补充收口；
-- [ ] #77 Outcome Routing / Completion Mapping；
-- [ ] #72 Human Decision / Decision Record；
-- [ ] #73 自动回退额度；
-- [ ] #78 Formal Records / Provenance；
-- [ ] #69 多格式 Artifact 接入 Formal Record。
-
-### Phase B — Logical Run Runtime
-
-- [ ] #79 Logical Run / Lifecycle / Snapshot Revision；
-- [ ] #80 Pause / Interrupt / Guidance / Resume；
-- [x] #40 legacy engine-run persistence（PR #50）；
-- [ ] #79 在既有持久化层上升级 Logical Run / Segment / Snapshot Revision persistence；
-- [ ] #74 Snapshot Preflight Probe。
-
-### Phase C — 正式资产
-
-- [x] #58 Built-in / Custom Role Library 基础能力（PR #61）；
-- [ ] #81 12 个正式角色及历史迁移；
-- [ ] #82 四套 Built-in Workflow、历史模板迁移、Built-in Model Override；
-- [ ] #78/#82 正式 Built-in artifact/file 契约随 Formal Record 与当前 Built-in 集合演进；
-- [ ] #83 Skill / Chat Invocation 接入 Logical Run。
-
-### Phase D — UI / 产品呈现
-
-- [ ] #75 UI/交互方案定稿；
-- [ ] Template Library Built-in/Custom 信息架构；
-- [ ] Outcome / Completion / Human Decision 渐进式配置；
-- [ ] Skill/Chat/插件入口关系；
-- [ ] Logical Run Dashboard / Timeline / 成果与证据；
-- [ ] Run Guidance / BLOCKED 恢复 / Snapshot 模型切换。
-
-## 16. 发布门槛
-
-四模板进入 Built-in 之前至少满足：
-
-- Blueprint 能表达专业 Outcome 和自定义结果字段；
-- 多结果路由不依赖把业务结果伪装成 failure；
-- Human Decision 可等待/恢复并持久化 Decision Record；
+- Blueprint 能表达专业 Outcome、自定义结果字段与 Completion Mapping；
+- 合法业务结果不再伪装成 failure；
+- 每个正式 Outcome 明确 producer + field path + route；
+- Human Decision 可等待 / 恢复并持久化 Decision Record；
 - 自动回退额度可按业务回退路径独立计数；
-- Logical Run 能跨多个 Execution Segment 保持同一 Run；
-- Run Snapshot 可冻结，并只对当前 Run 修改 Provider/Model Revision；
-- Provider/Model Preflight 可实际验证；
-- Formal Records 和版本依赖可追溯；
-- 12 个正式 Role 和四套 Workflow 正确生成 Skill；
+- 额度耗尽时保留原 Node Business Outcome 并转 WAITING_HUMAN；
+- Logical Run 可跨多个 Execution Segment 保持同一 Run；
+- Run Snapshot 冻结，v0.1 当前 Run 只允许 Provider / Model Revision；
+- Preflight Probe 可实际验证当前模型；
+- Formal Records / Revision / dependency 可追溯；
+- 12 Roles 与四套 Workflow 正确生成 / 更新 Skill；
 - 旧 Built-in 资产完成兼容迁移；
-- 产品模式下完成真实 E2E。
+- **#53 发布闸门完成：开发态不是发布证据，正式发布必须重新生成正式产物、完整重启 DSH，并在产品模式完成真实 E2E。**
 
-## 17. 迁移与实现素材
+## 14. 当前未决项
 
-- Draft PR #70（`feat/multi-perspective-exploration`）已关闭且未合并；分支保留为探索模板素材库；
-- 后续 Agent 不得 reopen/rebase #70 作为正式实现，也不得整包 cherry-pick；
-- `orchestrator/researcher/synthesizer` 与探索业务 Schema 可在 #81/#82 选择性复用；旧 success/failure 路由、10-role registry 和数量测试必须按 #77/#81/#82 重做；
-- #40 的 legacy engine-run persistence 已完成；v0.1 不重新打开 #40，而是在 #79 中把既有持久化层升级为 Logical Run / Execution Segment / Snapshot Revision 模型；
-- #65–#68 已关闭为 superseded，后续只引用迁移后的正式承接 Issue。
+仅保留：**诊断模板默认自动回退额度的具体数值**。推荐 3，但实施前必须明确确认。
+
+探索轮次已经锁定：总研究轮次最多 3，首次 BROAD 计入总数，最多 2 次自动 `NEEDS_RESEARCH -> orchestrate` 回退；第 3 轮仍 NEEDS_RESEARCH 时保留 Outcome 并转人工。
+
+## 15. 历史 Issue / 文档边界
+
+- #3 已审计并关闭为 Historical / Superseded；当前正式产品总览由 #76、UI 由 #75 承接；
+- #64–#68 已 superseded，不再作为施工依赖；
+- #40 保持 completed，不重新打开；
+- `CONTEXT.md` 与旧“开发工作流 2.0”文档当前继续描述 main 的兼容实现，待 #77/#79 等新语义真实进入 main 后再同步重写，避免文档先于代码。

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,522 +1,247 @@
 # Workflow Manager Roadmap
 
-> 状态基线：2026-08-25
->
-> 本文档是产品 / 架构级路线图。详细字段与运行语义以 `docs/design/` 为准，项目共同规则以 `AGENTS.md` 为准，术语以 `CONTEXT.md` 为准，历史决策以 `wayfinder/MAP.md` 为准，具体施工状态以 GitHub Issue / PR 与 `main` 实际实现为准。
+> 状态：2026-08-30 统一审查后重排  
+> 当前主目标：把早期可运行的 VWF/DSH 工作流原型收敛为正式、可扩展、可审计的 Workflow Manager v0.1 产品底座。
 
-## 1. 项目定位
+## 1. 北极星
 
-Workflow Manager 的长期目标不是维护一份固定的 DSH 编排脚本，也不是单纯做一个“通用工作流引擎”。
+Workflow Manager 面向复杂软件研发与通用知识工作，目标不是“按顺序调用多个 Agent”，而是建立一套：
 
-项目定位调整为：
+- 可配置：Workflow / Role / Provider / Model / Outcome / Gate 可声明；
+- 可运行：Blueprint 经统一校验、生成与 Runtime 执行；
+- 可干预：Human Decision、Pause、Interrupt、Guidance；
+- 可恢复：BLOCKED、Snapshot Revision、Resume；
+- 可追溯：Formal Record、Revision、Provenance、证据有效性；
+- 可扩展：Built-in 给出正式标准，Custom Workflow/Role 保留开放能力。
 
-> **面向复杂软件研发的 AI 协作工作流系统。**
->
-> 它负责把需求、设计、项目规则与专业能力按需交给正确的角色；约束每个角色的责任、权限与交付证据；允许 Agent 在职责边界内自主工作；在关键范围变更、验收、合并与其他高风险动作上保留人工授权；并让同一套协作规则逐步复用于不同 Coding Agent。
+DSH 是首个运行环境；Codex、Claude Code 等 Coding Agent 属于后续执行器扩展，不反向定义工作流产品模型。
 
-因此，跨 Agent 兼容仍然重要，但它是实现手段，不再是最高层产品目标。
+## 2. 两条基线必须分开
 
-### 1.1 项目优先解决的问题
+### 2.1 当前 main 已实现基线
 
-1. **上下文正确性**：Agent 不应靠复制整份项目知识工作，而应在当前阶段获得最小且权威的上下文指针。
-2. **责任边界**：每个角色清楚知道自己负责什么、不负责什么、必须交付什么证据。
-3. **局部自主与宏观授权**：正常开发 / 测试 / 审核尽量自动推进；改变范围、接受风险、最终验收、合并发布等动作保留人工决策。
-4. **证据驱动交接**：角色之间不是靠“我做完了”交接，而是靠结构化结果、文件产物、验证记录和可复现证据交接。
-5. **多人 / 多 Agent 协作**：同一个需求可以拥有不同责任轨道并行推进，而不只是多个独立需求同时运行。
-6. **执行器可替换**：DSH、Codex、Claude Code 或其他 Agent 可以逐步成为执行者，但不能绕过协作契约。
+截至 2026-08-30，仓库已经具备：
 
-### 1.2 长期四层模型
+- Blueprint → 统一校验/生成 → Skill 的单一事实源链；
+- 可视化模板库、画布编辑器和配置面板；
+- Built-in / Custom Role Library 基础能力（#58 / PR #61）；
+- 受限 Fan-out 与聚合（#18 / PR #38）；
+- 多 run 并行、同 taskId 互斥和人工门禁排队（#19 / PR #41、#44）；
+- legacy engine-run 运行记录跨进程持久化（#40 / PR #50）；
+- 开发/产品双轨规则已经进入 `AGENTS.md`，实施入口仍由 #53 完成；
+- 当前 Skill / Chat 是正式执行入口。
+
+这些能力仍运行在早期契约上：`success/failure` 二态路由、旧 run 状态字符串、旧 Built-in 模板/角色集合等。
+
+### 2.2 v0.1 目标规格
+
+权威目标规格：`docs/design/workflow-manager-v0.1-final-product-spec.md`。
+
+v0.1 将正式收敛为：
+
+- 四套 Built-in Workflow：建设 / 优化 / 诊断 / 探索；
+- 12 个 Built-in Role；
+- Business Outcome Routing + Completion Mapping；
+- Formal Records / Revision / Provenance；
+- Logical Run / Execution Segment / 固定 Lifecycle；
+- Run Snapshot Revision（v0.1 运行中只允许 Provider / Model）；
+- Human Decision；
+- Pause / Interrupt / Guidance / Resume；
+- 自动回退额度；
+- Static Validation + Preflight Probe；
+- Skill/Chat/未来插件入口共享同一 Logical Run Runtime。
+
+目标规格不是“main 已完成能力清单”。任何施工都必须同时核对实际代码与目标规格。
+
+## 3. v0.1 — Formal Workflow Foundation
+
+v0.1 是当前最高优先级。实施总览：#76。
+
+### Phase A — Blueprint、结果与证明契约
+
+目标：先让框架能正确表达业务语义，再迁移模板。
+
+- #71：全局工作流设计原则；
+- #77：Business Outcome Routing + Completion Mapping；
+- #72：Human Decision；
+- #73：自动回退额度 / `countRound`；
+- #78：Formal Records / Revision / Provenance；
+- #69：多格式正式 Artifact，在 #78 模型上接入。
+
+阶段出口：
+
+- 合法业务结果不再伪装成 failure；
+- Node Result 不携带 `next_node`；
+- Proof 能绑定具体 Record Revision；
+- Human Decision 与人工验收解耦；
+- 回退额度由业务路径显式声明。
+
+### Phase B — Logical Run Runtime
+
+目标：用户看到的是一个完整、可恢复的 Run，而不是多次 engine start。
+
+- #79：Logical Run / Execution Segment / Lifecycle / Snapshot Revision；
+- #80：Pause / Interrupt / Run Guidance / Resume；
+- #74：Preflight Probe；
+- #40 已完成的持久化层作为实现基础，由 #79 升级为 Logical Run 持久化；
+- #53：开发模式 / 产品模式双轨入口和正式发布闸门。
+
+阶段出口：
+
+- 一个 Logical Run 可跨人工等待、暂停、阻塞、模型切换继续；
+- Provider / Model 修改生成 Snapshot Revision，仅影响当前 Run；
+- READY / RUNNING / WAITING_HUMAN / PAUSED / BLOCKED / COMPLETED / STOPPED / FAILED 语义稳定；
+- 运行前能够验证 Provider / Model 当前实际可用。
+
+### Phase C — 正式 Built-in 资产与 Invocation
+
+- #81：12 个正式 Built-in Role + 历史角色迁移；
+- #82：四套正式 Built-in Workflow + 历史模板迁移 + Built-in Provider/Model Override；
+- #83：Skill / Chat Invocation 接入统一 Logical Run Runtime。
+
+正式四模板：
+
+1. 建设：需求分析 → 方案设计 → 开发 → 独立审核 → 独立测试 → 人工验收 → 收口；
+2. 优化：目标确认 → 执行 → 评估 → 收口；
+3. 诊断：缺陷诊断 → 修复 → 审核 → 回归验证 → 收口；
+4. 探索：探索统筹 → 专家研究 Fan-out → 综合分析 → 结论评估。
+
+探索轮次已锁定：**总研究轮次最多 3 轮，包含首次 BROAD；自动 TARGETED 补充最多 2 轮。** 若使用 #73 的回退额度映射，则最多允许 2 次 `NEEDS_RESEARCH -> orchestrate` 自动回退。
+
+历史 `default-workflow` / `dev-workflow-2-0` 迁为 Custom Workflow；`dispatcher` 迁为 Custom Role。
+
+Draft PR #70 已关闭且未合并；`feat/multi-perspective-exploration` 仅作为 #81/#82 的实现素材，不得整包合入 main。
+
+### Phase D — 产品呈现与 UI
+
+- #75 负责正式信息架构和交互定稿；
+- 当前模板库 + 画布编辑器可复用，但需要适配 Outcome、Completion、Snapshot、Human Decision、Logical Run Timeline、Guidance 和成果/证据视图；
+- 当前 Skill / Chat 入口不因 UI 重构被废弃；未来插件“使用/运行”只能作为同一 Runtime 的 Invocation Adapter。
+
+v0.1 是否要求完整 UI 重构进入首发，由 #75 拆分后按“发布必需 / 可后置”划界；底层契约不能等待 UI 决策才实施。
+
+## 4. v0.1 发布门槛
+
+只有以下条件同时满足，四套正式模板才可作为 Built-in 发布：
+
+1. #77/#72/#73/#78 的契约和兼容迁移完成；
+2. Logical Run、Snapshot Revision、持久化、Human Decision、Pause/Resume、Preflight 可真实工作；
+3. 12 Roles 与四模板符合最终规格；
+4. 旧 Built-in 资产安全迁为 Custom，不丢用户引用和历史；
+5. Skill/Chat 能创建、恢复同一个 Logical Run；
+6. `npm run validate`、相关包测试和回归测试全绿；
+7. 开发模式验证不能作为发布证据；必须按 #53 切产品模式、重启 DSH、完成真实 E2E；
+8. 四模板关键正常/回退/人工/不足路径均有 E2E 证据；
+9. 产品文档、Roadmap、CONTEXT/历史文档的当前/目标边界清晰。
+
+## 5. v0.2 — Product Interaction & Governance
+
+在 v0.1 Runtime/资产模型稳定后，集中完成用户体验和治理能力，而不是继续扩大底层状态机。
+
+候选主题：
+
+- #75 拆出的模板库、编辑器、Run Dashboard / Timeline / 成果与证据 UI；
+- Context Pointer：节点按需引用需求、设计、规则、Skill 和历史 Record；
+- Responsibility / Permission / Evidence Contract；
+- S / M / L 任务准入与风险分级；
+- 多格式 Artifact 的更完整可视化和人工决策呈现；
+- Provider/Model 推荐替代方案，但仍不默认静默 Failover。
+
+## 6. v0.3 — 同一需求的多角色并行协作
+
+在 Fan-out“同类子任务并行”之外，支持同一需求里的不同责任轨并行：
+
+- 开发轨 / 测试轨 / Review 轨；
+- 明确的交接版本和 Gate；
+- 主控同步点；
+- 失败只回到真正根因来源；
+- 证据链仍通过 Formal Records 管理。
+
+重点是职责协作，不是单纯提高并发数。
+
+## 7. v0.4 — 多 Coding Agent 执行器
+
+在 Workflow/Role/Run 契约稳定后，再把执行器从 DSH 扩展到 Codex、Claude Code 等：
+
+- Workflow 语义不为单一执行器复制；
+- Adapter 负责执行器差异；
+- 权限、上下文、证据和生命周期由 Workflow Manager 保持统一；
+- 新执行器必须通过同一行为/契约回归。
+
+## 8. v0.5+ — 专业 Profile、动态规划与生态
+
+候选：
+
+- 专业领域 Profile / Role Packs；
+- 更强的动态规划与任务分解；
+- 跨项目/跨仓库协作；
+- ACP 或其他协议适配；
+- 独立分发、注册表、模板生态。
+
+## 9. 独立分发：明确后置
+
+早期 P2 Epic #6 已关闭为 superseded。
+
+以下 Issue 保留，但不属于当前 v0.1 frontier：
+
+- #21：独立仓库 + GitHub 分发；
+- #45：包自包含边界；
+- #46：构建产物策略；
+- #47：独立分发下的仓库根解析；
+- #48：仓库归属 / monorepo 去留。
+
+它们必须在 #76 正式体系稳定后重新基于届时 main 取证；不得直接使用 2026-08-23 的目录与打包假设施工。
+
+## 10. 外部兼容性
+
+#35 是 Minke / DSH 版本兼容跟踪项，独立于正式 Workflow Runtime 设计。
+
+- 若正式发布声明支持 Minke，则未解决的宿主兼容问题进入发布门槛；
+- 若 v0.1 首发以原生 DSH 为支持宿主，则 #35 不阻塞 #76。
+
+## 11. 已完成能力如何看待
+
+历史已完成 Issue/PR 是“当前实现基线和回归资产”，不因为产品体系升级而删除历史：
+
+- 工作区隔离、分支/HEAD 验证等可靠性能力继续保留；
+- fanOut、多 run、持久化继续作为底层能力演进；
+- 旧 `success/failure`、`AWAITING_HUMAN_*`、`FAILED_MAX_ROUNDS` 等属于兼容层，不再作为新设计目标；
+- 旧 Built-in Workflow/Role 保留为迁移对象，不继续定义正式标准。
+
+## 12. 版本开发与发布节奏
+
+长期遵循 `AGENTS.md`：
 
 ```text
-权威上下文层
-需求 / 设计 / AGENTS / 决策 / Skill / 历史证据
-        │
-        │ 只传递当前阶段需要的引用与摘要
-        ▼
-协作契约层
-责任 / 输入 / 输出 / 证据 / 权限 / Gate / 状态
-        │
-        ▼
-协作执行层
-开发轨 / 测试轨 / Review / 人工裁决 / 汇合
-        │
-        ▼
-执行器层
-DSH / Codex / Claude Code / Other Agent
+版本内开发
+→ 开发模式快速迭代
+→ 契约/测试/人工验收
+→ 准备发布
+→ 切产品模式
+→ 重建正式产物
+→ 完整重启 DSH
+→ 真实 E2E
+→ PR / Review / Merge / Tag / Release
 ```
 
-核心顺序是：
+产品模式验收失败必须回开发模式修复，再重新进行完整产品模式验收。
 
-> **上下文 → 责任 → 权限 → 证据 → 协作 → 执行器。**
-
-不再以“先接更多执行器，再补协作语义”为主要演进顺序。
-
----
-
-## 2. 版本与命名规范
-
-项目正式版本从 **`0.1.0`** 开始，遵循 Semantic Versioning（SemVer）：
+## 13. 当前优先级
 
 ```text
-MAJOR.MINOR.PATCH
+P0  #71/#77/#72/#73/#78   Blueprint + 结果/证据契约
+ ↓
+P0  #79/#80/#74/#53       Logical Run + Snapshot + 可恢复运行
+ ↓
+P0  #81/#82/#83           12 Roles + 四模板 + Skill Invocation
+ ↓
+P1  #75                    正式 UI/交互实施拆分
+ ↓
+P2  Context / Responsibility / 多角色协作
+ ↓
+P3  多执行器
+ ↓
+Later #21/#45-#48          独立分发
 ```
 
-在 `1.0.0` 前：
-
-- `0.x.0`：新增一组明确的产品 / 架构能力；
-- `0.x.y`：兼容性修复、测试补强、文档 / 体验优化；
-- Git Tag / GitHub Release 使用 `v0.1.0`、`v0.2.0` 形式。
-
-历史 Workflow 名称与项目版本分离：
-
-- `dev-workflow-2-0` / “开发工作流 2.0”是模板历史名称；
-- `version` 是具体 Workflow 模板版本；
-- `contractVersion` 是 Workflow Contract 版本；
-- GitHub Release 版本是整个项目版本。
-
----
-
-## 3. 当前现实基线
-
-截至 2026-08-25，项目已经完成了第一阶段目标：**把 AI 开发流程从提示词集合收敛为可验证、可回归、可人工裁决的工作流底座。**
-
-### 3.1 Workflow 定义与执行基线 ✅
-
-已完成：
-
-- Blueprint 作为具体 Workflow 的唯一事实源；
-- Schema / 状态机蓝图化；
-- 单一编译路径；
-- 单一校验规则集；
-- runtime harness 行为测试；
-- DSH / vwf 双入口统一语义；
-- 生成 Skill 运行路径；
-- 用户模板保存 → 校验 → 编译 → Skill 闭环；
-- 生成物不可手改与重生成一致性检查。
-
-### 3.2 软件开发流程健壮性 ✅
-
-已完成：
-
-- dev / review 异源约束；
-- 工作分支物理隔离；
-- test / review / accept 验证分支与 HEAD 留痕；
-- 验证结论值一致性检查；
-- 测试 / 审核打回循环；
-- 9 轮上限与超限归因；
-- AI 验收准备 + 人工最终裁决；
-- `output.files` 与角色 / 目标的文件契约核对；
-- 关键状态机行为进入回归测试。
-
-### 3.3 可视化与产品入口 ✅
-
-已完成：
-
-- 模板库；
-- 节点 / 边编辑；
-- 节点属性和结构化输出配置；
-- JSON / 画布双向编辑；
-- 保存 / 删除 / 另存为；
-- 运行看板；
-- DSH 静态组合包安装路径；
-- 浏览器入口与宿主生命周期修复；
-- 默认工作流与角色自包含分发。
-
-### 3.4 并行基础能力 ✅
-
-项目已经提前完成了原 Roadmap 后置的两项能力：
-
-- **多 run 并行**：不同 taskId 的 Workflow 可同时运行；同 taskId 互斥；人工门禁可排队裁决。Issue #19 已验收关闭。
-- **fanOut 受限并行子任务**：同一节点可按 items 并行展开同类子任务、聚合结果并执行数量上限保护。Issue #18 已验收关闭，PR #38 已合并。
-
-需要明确：
-
-> 多 run 并行解决“多个独立任务同时跑”；fanOut 解决“同类子任务批量并行”。它们都不是“同一需求下多个不同责任角色并行协作”的完整实现。
-
-### 3.5 运行历史持久化：Reality Reconciliation ⚠️
-
-Issue #40 定义的是运行记录跨进程重启后的恢复能力。
-
-截至本 Roadmap 更新时，GitHub Issue #40 仍显示为 open，`main` 最近提交中也没有找到可明确归属于 #40 的合并记录。因此当前文档不把它标记为已完成。
-
-如果该能力已在其他分支 / PR 完成验收，需要先完成一次 Reality Reconciliation：
-
-1. 找到对应 PR / commit；
-2. 核对验收证据；
-3. 合入 `main`；
-4. 关闭 #40；
-5. 再将本节改为 ✅。
-
-### 3.6 当前仍存在的产品级缺口
-
-当前底座已经可控，但离“复杂软件研发 AI 协作系统”还有五个关键缺口：
-
-1. **Context Pointer 只完成角色级雏形**：节点会按角色读取规则，但尚未把需求、设计、项目规则、Skill、历史证据等正式建模为按需上下文。
-2. **人工授权粒度较粗**：主要依赖固定 `manualCheck` 节点，尚未形成按风险 / 规模 / 动作定义的权限策略。
-3. **S / M / L 需求准入未进入主工作流硬约束**：`requirements-analysis` 已有分级治理，但默认 Workflow 仍主要检查“三要素完整”后开工。
-4. **同需求多角色并行未建立**：尚不能正式表达“开发轨与测试轨并行准备 → 汇合验证 → Review → 人工决策”。
-5. **权威上下文仍可能漂移**：Roadmap、旧 OpenSpec、Issue、PR 与实际实现需要更强的持续对账机制。
-
----
-
-## 4. v0.1.0 — 可信基线与现实对账
-
-### 目标
-
-发布首个正式版本，确认当前成果具有可信、可重复、可回归的基线。
-
-**原则：只收口，不扩大能力边界。**
-
-### 已完成
-
-- [x] Blueprint 单一事实源
-- [x] 统一编译与校验语义
-- [x] runtime harness
-- [x] DSH / vwf 双入口一致
-- [x] 可视化编辑器基础能力
-- [x] 用户模板持久化与 Skill 闭环
-- [x] 工作分支隔离与验证可信度闸门
-- [x] 人工门禁
-- [x] 多 run 并行（#19）
-- [x] fanOut 受限并行（#18 / PR #38）
-- [x] DSH 安装形态基础能力
-- [x] CI / validate 基础
-
-### 发布前必须完成
-
-- [ ] 完成 VWF 开发 / 产品双轨：独立开发 DSH 中以 host + client 联合动态版本快速迭代，
-  发布前切回正式组合包，并完成一次包含开发、发布和失败回退的真实版本切换演练（#53）；
-- [ ] 正式统一项目与尚未正式发布子包的版本号基线；
-- [ ] 完成 `docs/design/equivalence-checklist.md` 正式签核；
-- [ ] 用生成 Skill 的真实触发路径完成一次完整 E2E；
-- [ ] 对 Issue / PR / Roadmap / OpenSpec / `main` 做 Reality Reconciliation；
-- [ ] 明确 #40 的真实实现状态并完成对账；
-- [ ] 处理仍开放但与已关闭 Issue 相关的 PR（包括 #44）的最终去向；
-- [ ] 重写或标记 #3 / #6 等历史 Epic，避免继续作为当前产品目标施工；
-- [ ] 在 `AGENTS.md` 中补齐架构硬规则、SemVer 规则与权威上下文层级；
-- [ ] 对已经过时的设计文档增加 Superseded / Historical 标记，而不是让 Agent 把旧方案当当前要求；
-- [ ] 创建 `v0.1.0` Tag / Release。
-
-### v0.1.0 完成定义
-
-以下条件必须同时成立：
-
-1. `npm run validate` 全绿；
-2. 等价验收清单签核；
-3. 真实 E2E 通过；
-4. Issue、PR、Roadmap、设计文档与 `main` 对关键能力的描述一致；
-5. 已过时文档不会被误认为当前权威方案；
-6. 发布 `v0.1.0`。
-
----
-
-## 5. v0.2.0 — Collaboration Contract v1
-
-### 目标
-
-把现有“节点 + 状态机”升级为第一版正式的**协作契约**：不仅描述下一步做什么，还描述谁负责、需要什么上下文、允许做什么、必须交什么证据、哪些动作需要人批准。
-
-这是下一阶段最高优先级。
-
-### 5.1 Context Pointer：上下文按需装载
-
-建立节点级上下文声明，使节点可以显式引用：
-
-- 需求来源；
-- 设计 / ADR / OpenSpec；
-- 项目共同规则；
-- 角色规则；
-- 可复用 Skill / 方法知识；
-- 前序节点产物；
-- 历史决策与验证证据。
-
-原则：
-
-- 默认传指针 / 引用，不复制整份知识；
-- 节点只获得职责所需的最小上下文；
-- 引用必须能追溯到权威来源；
-- 不通过复制多个 Skill 来解决知识复用问题；
-- 允许对当前节点生成短摘要，但摘要不能替代原始权威来源。
-
-### 5.2 Responsibility Contract：责任与交付
-
-为节点 / 角色正式描述：
-
-- 责任目标；
-- 明确非目标；
-- 输入契约；
-- 输出契约；
-- 必须提交的证据；
-- 可修改范围；
-- 可自主决策范围；
-- 失败 / 阻塞 / 升级条件。
-
-目标是让角色交接从“Prompt 约定”升级为可检查的协作协议。
-
-### 5.3 Human Authorization Policy：宏观授权
-
-人工参与从固定节点升级为策略：
-
-- 局部开发、测试、审核、打回可以自动推进；
-- 需求范围变化必须人工确认；
-- L 型 / 高风险需求进入实施前必须人工授权；
-- 最终体验 / 业务验收保留人工裁决；
-- 合并、发布、不可逆清理等动作可按项目策略独立授权；
-- AI 不得代签人工 Gate。
-
-目标不是增加审批次数，而是明确哪些决定属于人。
-
-### 5.4 S / M / L 实施准入
-
-将现有需求分析能力与开发 Workflow 正式衔接：
-
-- **S**：三要素完整、风险低，可直接进入实施；
-- **M**：必须存在可执行子任务与依赖关系；
-- **L / 高风险**：必须先完成决策 / 规格收敛，并取得人工“允许实施”授权。
-
-默认 Workflow 不再仅凭“三要素完整”判断所有任务都可以直接开发。
-
-### 5.5 运行历史与续接
-
-如果 #40 尚未实际落地，则在本版本完成：
-
-- run 历史跨进程保留；
-- 重启后可查看最近状态、角色调用与日志；
-- 人工 Gate 可以恢复归属；
-- 后续逐步支持从可信检查点继续工作，而不是只恢复 UI 展示。
-
-### 5.6 Workflow Contract 正式化
-
-在上述协作语义确定后，再正式化 Contract：
-
-- `contractVersion`；
-- Workflow 独立 `version`；
-- 字段兼容 / 废弃 / breaking change 策略；
-- migration；
-- 状态、Gate、Artifact、Evidence 的稳定协议；
-- 兼容性测试矩阵。
-
-### 5.7 AGENTS 与权威上下文治理
-
-建立明确的知识层级：
-
-```text
-AGENTS.md        项目共同规则
-CONTEXT.md       统一术语
-Workflow Contract
-                 协作与运行协议
-templates/       具体工作流事实源
-specs / ADR      已批准需求与设计
-wayfinder/MAP.md 历史决策与雾区
-roles / skills   专业角色与可复用方法
-run evidence     某次执行的证据
-```
-
-Review / closeout 增加文档漂移检查。
-
----
-
-## 6. v0.3.0 — 同一需求的多角色并行协作
-
-### 目标
-
-从“多个独立 run 并行”和“同类子任务 fanOut”升级为真正的软件研发协作：**同一个需求下，不同责任角色可以并行工作并在证据 Gate 汇合。**
-
-推荐第一条目标流程：
-
-```text
-                 ┌─ 开发轨：设计理解 → 开发 → 单测 / 自检 ─┐
-需求确认 / 授权 ─┤                                      ├─ 集成验证 → Review → 人工裁决
-                 └─ 测试轨：场景分析 → 用例 / 验证准备 ─────┘
-```
-
-### 本阶段重点
-
-- [ ] 多责任轨道定义；
-- [ ] 轨道级 Context Pointer；
-- [ ] 轨道间只通过正式 Artifact / Evidence 交接；
-- [ ] 汇合条件与未完成分支处理；
-- [ ] 开发与测试的独立责任边界；
-- [ ] 冲突与重新规划机制；
-- [ ] 人工 Gate 对多轨道状态的统一裁决；
-- [ ] 看板从“run 列表”升级为“责任轨道 + 证据 + 等待关系”。
-
-### 关于已有 fanOut
-
-#18 已完成的 fanOut 作为底层并行原语保留，但不把 fanOut 等同于多人协作。
-
----
-
-## 7. v0.4.0 — 多 Coding Agent 执行器
-
-### 目标
-
-在 Collaboration Contract 稳定后，让不同 Coding Agent 执行同一责任节点，而不改变协作规则。
-
-### 推荐顺序
-
-1. 保持 DSH 为默认执行器；
-2. 定义能力矩阵；
-3. 接入 Codex 执行原型；
-4. 接入 Claude Code 执行原型；
-5. 统一结果归一化、权限、取消、超时与错误分类；
-6. 同一 Workflow 至少在两种执行器上通过行为验证。
-
-### 核心原则
-
-- 执行器不能绕过 Schema / Artifact / Evidence / branch verification / Human Gate；
-- 不为了兼容某个 Agent 复制第二套 Workflow；
-- 不在本阶段强制引入 ACP 作为中间层。
-
----
-
-## 8. v0.5.0 — 专业开发 Profile 与规模化协作
-
-在核心协作模型稳定后，再增加特定开发场景。
-
-候选能力：
-
-- DSH / Cordis 插件开发 Profile；
-- 需要真实运行时审批的开发流程；
-- 复杂人工 Gate 生命周期；
-- 更丰富的协作看板；
-- 多团队 / 多项目上下文边界；
-- 运行历史、Evidence 与项目决策的长期查询。
-
-原则：共享 Workflow Core，不复制一套独立工作流。
-
----
-
-## 9. v0.6.0+ — 通用通讯、动态规划与分发
-
-以下能力保持后置，只有在核心协作模型已经验证后再推进。
-
-### ACP / 通用 Agent 通讯
-
-- ACP Executor；
-- capability negotiation；
-- 通讯协议与 Workflow Contract 分层；
-- structured output repair / retry；
-- permission / cancel / error 映射；
-- 多 Agent 互操作实验。
-
-ACP 是通讯层，不替代 Workflow Contract。
-
-### 动态规划
-
-- Agent 在约束内动态拆解任务；
-- 动态结果必须落入 Contract；
-- 不得绕过权限、Gate、轮次与证据要求。
-
-### 独立分发
-
-Issue #21 以及 #45–#48 当前涉及独立仓库、自包含边界、构建产物与后续开发流归属。
-
-这些问题本身重要，但短期对“复杂软件研发协作质量”的提升有限，因此在 v0.1 收口后默认暂停扩张，待 Collaboration Contract 与多角色协作稳定后再恢复。
-
-后续再评估：
-
-- 独立插件仓库；
-- GitHub 安装；
-- registry 发布；
-- 升级 / migration / rollback；
-- 多仓库 Issue 与协作流归属。
-
----
-
-## 10. GitHub Reality Reconciliation
-
-当前 Issue 是重要历史记录，但不能自动视为当前产品计划。
-
-| Issue / PR | 当前判断 | Roadmap 处理 |
-|---|---|---|
-| #3 DSH 可视化工作流总 Epic | 大量目标已实现，定位已升级 | 标记历史 Epic / 重写剩余目标 |
-| #6 P2 持久化产品 Epic | 旧范围已多次变化 | 重写或收口，不再直接作为新施工计划 |
-| #18 fanOut | ✅ 已验收关闭，PR #38 已合并 | 记入当前基线 |
-| #19 多 run 并行 | ✅ 已验收关闭 | 记入当前基线 |
-| PR #44 | 当前仍开放，属于 #19 后续验收修复 | v0.1 决定合入 / 替代 / 关闭 |
-| #40 run 记录持久化 | GitHub 当前仍 open，未找到明确合并证据 | v0.1 先现实对账；未完成则进入 v0.2 |
-| #21 独立仓库分发 | 后置合理 | v0.6+ |
-| #45–#48 分发决策工单 | 已形成较大决策成本 | 暂停，待核心协作模型稳定后恢复 |
-
----
-
-## 11. 架构与产品硬规则
-
-以下原则应由 `AGENTS.md`、Contract、测试与 Review 共同保护：
-
-1. Blueprint 是具体 Workflow 的唯一事实源。
-2. 生成物永远不是人工修改源。
-3. 同一 Contract 不允许存在两套语义不同的编译 / 校验解释。
-4. Contract 变化必须有行为测试保护。
-5. 节点默认只获得完成职责所需的最小权威上下文。
-6. 权威知识优先引用，不因复用方便而复制成多份长期真源。
-7. 角色必须有明确输入、输出、证据与权限边界。
-8. 局部执行尽量自主，宏观范围和高风险动作保留人工授权。
-9. AI 不代签人工 Gate。
-10. 外部 Agent 接入不能降低 Schema、Artifact、Evidence、分支验证与人工 Gate。
-11. fanOut、多 run 与多角色协作是三种不同能力，不混为一谈。
-12. Roadmap、Issue、设计文档与 `main` 出现冲突时，必须显式对账，不允许 Agent 静默选择旧文档继续施工。
-13. 只有真实出现重复、漂移或接入成本时才增加抽象，不为未来可能性提前复制体系。
-
----
-
-## 12. 近期施工顺序
-
-```text
-v0.1.0 可信基线
-  │
-  ├─ E2E / 等价签核
-  ├─ Issue / PR / 文档现实对账
-  ├─ #40 / PR #44 状态收口
-  ├─ 权威上下文与过时文档治理
-  └─ v0.1.0 Release
-        │
-        ▼
-v0.2.0 Collaboration Contract v1
-  │
-  ├─ Context Pointer
-  ├─ Responsibility Contract
-  ├─ Human Authorization Policy
-  ├─ S/M/L 实施准入
-  ├─ run 历史与续接
-  └─ Contract / AGENTS 治理
-        │
-        ▼
-v0.3.0 同需求多角色并行
-  │
-  └─ 开发轨 + 测试轨 + 汇合 Gate + Review
-        │
-        ▼
-v0.4.0 多 Coding Agent 执行器
-  │
-  └─ DSH / Codex / Claude Code
-        │
-        ▼
-v0.5.0 专业 Profile / 规模化协作
-        │
-        ▼
-v0.6.0+
-     ACP / 动态规划 / 独立分发
-```
-
----
-
-## 13. 1.0.0 前的成功标准
-
-项目进入 `1.0.0` 前，至少应满足：
-
-- Workflow / Collaboration Contract 稳定并具有版本与迁移机制；
-- 节点能够声明并获得最小必要上下文，而不是依赖全量提示词复制；
-- 责任、Artifact、Evidence、权限与 Gate 均可机器检查或明确人工裁决；
-- S / M / L 需求具有与风险匹配的实施准入；
-- 同一需求至少支持两条不同责任轨道可靠并行并汇合；
-- 运行历史与关键人工决策可以跨会话追溯；
-- 至少两个不同 Coding Agent 通过同一 Collaboration Contract 的 E2E 验证；
-- 可视化编辑与文本编辑不会产生语义分叉；
-- Roadmap、AGENTS、设计文档、Issue / PR 与真实实现能够持续保持一致；
-- 分发和通讯层不会反向绑架核心协作模型。
-
----
-
-本 Roadmap 随真实使用持续更新。新的抽象只有在能够减少已经发生的上下文错误、职责混乱、知识复制、协议漂移或协作成本时才进入核心；新的执行器、通讯协议与分发方式默认晚于协作语义本身。
+任何新 Issue 如果改变上述依赖，必须先更新本 Roadmap 或 #76，避免并行 Agent 按不同版本规划施工。


### PR DESCRIPTION
## 目标

把 2026-08-30 完成的四套正式工作流统一审查结果正式落库，并让项目规划文档与当前 GitHub Reality 对齐。

## 文档变更

1. 新增 `docs/design/workflow-manager-v0.1-final-product-spec.md`
   - 七层产品模型；
   - Lifecycle / Business Outcome / Completion 三层结果模型；
   - R1–R6；
   - Logical Run / Snapshot Revision / Guidance / Human Decision / Formal Records；
   - 12 个正式 Built-in Role；
   - 建设 / 优化 / 诊断 / 探索四套正式 Built-in Workflow；
   - 探索总研究轮次明确为 **最多 3 轮，包含首次 BROAD**，自动 TARGETED 补充最多 2 轮；
   - 第 3 轮仍为 `NEEDS_RESEARCH` 时保留专业 Outcome，进入 `WAITING_HUMAN + MAX_ROUNDS_REACHED`，不启动第 4 轮；
   - 快速迭代 `RECONFIRM_REQUIRED` 明确由执行节点产生，返回目标确认且 `countRound=false`；
   - #53 纳入 Phase B / 发布门槛；
   - 实施依赖与发布门槛。
2. 重写 `roadmap.md`
   - 明确“当前 main 已实现基线”与“v0.1 目标规格”是两条不同基线；
   - v0.1 调整为 Formal Workflow Foundation；
   - #71/#77/#72/#73/#78 → #79/#80/#74/#53 → #81/#82/#83 的实施顺序；
   - #21/#45–#48 独立分发后置；
   - 修正 #40 已由 PR #50 完成的历史事实。
3. 同步 `README.md`
   - 去除 2026-08-25 的过时 Roadmap / #40 Reality Reconciliation 口径；
   - 增加正式四模板、12 Roles 和新 Runtime 目标；
   - 明确 `CONTEXT.md` 当前描述 main 的兼容实现，而 v0.1 目标以最终规格为准。

## Review 反馈处理

已接受并同步到 #71/#73/#76/#77/#79/#82/#53：

- 不得在探索额度耗尽时把 `NEEDS_RESEARCH` 改写为 `PASS/INSUFFICIENT`；额度只控制自动路由；
- `RECONFIRM_REQUIRED` 的 producer / route / countRound 语义必须完整；
- #53 是 v0.1 正式发布门槛，不能只存在于 Roadmap。

## 迁移 / 历史处理

- #64–#68 已退出活动实施依赖；
- Draft PR #70 已关闭且未合并，`feat/multi-perspective-exploration` 分支仅作为 #81/#82 素材库，不得整包合入 main；
- #40 保留为已经完成的 legacy engine-run persistence 历史记录，Logical Run persistence 演进归 #79；
- 旧 `default-workflow` / `dev-workflow-2-0` 在正式资产迁移时转 Custom Workflow；旧 `dispatcher` 转 Custom Role；
- #3 已审计并关闭为 Historical / Superseded，当前总览由 #76、UI 由 #75 承接。

## 为什么暂不改写 CONTEXT.md / 旧 2.0 文档

它们目前仍准确描述 main 的现有兼容实现。如果在 #77/#79 尚未落地前把 `success/failure`、旧状态字符串等直接改成未来语义，会造成“文档先于代码”的另一种漂移。本 PR 通过 README 明确 Current vs Target 权威边界；等对应实现进入 main 后再同步重写术语和历史实现文档。

## Related

#3 #53 #71 #72 #73 #74 #75 #76 #77 #78 #79 #80 #81 #82 #83