### PR TITLE
docs: 建立 v0.1 三 Agent 并行开发计划与建设 Dogfood 调度

### DIFF
--- a/docs/design/v0.1-parallel-development-plan.md
+++ b/docs/design/v0.1-parallel-development-plan.md
@@ -1,0 +1,629 @@
+# Workflow Manager v0.1 并行开发计划
+
+> 日期：2026-08-30  
+> 状态：DSH / Cursor / Codex 三执行器调度基线  
+> Parent：#76  
+> 计划维护：#106  
+> 产品语义权威：`workflow-manager-v0.1-final-product-spec.md` + `workflow-design-principles.md`
+
+## 1. 目标
+
+本计划解决两个问题：
+
+1. **先把“建设 · 完整功能开发”工作流做成可立即 Dogfood 的双执行 Profile**，以后尽可能使用它开发本项目后续 Issue；
+2. 对仓库全部 Issue 做一次统一调度，明确依赖、开发顺序、DSH/Cursor/Codex 主责与并行边界，避免三个 Agent 同时修改同一片代码或按不同产品口径施工。
+
+本计划不改变正式产品语义。DSH、Codex、Cursor 只允许有不同 Execution Profile，不允许拥有不同的“建设工作流”。
+
+---
+
+## 2. 当前事实基线
+
+截至本计划创建时：
+
+- #71 已完成并通过 PR #85 进入 main；
+- #77 正在需求分析，已拆出 #86–#92，**继续当前分析，不重新启动**；
+- #72 正在并行需求分析，已拆出 #94–#101，**继续当前分析，不重新启动**；
+- #93 已建立 Workspace / Resource / Integration Isolation；
+- #79 已明确 Blocked by #93 的稳定数据契约；
+- #102–#105 已建立建设工作流 Dogfood 主线；
+- 当前活动 Issue 已开始用 `generic-agent` / `dsh-cordis` 标记执行环境；
+- 旧 #14 worktree、#19 多 Run、#23/#27 verified branch/HEAD 是新 #93/#78 的回归资产，不重新实现；
+- #40 persistence 与 #58 Role Library 已完成，后续在其上演进，不重新打开；
+- PR #70 已关闭且未合并，只允许作为 #81/#82 探索素材库。
+
+---
+
+## 3. 建设工作流双执行 Profile：第一优先级
+
+### 3.1 唯一业务语义
+
+```text
+Construction Portable Contract (#103)
+  requirements
+    -> design
+    -> dev
+    -> review
+    -> test
+    -> human acceptance
+    -> closeout
+           |
+      +----+----+
+      |         |
+      v         v
+External       DSH-native
+Profile #104   Profile #105
+Codex/Cursor   DSH
+```
+
+关键原则：
+
+- #103 是两套 Profile 的唯一共享业务契约；
+- #104/#105 只负责执行器映射，不复制 Workflow Semantics；
+- Bootstrap 期间缺失的正式 Runtime 能力必须显式标记 shim/manual handoff；
+- 随 #77/#72/#73/#78/#93/#79 等完成，#105 删除 shim，最终直接成为 #82 的正式“建设” Built-in；
+- v0.1 的 External Profile 是项目 Dogfood Runbook，不等于提前交付 v0.4 的通用 Executor SDK。
+
+### 3.2 建设工作流强制隔离规则
+
+所有 DSH/Cursor/Codex 建设 Run：
+
+- 独立 run identity；
+- 独立 Git branch + worktree；
+- 禁止在共享 main cwd 直接施工；
+- Review/Test/Human Acceptance 必须记录实际 verified HEAD；
+- 最终 merge 前执行 Integration Checkpoint；
+- target HEAD 改变后，根据变化重新执行受影响 Proof；
+- 临时运行文件不得混入最终 PR diff。
+
+### 3.3 Dogfood 解锁顺序
+
+1. **#103 — Cursor**：冻结 Portable Contract；
+2. **#104 — Cursor 主责**：实现 Codex/Cursor External Runbook；
+3. **#105 — DSH**：实现 DSH-native Bootstrap；
+4. #104 用一个 Cursor Issue + 一个 Codex Issue完成真实 Dogfood；
+5. #105 用一个 DSH Issue 完成真实 Dogfood；
+6. 后续新施工默认使用对应建设 Profile。
+
+推荐首批 Dogfood：
+
+- Cursor：#81 正式角色体系；
+- Codex：#73 自动回退额度（前提：#77 决策毕业并形成可施工契约）；
+- DSH：#53 开发/产品模式双轨入口与发布闸门。
+
+---
+
+## 4. Execution Lane 与当前 Agent 分工
+
+### 4.1 标签语义
+
+| 标签 | 含义 | 默认主责 |
+|---|---|---|
+| `generic-agent` | 仓库内纯代码、Schema、编译器/校验器、角色/模板、文档，可用普通测试验证 | Codex 或 Cursor |
+| `dsh-cordis` | Cordis/DSH Runtime、Host/RPC、真实挂起恢复、Probe、DSH 产品模式 E2E | DSH |
+| 两者都有 | 核心可脱离 DSH 实现，但必须 DSH 接线/真机验收 | External 主实现 + DSH 收口 |
+
+标签只是**能力边界**。本文件中的“当前主责 Agent”是当前排班，避免同一个 `generic-agent` Issue 被 Cursor/Codex 同时抢占。
+
+### 4.2 文件/能力主责边界
+
+当前并行阶段默认：
+
+- **Codex**：Blueprint Schema、validator/compiler/runtime-core 纯逻辑、Outcome/rollback/provenance/workspace core、对应单元/行为测试；
+- **DSH**：Cordis/workflow engine 接线、Host/RPC、Skill 实际运行、挂起/恢复、Provider Probe、DSH E2E、产品模式；
+- **Cursor**：Portable Contract/Runbook、Role/Template 资产、产品/设计文档；#75 启动后可承担 Client UI 主体。
+
+如果实际 Issue 必须跨越上述边界：拆垂直子 Issue，不允许三个 Agent 长时间同时编辑同一组核心文件。
+
+---
+
+## 5. 总体依赖图
+
+```text
+                    #71 DONE
+                       |
+       +---------------+----------------+
+       |                                |
+       v                                v
+ #77 + #86-#92                    #72 + #94-#101
+ Outcome decisions                Human Decision decisions
+       |                                |
+       +---------------+----------------+
+                       |
+              #73 + #78 + #69
+                       |
+                #93 Workspace
+                       |
+                #79 Logical Run
+                  /          \
+                #80          #74
+                  \          /
+                       |
+                 #81 Roles
+                       |
+                 #82 Workflows
+                 /          \
+     #102-#105 Construction   other 3 Built-ins
+                 \          /
+                       |
+                 #83 Invocation
+                       |
+                 #75 UI / Product
+                       |
+                 #53 Release Gate
+```
+
+说明：#102–#105 是 Dogfood Bootstrap，可以在完整 Runtime 前先工作；它们的**正式收敛**仍受 #77/#72/#73/#78/#93/#79/#81/#74/#83 约束。
+
+---
+
+## 6. 三 Agent 波次排班
+
+## Wave 0 — 现在立即执行
+
+### Codex：保持 #77 分析主线
+
+不要重新创建另一套 #77 分析。按现有 Wayfinder 推进：
+
+1. #88 Blueprint Outcome Routing Schema 编码；
+2. #87 #77 与 #72/#73/#79 交付边界；
+3. #89 Fan-out 是否参与 Outcome Routing；
+4. #90 业务回退与走通性/环规则（依赖 #88）；
+5. #91 Outcome 完整性/Preset（依赖 #88）；
+6. #92 Completion Mapping（依赖 #87）；
+7. #86 决策地图毕业，生成 OpenSpec；
+8. 对 #77 重新 requirements-analysis，拆正式实施 tickets。
+
+限制：#86 未毕业前禁止直接实施大范围 Blueprint 重构。
+
+### DSH：保持 #72 分析主线
+
+按现有 Wayfinder 推进：
+
+1. #95 当前 manualCheck 真实行为基线；
+2. #96 Acceptance 与 Human Decision Runtime 身份；
+3. #97 Decision Record 归属；
+4. #98 Decision Package（依赖 #96）；
+5. #99 Decision Result/路由（依赖 #96 + #87）；
+6. #100 manualCheck 兼容映射（依赖 #95 + #99）；
+7. #101 WAITING_HUMAN 过渡契约（依赖 #99 + #87）；
+8. #94 决策地图毕业，生成 OpenSpec；
+9. 对 #72 重新 requirements-analysis，拆正式实施 tickets。
+
+DSH 负责 #95/#101 的真实 Runtime 取证；纯产品决策可以在同一分析 Run 内完成，不另开互相冲突的实现分支。
+
+### Cursor：优先建立建设工作流
+
+1. #103 Portable Contract；
+2. #104 External Codex/Cursor Profile；
+3. 准备第一个 Cursor Dogfood Run。
+
+此阶段 Cursor 不进入 #77/#72 核心实现文件，避免与当前分析结论并行漂移。
+
+### Wave 0 出口
+
+- #77/#72 两棵决策树毕业；
+- #103 完成；
+- #104 至少可启动 External Dogfood；
+- #105 可基于稳定 Portable Contract 开始。
+
+---
+
+## Wave 1 — 建设工作流开始真正 Dogfood
+
+### DSH
+
+1. #105 DSH-native Bootstrap Profile；
+2. 使用 #105 Dogfood #53；
+3. #72 分析生成的实施 tickets，在 #105 可用后用建设工作流施工。
+
+### Cursor
+
+1. 完成 #104；
+2. 用 External Profile Dogfood #81；
+3. #81 完成后，等待 #78 或帮助 #75 做不依赖 Runtime 的产品设计拆解。
+
+### Codex
+
+1. 执行 #77 分析生成的实现 tickets；
+2. #77 可用后用 External Profile Dogfood #73；
+3. 完成 #104 所需的 Codex Dogfood 验证。
+
+### Wave 1 出口
+
+- DSH/Cursor/Codex 三种环境都至少实际跑过“建设”流程；
+- #77/#72 开始从决策进入实现；
+- #81 / #53 / #73 作为第一批 Dogfood Issue；
+- 之后新 Issue 默认按对应 Profile 执行。
+
+---
+
+## Wave 2 — Phase A 契约收敛
+
+### Codex 主责
+
+1. #73 自动回退额度；
+2. #78 Formal Records / Provenance；
+3. 根据 #78 为 #69 提供稳定 Record/Revision 接口。
+
+### DSH 主责
+
+1. #72 正式 Runtime 实施 tickets；
+2. Human Decision 挂起/恢复、旧 manualCheck 兼容、DSH 真机 E2E；
+3. 不提前偷做完整 #79 Lifecycle。
+
+### Cursor 主责
+
+1. #81 正式 12 Roles；
+2. #69 在 #78 接口稳定后实现多格式 Formal Artifact；
+3. 建设模板的 Role/Portable Contract 持续与 #102 对齐。
+
+### Wave 2 出口
+
+- Outcome/Human Decision/rollback/Formal Records 的正式契约可互相消费；
+- Portable evidence 可以开始向 Formal Records 迁移；
+- #81 可供 #82 使用。
+
+---
+
+## Wave 3 — Workspace / Logical Run
+
+### Codex：#93 Core
+
+实现/验证：
+
+- Workspace Provider / Mode；
+- Git worktree + branch/source revision；
+- Directory Sandbox；
+- worker scratch；
+- resource allocation / resource key / lock 的纯逻辑；
+- Integration Checkpoint；
+- target HEAD 改变后的 proof invalidation 接口；
+- stale workspace/lock recovery 的可测试核心。
+
+### DSH：#93 Runtime Integration -> #79
+
+1. 把 #93 core 接入 DSH workflow/runtime；
+2. 真机验证两 Run 同仓并行；
+3. #93 数据契约稳定后实施 #79；
+4. #79 在 #40 persistence 上升级 Logical Run/Segment/Snapshot/Workspace Context。
+
+### Cursor
+
+1. #69 / #81 收尾；
+2. 准备 #82“建设”正式 Built-in 资产迁移，但不在 #79 未稳定时宣布正式完成；
+3. 可以开始 #75 的信息架构设计，不修改尚未稳定的 Runtime 状态代码。
+
+### Wave 3 出口
+
+- 多 Run 具备五层隔离的核心能力；
+- Logical Run 数据模型稳定；
+- 建设 Bootstrap 可以开始替换 workspace/logical-run shim。
+
+---
+
+## Wave 4 — 可恢复 Runtime 与正式建设 Built-in
+
+### DSH
+
+顺序：
+
+1. #79 Logical Run；
+2. #80 Pause / Interrupt / Guidance / Resume；
+3. #74 Preflight Probe；
+4. 持续把 #105 shim 替换成正式 Runtime。
+
+#80 与 #74 在 #79 稳定后可拆小票并行，但若只有一个 DSH 执行 Run，优先 #80，再 #74。
+
+### Cursor
+
+1. #82 先完成“建设”正式 Built-in，直接消费 #102/#103/#105，不重新定义；
+2. Built-in Model Override 与历史模板迁移；
+3. 为优化/诊断/探索准备模板资产。
+
+### Codex
+
+1. #82 所需的 validator/compiler regression；
+2. 旧 Blueprint compatibility tests；
+3. 四模板 Outcome/Completion/rollback 行为测试；
+4. 帮助验证 #93/#79 的迁移与历史记录兼容。
+
+### Wave 4 出口
+
+- “建设”正式 Built-in 在 DSH Runtime 上运行；
+- Bootstrap 私有 shim 基本退出；
+- External Profile 与 DSH Built-in 仍共享 #103 语义。
+
+---
+
+## Wave 5 — 其余三模板、Invocation 与 UI
+
+### #82 模板拆分规则
+
+底座稳定后，把 #82 拆成四个施工子 Issue，避免多人在同一个 Epic/模板目录互踩：
+
+- 建设：Cursor 主责，DSH E2E；
+- 优化：Codex 主责 Blueprint/行为，DSH E2E；
+- 诊断：Codex 主责 Blueprint/行为，DSH E2E；
+- 探索：Cursor 主责资产迁移（可参考 #70 素材），Codex 行为回归，DSH E2E。
+
+所有模板都消费 #81 Roles、#93 Workspace Policy、#77 Outcome Routing、#72 Human Decision、#78 Formal Records。
+
+### DSH
+
+- #83 Skill/Chat Invocation；
+- 四模板产品模式 E2E；
+- #75 中 Host/RPC/Run Dashboard 真机部分。
+
+### Cursor
+
+- #75 Client/UI 主体；
+- Template Library、编辑器、Outcome/Completion/Human Decision/Run Detail；
+- 不另造第二套 Runtime。
+
+### Codex
+
+- #75 数据模型/validator/API 辅助；
+- 四模板回归、迁移、兼容测试；
+- 根据 Review 处理框架层缺口。
+
+---
+
+## Wave 6 — 发布收口
+
+### DSH 主责 #53 Release Gate
+
+最终必须：
+
+1. 清除开发态临时插件；
+2. 重建正式产物；
+3. `npm run validate` 全绿；
+4. 完整关闭并重启 DSH；
+5. 从真实正式安装路径加载；
+6. 四模板关键成功/回退/人工/不足路径 E2E；
+7. 多 Run 隔离/恢复/Probe/Invocation 真实验证；
+8. 产品模式失败则回开发模式修复后重新完整验收。
+
+### #35
+
+只有 v0.1 明确承诺支持 Minke 时才进入 Release Gate；否则保持 External Compatibility Watch。
+
+---
+
+## 7. 活动 Issue 调度表
+
+| Issue | 状态/作用 | 当前主责 | 启动条件/顺序 |
+|---|---|---|---|
+| #21 | Deferred 独立分发 | 不分配 | v0.1 正式体系稳定后重评 |
+| #35 | External Compatibility | Cursor | 低优先；仅支持 Minke 时进入发布门槛 |
+| #45–#48 | Deferred 分发决策 | 不分配 | #21 恢复后重新取证 |
+| #53 | Dev/Product 双轨 + Release Gate | DSH | #105 Dogfood；最终 Wave 6 收口 |
+| #69 | 多格式 Formal Artifact | Cursor | Blocked by #78 稳定接口 |
+| #72 | Human Decision Epic | DSH 主责 | 当前分析继续；#94–#101 毕业后实施 |
+| #73 | rollback budget/countRound | Codex | #77 决策/Schema稳定后；External Dogfood 候选 |
+| #74 | Preflight Probe | DSH | #79 Snapshot 稳定后 |
+| #75 | UI/交互总设计 | Cursor + DSH | 设计可提前，Runtime施工后置 |
+| #76 | v0.1 总 Epic | 项目统筹 | 持续更新 |
+| #77 | Outcome Routing Epic | Codex 主责 | 当前 #86–#92 分析继续 |
+| #78 | Formal Records | Codex | #77/#72核心契约稳定后 |
+| #79 | Logical Run | DSH | **Blocked by #93** + #77/#72/#73/#78 |
+| #80 | Pause/Guidance | DSH | Blocked by #79 + #78 |
+| #81 | 12 Roles | Cursor | #103/#104 后优先 Dogfood；#58已完成 |
+| #82 | 四模板 Epic | Cursor/Codex + DSH验收 | 建设先行；最终受 #77/#72/#73/#78/#93/#79/#81 阻塞 |
+| #83 | Invocation | DSH | #79/#80/#82 后 |
+| #86 | #77 Wayfinder | Codex | #87–#92 全关闭后毕业 |
+| #87 | #77/#72/#73/#79 边界 | Codex | 立即；优先级高 |
+| #88 | Outcome Schema编码 | Codex | 立即；优先级最高 |
+| #89 | Fan-out research | Codex | 可立即 |
+| #90 | 回退环/走通性 | Codex | #88 后 |
+| #91 | Outcome完整性/Preset | Codex | #88 后 |
+| #92 | Completion Mapping | Codex | #87 后 |
+| #93 | Workspace/Resource Isolation | Codex core + DSH integration | #78接口对齐；先于 #79 |
+| #94 | #72 Wayfinder | DSH | #95–#101 全关闭后毕业 |
+| #95 | manualCheck真实基线 | DSH | 立即、真机/源码取证 |
+| #96 | Acceptance/Decision身份 | DSH分析 | 立即 |
+| #97 | Decision Record归属 | DSH分析 | 立即 |
+| #98 | Decision Package | DSH分析 | #96 后 |
+| #99 | Decision Result路由 | DSH分析 | #96 + #87 后 |
+| #100 | manualCheck兼容映射 | DSH | #95 + #99 后 |
+| #101 | WAITING_HUMAN过渡契约 | DSH | #99 + #87 后 |
+| #102 | 建设双 Profile Epic | 项目统筹 | P0 Dogfood |
+| #103 | Portable Contract | **Cursor** | 立即，第一优先 |
+| #104 | External Codex/Cursor Profile | **Cursor** | #103 后；Codex交叉Dogfood |
+| #105 | DSH-native Bootstrap | **DSH** | #103 后；正式收敛依赖 Runtime |
+| #106 | 本并行计划文档 | Cursor/项目统筹 | 当前，通过 PR 入库后关闭 |
+
+---
+
+## 8. 全仓 Issue 审计（全部 Issue）
+
+### 8.1 已完成 / 历史回归资产
+
+以下 Issue 已完成，不重新分配 Agent；必要时作为回归和迁移事实引用：
+
+- #1：早期开发工作流状态机试跑；
+- #4：动态插件 P0 原型；
+- #5：早期编辑器/运行看板；
+- #7：早期 P0 工作流/插件配套；
+- #9–#13：早期产品/架构决策 D1–D5；
+- #14：Git worktree 多任务隔离——**#93 强制回归来源**；
+- #16–#20：P2 基础能力、模板/并行/Fan-out/执行路径；其中 #18/#19 是 #82/#93 的重要回归来源；
+- #22–#23：需求分析 Skill/验证分支问题；#23 是 Proof/HEAD 回归来源；
+- #27–#29：verified branch/HEAD、角色快照、worktree复验可靠性；
+- #33：Minke/VWF host-entry 修复；
+- #36–#37：Client/Host 生命周期修复；
+- #40：legacy engine-run persistence，#79 在其上升级；
+- #51：CI dependency install；
+- #54–#57：编辑器 UX 改善；
+- #58：Built-in/Custom Role Library；
+- #71：全局工作流设计原则（PR #85）。
+
+### 8.2 Historical / Superseded
+
+不允许后续 Agent 重新拾取旧产品规则：
+
+- #3：早期总 Epic，Historical/Superseded；
+- #6：旧 P2 总 Epic，Superseded；
+- #64–#68：旧 task-workflow 系列，Superseded。
+
+其中有价值的能力已经分别迁入 #73/#77/#78/#81/#82/#93 等新体系。
+
+### 8.3 Deferred
+
+- #21：独立仓库 + GitHub 分发；
+- #45：包自包含边界；
+- #46：构建产物策略；
+- #47：独立分发路径语义；
+- #48：仓库归属/monorepo。
+
+全部禁止当前施工，待 v0.1 Runtime/资产边界稳定后重新取证。
+
+### 8.4 External Watch
+
+- #35：Minke / DSH 凭据与宿主兼容。除非 v0.1 声明 Minke 为支持宿主，否则不阻塞主线。
+
+### 8.5 当前正式活动主线
+
+- #53、#69、#72–#83、#86–#106。
+
+这些 Issue 的当前 Agent/依赖已在第 7 节逐项列出。
+
+### 8.6 无实施含义的误操作记录
+
+- #107–#110：创建计划分支时的工具误操作占位 Issue，均已立即关闭为 `not_planned`；无产品/实施含义，任何 Agent 都不得引用或施工。
+
+> 说明：仓库 Issue 编号中间存在 PR 编号占位，因此 Issue 编号不是连续序列。以上分类覆盖当前仓库全部 Issue 实体。
+
+---
+
+## 9. 并行开发强制协作规则
+
+### 9.1 一 Issue / 一 Run / 一 Worktree
+
+每个施工 Agent 必须：
+
+```text
+Issue
+ ->独立 Run
+ ->独立 branch
+ ->独立 worktree
+ ->独立 PR
+```
+
+不得让 DSH/Cursor/Codex 在同一个共享工作目录或同一未提交分支上协作。
+
+### 9.2 Active Ownership
+
+一个 Issue 在同一时刻只有一个主责 Agent。
+
+- 需要另一 Agent 验证：创建 Review/Test Run，而不是直接接管开发 worktree；
+- 需要跨 DSH + generic 的实现：拆 Core/Integration 子票或明确分阶段交接；
+- 不允许两个 Agent 同时对同一文件集实施两个不同版本的需求分析结论。
+
+### 9.3 Integration Checkpoint
+
+PR 合并前：
+
+1. 记录开发/Review/Test 的 verified HEAD；
+2. 检查 current main/target 是否已变化；
+3. 若变化，sync/rebase/merge；
+4. 判断哪些 Proof 因新 HEAD 失效；
+5. 重跑受影响 Review/Test；
+6. 再进入人工验收/merge。
+
+### 9.4 分析 Epic 禁止跳票实现
+
+- #77：#86 未毕业前，不做未经决策的全面实现；
+- #72：#94 未毕业前，不做未经决策的全面实现；
+- 后续新 sized-L Issue 继续遵守 Wayfinder -> decisions -> OpenSpec -> requirements-analysis -> implementation tickets。
+
+### 9.5 DSH 验收不可被 generic 测试替代
+
+带 `dsh-cordis` 的任务即使 Codex/Cursor 完成纯代码部分，仍必须在 DSH 完成对应 Runtime/E2E 验收。
+
+### 9.6 产品模式才是发布证据
+
+开发模式、External Profile、单元测试、模拟 Runtime 都不能替代 #53 产品模式最终 E2E。
+
+---
+
+## 10. 建设工作流 Dogfood 后的默认派单规则
+
+当 #104/#105 达到可用状态：
+
+1. `generic-agent` Issue：默认 External Construction Profile；
+   - Schema/compiler/runtime-core 倾向 Codex；
+   - Role/Template/文档/UI 倾向 Cursor。
+2. `dsh-cordis` Issue：默认 DSH Construction Profile；
+3. 两标签 Issue：
+   - External Profile 完成可脱离 DSH 的 Core；
+   - DSH Profile 完成 integration/E2E；
+   - 两个 Run 独立 worktree，通过 Integration Checkpoint 合流。
+4. sized-L / needs-info：仍先分析，不因为有建设工作流就跳过产品决策。
+
+---
+
+## 11. 当前推荐三条队列
+
+### Codex Queue
+
+```text
+#77/#88
+ -> #87
+ -> #89
+ -> #90/#91/#92
+ -> #86 graduation
+ -> #77 implementation tickets
+ -> #73 (External dogfood)
+ -> #78
+ -> #93 core
+ -> #82 behavior/compat regression
+```
+
+### DSH Queue
+
+```text
+#72/#95
+ -> #96/#97/#98/#99/#100/#101
+ -> #94 graduation
+ -> #105 Bootstrap
+ -> #53 Dogfood
+ -> #72 implementation/runtime
+ -> #93 DSH integration
+ -> #79
+ -> #80
+ -> #74
+ -> #83
+ -> #75 DSH integration
+ -> #53 final release E2E
+```
+
+### Cursor Queue
+
+```text
+#103 Portable Contract
+ -> #104 External Profile
+ -> #81 (Cursor dogfood)
+ -> #69 after #78
+ -> #82 construction asset
+ -> #82 exploration asset (reuse #70 selectively)
+ -> #75 Client/UI
+```
+
+注意：队列是依赖顺序，不要求等待整条前序全部结束；只要某个具体 Blocker 已解除即可领取下一项。
+
+---
+
+## 12. 需要动态重排的触发条件
+
+出现以下情况必须更新 #76 或本计划：
+
+- #77/#72 决策改变 #73/#78/#79 的边界；
+- #93 发现 DSH Runtime 无法支持当前 Workspace Provider 契约；
+- #104/#105 Dogfood 证明 Portable Contract 有结构缺陷；
+- #82 需要拆成更多模板/迁移子票；
+- #75 确认某 UI 能力是 v0.1 必需发布门槛而非 v0.2；
+- v0.1 明确宣布支持 Minke，使 #35 进入主线；
+- 某 Agent 的 PR 与另一条主线发生高频文件冲突，需要重新划文件 ownership。
+
+任何重排必须保留：一个产品语义、一套主 Runtime、独立 worktree、Proof 绑定版本、DSH 产品模式最终验收。

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,7 +1,7 @@
 # Workflow Manager Roadmap
 
-> 状态：2026-08-30 统一审查后重排  
-> 当前主目标：把早期可运行的 VWF/DSH 工作流原型收敛为正式、可扩展、可审计的 Workflow Manager v0.1 产品底座。
+> 状态：2026-08-30 并行开发计划同步版  
+> 当前主目标：先建立可 Dogfood 的“建设 · 完整功能开发”双执行 Profile，再用 DSH / Cursor / Codex 并行完成 Workflow Manager v0.1 正式底座。
 
 ## 1. 北极星
 
@@ -12,11 +12,12 @@ Workflow Manager 面向复杂软件研发与通用知识工作，目标不是“
 - 可干预：Human Decision、Pause、Interrupt、Guidance；
 - 可恢复：BLOCKED、Snapshot Revision、Resume；
 - 可追溯：Formal Record、Revision、Provenance、证据有效性；
+- 可隔离：Logical Run 拥有独立 Workspace / Resource / Integration 上下文；
 - 可扩展：Built-in 给出正式标准，Custom Workflow/Role 保留开放能力。
 
-DSH 是首个运行环境；Codex、Claude Code 等 Coding Agent 属于后续执行器扩展，不反向定义工作流产品模型。
+DSH 是首个正式运行环境。v0.1 同时提供 Codex/Cursor 的**项目 Dogfood External Profile**，使非 DSH Agent 能执行同一建设工作流；这不等于提前交付 v0.4 的通用多执行器产品能力。
 
-## 2. 两条基线必须分开
+## 2. 三条基线必须分开
 
 ### 2.1 当前 main 已实现基线
 
@@ -26,23 +27,25 @@ DSH 是首个运行环境；Codex、Claude Code 等 Coding Agent 属于后续执
 - 可视化模板库、画布编辑器和配置面板；
 - Built-in / Custom Role Library 基础能力（#58 / PR #61）；
 - 受限 Fan-out 与聚合（#18 / PR #38）；
+- Git worktree 工作隔离、验证分支/HEAD 留痕（#14/#23/#27）；
 - 多 run 并行、同 taskId 互斥和人工门禁排队（#19 / PR #41、#44）；
 - legacy engine-run 运行记录跨进程持久化（#40 / PR #50）；
-- 开发/产品双轨规则已经进入 `AGENTS.md`，实施入口仍由 #53 完成；
-- 当前 Skill / Chat 是正式执行入口。
+- 开发/产品双轨长期规则；
+- 当前 Skill / Chat 正式执行入口。
 
 这些能力仍运行在早期契约上：`success/failure` 二态路由、旧 run 状态字符串、旧 Built-in 模板/角色集合等。
 
-### 2.2 v0.1 目标规格
+### 2.2 v0.1 正式产品目标
 
 权威目标规格：`docs/design/workflow-manager-v0.1-final-product-spec.md`。
 
-v0.1 将正式收敛为：
+v0.1 正式收敛为：
 
 - 四套 Built-in Workflow：建设 / 优化 / 诊断 / 探索；
 - 12 个 Built-in Role；
 - Business Outcome Routing + Completion Mapping；
 - Formal Records / Revision / Provenance；
+- Workspace / Resource / Integration Isolation；
 - Logical Run / Execution Segment / 固定 Lifecycle；
 - Run Snapshot Revision（v0.1 运行中只允许 Provider / Model）；
 - Human Decision；
@@ -51,47 +54,93 @@ v0.1 将正式收敛为：
 - Static Validation + Preflight Probe；
 - Skill/Chat/未来插件入口共享同一 Logical Run Runtime。
 
-目标规格不是“main 已完成能力清单”。任何施工都必须同时核对实际代码与目标规格。
+### 2.3 v0.1 Dogfood Bootstrap
+
+为了让项目本身尽早使用新“建设”工作流开发后续 Issue，#102–#105 允许在完整 Runtime 尚未完成时先交付：
+
+```text
+#103 Construction Portable Contract
+          |
+     +----+----+
+     |         |
+     v         v
+#104 External  #105 DSH-native
+Codex/Cursor   Bootstrap
+```
+
+约束：
+
+- 只有一份建设业务语义；
+- Bootstrap 缺失能力必须显式 shim/manual handoff；
+- worktree/branch/verified HEAD 从第一天就必须执行；
+- #105 随正式 Runtime 落地删除 shim，最终成为 #82 的建设 Built-in；
+- #104 是 repo-local Dogfood Runbook，不是 v0.4 Executor SDK。
+
+详细调度：`docs/design/v0.1-parallel-development-plan.md`。
 
 ## 3. v0.1 — Formal Workflow Foundation
 
-v0.1 是当前最高优先级。实施总览：#76。
+实施总览：#76。
+
+### Bootstrap — 建设工作流先行
+
+- #102：建设双执行 Profile 总 Epic；
+- #103：Portable Contract，Cursor 优先；
+- #104：Codex/Cursor External Profile，Cursor 主责；
+- #105：DSH-native Bootstrap / Formal Convergence，DSH 主责。
+
+Dogfood 首批候选：Cursor→#81、Codex→#73、DSH→#53。
 
 ### Phase A — Blueprint、结果与证明契约
 
-目标：先让框架能正确表达业务语义，再迁移模板。
-
-- #71：全局工作流设计原则；
-- #77：Business Outcome Routing + Completion Mapping；
-- #72：Human Decision；
+- #71：全局工作流设计原则——已完成（PR #85）；
+- #77：Business Outcome Routing + Completion Mapping；分析树 #86–#92；
+- #72：Human Decision；分析树 #94–#101；
 - #73：自动回退额度 / `countRound`；
 - #78：Formal Records / Revision / Provenance；
 - #69：多格式正式 Artifact，在 #78 模型上接入。
+
+当前约束：#77 的 #86、#72 的 #94 未毕业前，不跳过决策直接做全面实现。
 
 阶段出口：
 
 - 合法业务结果不再伪装成 failure；
 - Node Result 不携带 `next_node`；
 - Proof 能绑定具体 Record Revision；
-- Human Decision 与人工验收解耦；
+- Human Decision 与人工验收在业务身份上解耦，但共享受控等待/恢复能力按最终决策实现；
 - 回退额度由业务路径显式声明。
 
-### Phase B — Logical Run Runtime
+### Phase B — Workspace + Logical Run Runtime
 
-目标：用户看到的是一个完整、可恢复的 Run，而不是多次 engine start。
+顺序核心：
 
-- #79：Logical Run / Execution Segment / Lifecycle / Snapshot Revision；
+```text
+#78 Provenance
+   ↓
+#93 Workspace / Resource / Integration Isolation
+   ↓
+#79 Logical Run / Lifecycle / Snapshot
+   ↓
+#80 Guidance / Resume
+#74 Preflight
+```
+
+任务：
+
+- #93：Workspace Provider/Mode、worktree/sandbox、worker scratch、资源隔离/锁、Integration Checkpoint、cleanup；
+- #79：Logical Run / Execution Segment / Lifecycle / Snapshot Revision；**Blocked by #93 稳定数据契约**；
 - #80：Pause / Interrupt / Run Guidance / Resume；
 - #74：Preflight Probe；
-- #40 已完成的持久化层作为实现基础，由 #79 升级为 Logical Run 持久化；
-- #53：开发模式 / 产品模式双轨入口和正式发布闸门。
+- #40 已完成 persistence 作为 #79 的演进基础，不重新打开；
+- #53：开发模式 / 产品模式双轨入口和最终发布闸门。
 
 阶段出口：
 
+- 多个 Logical Run 同仓并行时状态、配置、文件、运行资源、最终集成互不静默干扰；
 - 一个 Logical Run 可跨人工等待、暂停、阻塞、模型切换继续；
 - Provider / Model 修改生成 Snapshot Revision，仅影响当前 Run；
 - READY / RUNNING / WAITING_HUMAN / PAUSED / BLOCKED / COMPLETED / STOPPED / FAILED 语义稳定；
-- 运行前能够验证 Provider / Model 当前实际可用。
+- Preflight 能真实验证当前 Provider / Model。
 
 ### Phase C — 正式 Built-in 资产与 Invocation
 
@@ -106,142 +155,153 @@ v0.1 是当前最高优先级。实施总览：#76。
 3. 诊断：缺陷诊断 → 修复 → 审核 → 回归验证 → 收口；
 4. 探索：探索统筹 → 专家研究 Fan-out → 综合分析 → 结论评估。
 
-探索轮次已锁定：**总研究轮次最多 3 轮，包含首次 BROAD；自动 TARGETED 补充最多 2 轮。** 若使用 #73 的回退额度映射，则最多允许 2 次 `NEEDS_RESEARCH -> orchestrate` 自动回退。
+建设模板第一优先，必须消费 #102/#103/#105，不从零重新实现。
+
+Workspace 默认：
+
+- 建设：`ISOLATED_WRITE`；
+- 优化：Git/file 修改 `ISOLATED_WRITE`，非 Git `SANDBOX`；
+- 诊断：从诊断开始 `ISOLATED_WRITE`；
+- 探索：`ISOLATED_READ` + shared frozen source + per-worker scratch。
+
+探索总研究轮次最多 3 轮（含首次 BROAD）；最多 2 次自动 `NEEDS_RESEARCH -> orchestrate`。
 
 历史 `default-workflow` / `dev-workflow-2-0` 迁为 Custom Workflow；`dispatcher` 迁为 Custom Role。
 
-Draft PR #70 已关闭且未合并；`feat/multi-perspective-exploration` 仅作为 #81/#82 的实现素材，不得整包合入 main。
+Draft PR #70 已关闭且未合并；仅作为 #81/#82 探索素材，不得 reopen/rebase 或整包 cherry-pick。
 
 ### Phase D — 产品呈现与 UI
 
 - #75 负责正式信息架构和交互定稿；
-- 当前模板库 + 画布编辑器可复用，但需要适配 Outcome、Completion、Snapshot、Human Decision、Logical Run Timeline、Guidance 和成果/证据视图；
-- 当前 Skill / Chat 入口不因 UI 重构被废弃；未来插件“使用/运行”只能作为同一 Runtime 的 Invocation Adapter。
+- 模板库 + 画布编辑器复用，但适配 Outcome、Completion、Snapshot、Workspace、Human Decision、Logical Run Timeline、Guidance、成果/证据；
+- 当前 Skill / Chat 入口不因 UI 重构被废弃；
+- 插件未来入口只能进入同一 Invocation/Runtime。
 
-v0.1 是否要求完整 UI 重构进入首发，由 #75 拆分后按“发布必需 / 可后置”划界；底层契约不能等待 UI 决策才实施。
+v0.1 是否包含完整 UI 重构，由 #75 拆分为“发布必需 / 可后置”；底层契约不等待 UI 才施工。
 
-## 4. v0.1 发布门槛
+## 4. DSH / Cursor / Codex 当前并行策略
 
-只有以下条件同时满足，四套正式模板才可作为 Built-in 发布：
+具体每个 Issue 排班见 `docs/design/v0.1-parallel-development-plan.md`。当前最高层队列：
 
-1. #77/#72/#73/#78 的契约和兼容迁移完成；
-2. Logical Run、Snapshot Revision、持久化、Human Decision、Pause/Resume、Preflight 可真实工作；
-3. 12 Roles 与四模板符合最终规格；
-4. 旧 Built-in 资产安全迁为 Custom，不丢用户引用和历史；
-5. Skill/Chat 能创建、恢复同一个 Logical Run；
-6. `npm run validate`、相关包测试和回归测试全绿；
-7. 开发模式验证不能作为发布证据；必须按 #53 切产品模式、重启 DSH、完成真实 E2E；
-8. 四模板关键正常/回退/人工/不足路径均有 E2E 证据；
-9. 产品文档、Roadmap、CONTEXT/历史文档的当前/目标边界清晰。
+```text
+Codex  : #77/#86-#92 -> #77 implementation -> #73 -> #78 -> #93 core
+DSH    : #72/#94-#101 -> #105 -> #53 dogfood -> #72 runtime -> #93 integration -> #79 -> #80 -> #74 -> #83
+Cursor : #103 -> #104 -> #81 dogfood -> #69 -> #82 construction/assets -> #75 UI
+```
 
-## 5. v0.2 — Product Interaction & Governance
+活动 Issue 标签：
 
-在 v0.1 Runtime/资产模型稳定后，集中完成用户体验和治理能力，而不是继续扩大底层状态机。
+- `generic-agent`：优先 Codex/Cursor；
+- `dsh-cordis`：优先 DSH；
+- 两者都有：External core + DSH integration/E2E，使用独立 Run/worktree 合流。
 
-候选主题：
+同一 Issue 同一时刻只有一个主责 Agent。
+
+## 5. v0.1 发布门槛
+
+四套正式模板作为 Built-in 发布前至少满足：
+
+1. #77/#72/#73/#78 契约和兼容迁移完成；
+2. #93 Workspace/Resource/Integration Isolation 完成；
+3. #79/#80/#74 Runtime 可真实工作；
+4. 12 Roles 与四模板符合最终规格；
+5. 建设 Bootstrap 已收敛，不存在 DSH/External 两份业务语义；
+6. 旧 Built-in 资产安全迁为 Custom，不丢用户引用和历史；
+7. Skill/Chat 能创建、恢复同一个 Logical Run；
+8. `npm run validate`、包测试、行为/迁移/并行回归全绿；
+9. 开发模式/External Dogfood 不能作为发布证据；必须按 #53 切产品模式、重启 DSH、真实 E2E；
+10. 四模板关键正常/回退/人工/不足路径有 E2E；
+11. 多 Run 同仓并行、Integration Checkpoint、Proof 版本绑定有 E2E；
+12. Current/Target 文档边界清晰。
+
+## 6. v0.2 — Product Interaction & Governance
+
+在 v0.1 Runtime/资产稳定后，集中完善：
 
 - #75 拆出的模板库、编辑器、Run Dashboard / Timeline / 成果与证据 UI；
-- Context Pointer：节点按需引用需求、设计、规则、Skill 和历史 Record；
+- Context Pointer；
 - Responsibility / Permission / Evidence Contract；
-- S / M / L 任务准入与风险分级；
-- 多格式 Artifact 的更完整可视化和人工决策呈现；
-- Provider/Model 推荐替代方案，但仍不默认静默 Failover。
+- S / M / L 准入与风险分级；
+- 多格式 Artifact 可视化；
+- Provider/Model 推荐替代方案，但不静默 Failover。
 
-## 6. v0.3 — 同一需求的多角色并行协作
+## 7. v0.3 — 同一需求多角色并行协作
 
-在 Fan-out“同类子任务并行”之外，支持同一需求里的不同责任轨并行：
+在 Fan-out 同类子任务并行之外，支持：
 
 - 开发轨 / 测试轨 / Review 轨；
-- 明确的交接版本和 Gate；
+- 明确交接版本和 Gate；
 - 主控同步点；
-- 失败只回到真正根因来源；
-- 证据链仍通过 Formal Records 管理。
+- 失败返回真正根因来源；
+- 证据链由 Formal Records 管理。
 
-重点是职责协作，不是单纯提高并发数。
+## 8. v0.4 — 产品化多 Coding Agent 执行器
 
-## 7. v0.4 — 多 Coding Agent 执行器
+v0.1 #104 只解决本仓库 Dogfood。v0.4 再正式产品化 Codex/Claude Code/其他执行器：
 
-在 Workflow/Role/Run 契约稳定后，再把执行器从 DSH 扩展到 Codex、Claude Code 等：
-
-- Workflow 语义不为单一执行器复制；
+- Workflow 语义不为执行器复制；
 - Adapter 负责执行器差异；
-- 权限、上下文、证据和生命周期由 Workflow Manager 保持统一；
-- 新执行器必须通过同一行为/契约回归。
+- 权限、上下文、证据、生命周期统一；
+- 新执行器通过同一契约回归。
 
-## 8. v0.5+ — 专业 Profile、动态规划与生态
+## 9. v0.5+ — 专业 Profile、动态规划与生态
 
-候选：
+候选：专业领域 Role Packs、更强动态规划、跨项目/跨仓库、ACP/其他协议、独立分发和模板生态。
 
-- 专业领域 Profile / Role Packs；
-- 更强的动态规划与任务分解；
-- 跨项目/跨仓库协作；
-- ACP 或其他协议适配；
-- 独立分发、注册表、模板生态。
+## 10. 独立分发：明确后置
 
-## 9. 独立分发：明确后置
+#21 / #45–#48 全部 Deferred。必须等 #76 正式体系稳定后重新基于届时 main 取证，不使用 2026-08-23 的旧打包/目录假设施工。
 
-早期 P2 Epic #6 已关闭为 superseded。
+## 11. 外部兼容性
 
-以下 Issue 保留，但不属于当前 v0.1 frontier：
+#35 独立跟踪 Minke / DSH 兼容。若 v0.1 明确支持 Minke，则进入发布门槛；否则不阻塞 #76。
 
-- #21：独立仓库 + GitHub 分发；
-- #45：包自包含边界；
-- #46：构建产物策略；
-- #47：独立分发下的仓库根解析；
-- #48：仓库归属 / monorepo 去留。
+## 12. 历史能力如何看待
 
-它们必须在 #76 正式体系稳定后重新基于届时 main 取证；不得直接使用 2026-08-23 的目录与打包假设施工。
+已完成 Issue/PR 是当前实现基线和回归资产：
 
-## 10. 外部兼容性
+- #14 worktree、#19 multi-run、#23/#27 verified HEAD 必须进入 #93/#78 回归；
+- #18 Fan-out、#40 persistence、#58 Role Library 在原能力上演进；
+- `success/failure`、`AWAITING_HUMAN_*`、`FAILED_MAX_ROUNDS` 属兼容层；
+- #3/#6/#64–#68 是 Historical/Superseded，不再作为施工入口。
 
-#35 是 Minke / DSH 版本兼容跟踪项，独立于正式 Workflow Runtime 设计。
-
-- 若正式发布声明支持 Minke，则未解决的宿主兼容问题进入发布门槛；
-- 若 v0.1 首发以原生 DSH 为支持宿主，则 #35 不阻塞 #76。
-
-## 11. 已完成能力如何看待
-
-历史已完成 Issue/PR 是“当前实现基线和回归资产”，不因为产品体系升级而删除历史：
-
-- 工作区隔离、分支/HEAD 验证等可靠性能力继续保留；
-- fanOut、多 run、持久化继续作为底层能力演进；
-- 旧 `success/failure`、`AWAITING_HUMAN_*`、`FAILED_MAX_ROUNDS` 等属于兼容层，不再作为新设计目标；
-- 旧 Built-in Workflow/Role 保留为迁移对象，不继续定义正式标准。
-
-## 12. 版本开发与发布节奏
+## 13. 版本开发与发布节奏
 
 长期遵循 `AGENTS.md`：
 
 ```text
 版本内开发
-→ 开发模式快速迭代
+→ 开发模式 / External Profile 快速迭代
 → 契约/测试/人工验收
 → 准备发布
-→ 切产品模式
+→ 切 DSH 产品模式
 → 重建正式产物
 → 完整重启 DSH
 → 真实 E2E
 → PR / Review / Merge / Tag / Release
 ```
 
-产品模式验收失败必须回开发模式修复，再重新进行完整产品模式验收。
+产品模式验收失败必须回开发模式修复，再重新执行完整产品模式验收。
 
-## 13. 当前优先级
+## 14. 当前优先级
 
 ```text
-P0  #71/#77/#72/#73/#78   Blueprint + 结果/证据契约
+P0  #103 -> #104/#105        建设工作流先 Dogfood
+ ||
+P0  #77/#86-#92             Outcome 决策/实现
+P0  #72/#94-#101            Human Decision 决策/实现
  ↓
-P0  #79/#80/#74/#53       Logical Run + Snapshot + 可恢复运行
+P0  #73/#78/#69             rollback + Records/Artifact
  ↓
-P0  #81/#82/#83           12 Roles + 四模板 + Skill Invocation
+P0  #93 -> #79              Workspace -> Logical Run
  ↓
-P1  #75                    正式 UI/交互实施拆分
+P0  #80/#74/#53             可恢复运行 + Probe + 发布闸门
  ↓
-P2  Context / Responsibility / 多角色协作
+P0  #81/#82/#83             Roles + 四模板 + Invocation
  ↓
-P3  多执行器
+P1  #75                     UI/交互
  ↓
-Later #21/#45-#48          独立分发
+Later #21/#45-#48           独立分发
 ```
 
-任何新 Issue 如果改变上述依赖，必须先更新本 Roadmap 或 #76，避免并行 Agent 按不同版本规划施工。
+任何新 Issue 如果改变上述依赖，必须先更新本 Roadmap、#76 或 `v0.1-parallel-development-plan.md`，避免并行 Agent 按不同版本规划施工。


### PR DESCRIPTION
## 目标

落实 #106，把本轮全量 Issue 审计、建设工作流双执行 Profile 和 DSH/Cursor/Codex 并行排班正式落库。

## 变更

1. 新增 `docs/design/v0.1-parallel-development-plan.md`
   - 建设工作流 #102–#105 Dogfood Bootstrap；
   - #77/#86–#92 与 #72/#94–#101 当前分析树；
   - #93 -> #79 Workspace/Logical Run 依赖；
   - Wave 0–6 三 Agent 排班；
   - 活动 Issue 逐项主责/前置条件；
   - 历史/Completed/Superseded/Deferred/External Watch 全仓审计；
   - 一 Issue / 一 Run / 一 Worktree、Integration Checkpoint 等并行硬规则；
   - #107–#110 明确为误操作 no-op，不得引用。
2. 更新 `roadmap.md`
   - 增加 v0.1 Dogfood Bootstrap 基线；
   - 增加 #93 Workspace/Resource/Integration Isolation；
   - 明确 #79 Blocked by #93；
   - 把 DSH/Cursor/Codex 当前队列写入 Roadmap；
   - 明确 #104 是 repo-local Dogfood，不提前替代 v0.4 产品化多执行器。

## 当前调度

- Codex：继续 #77/#86–#92，不重复分析；
- DSH：继续 #72/#94–#101，不重复分析；
- Cursor：#103 -> #104，优先建立可 Dogfood 的建设 External Profile；
- #105 在 #103 后由 DSH 实施；
- 后续 Dogfood 首批候选：Cursor→#81、Codex→#73、DSH→#53。

## Related

#76 #82 #93 #102 #103 #104 #105 #106