### PR TITLE
docs(construction): 落地建设主链 Stage 语义与回退/路由原则 (#112)

### DIFF
--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,6 +1,6 @@
 # 建设 · 完整功能开发 Portable Contract
 
-> **版本**：**v0.1（内容冻结 2026-08-30；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；冻结与修订规则见 §9.3；Run 级人工验收随 PR #115 进行）**
+> **版本**：**v0.1.1（2026-08-30 冻结，同日按 PR #115 Codex Review 修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
 > **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
 > **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
 > **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
@@ -114,10 +114,10 @@ requirements -> design -> dev -> review -> test -> human acceptance -> closeout
 
 - **目的**：只整理、冻结、交付；不重新开发、测试或审查。
 - **输入**：通过的 acceptance proof + 本 Run 全部记录。
-- **专业输出**：closeout summary——交付清单、冻结记录、PR/merge 结果、遗留事项。
-- **Proof**：closeout summary + 最终集成结果（PR 编号/merge commit）。
+- **专业输出**：closeout summary——交付清单、冻结记录、**验收决议（`accept` / `user_accepted`，必须保留）**、遗留事项。
+- **Proof**：closeout summary + 最终集成结果（PR 编号 / merge commit 至少其一）。
 - **回退根因**：**无回退出口**。若发现交付物与 Proof 不符，属完整性违约，升级人工处理，不作为回退。
-- **完成判定**：交付完成，Run 归档（记录保留要求见 §7/§8）。
+- **完成判定**：交付完成，Run 归档（记录保留要求见 §7/§8）。`user_accepted` 是合法交付决议：Completion 权威事实以 closeout 保留的验收决议为准，不得把「知情接受的异常交付」洗成普通交付（对齐 #72 与 v0.1 规格 Completion Type）。
 
 ## 4. 回退与升级语义
 
@@ -129,7 +129,7 @@ requirements -> design -> dev -> review -> test -> human acceptance -> closeout
 | 设计问题 | Design（§3.2） | review/test 发现方案不可行、接口不成立 |
 | 实现问题 | Dev（§3.3） | review request-changes、test 失败的常规缺陷 |
 
-判定纪律：**产生 findings 的 Role 必须给出根因分类**（这是专业结果的一部分）；Controller 按分类路由，不重估专业判断。同一 findings 内允许多根因并存，Controller 拆分路由，分别消耗额度（见 4.2 的声明规则）。
+判定纪律：**产生 findings 的 Role 必须给出根因分类**（这是专业结果的一部分）；Controller 按分类路由，不重估专业判断。同一 findings 允许多根因并存，但**一次回退只执行一条回退边、消耗 1 点额度**：Controller 按根因优先级选择本次回退目标（requirements > design > dev，先修上游）；其余 findings 原样保留在记录中，由回退重做后的下一轮 review/test 复验（边级计数语义对齐 #73 与设计原则 11 的 `countRound`）。
 
 ### 4.2 自动回退额度
 
@@ -219,9 +219,11 @@ requirements -> design -> dev -> review -> test -> human acceptance -> closeout
 | human acceptance | （人工）accept / reject / user-accepted |
 | closeout | delivered |
 
+两类易混结果在此明确：`blocked` 基元仅用于**可恢复的外部/技术条件**（环境不可用、Provider 额度、鉴权失效等），不是业务失败；业务性受阻必须以 `decision-required` 或根因报告表达。节点的业务 `blocked` 结果不等于 Run Lifecycle 的 `BLOCKED` 状态（对齐 workflow-design-principles §3.2/§3.3）。closeout 的 `delivered` 必须携带验收决议（`accept` / `user_accepted`），它是 Completion 的权威事实来源（§3.7）。
+
 ### 6.4 路由动作基元
 
-Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, <root-cause>)`（回退，受额度约束）/ `await-human(<reason>)`（挂起）/ `escalate`（升级）。额度耗尽时 `rollback` 不可用，唯一出路是 `await-human(MAX_ROUNDS_REACHED)`。
+Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, <root-cause>)`（回退，受额度约束，一次一条边）/ `await-human(<reason>)`（挂起等人工决策）/ `hold(<reason>)`（Run 进入 `BLOCKED`：可恢复外部/技术条件，不消耗额度，条件恢复后重入同一 Stage）/ `escalate`（升级）。`blocked` 专业结果路由到 `hold`；额度耗尽时 `rollback` 不可用，唯一出路是 `await-human(MAX_ROUNDS_REACHED)`。
 
 ### 6.5 悬空禁止
 
@@ -300,7 +302,7 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 | 字段 | 语义 |
 |---|---|
 | `record_type` | 七者之一 |
-| `record_version` | 记录 schema 版本（当前 v0.1） |
+| `record_version` | 记录 schema 版本（当前 v0.1.1） |
 | `created_at` | ISO 8601 时间 |
 | `produced_by` | 产生者 Role/会话标识 |
 | `run` | §7.1 portable run identity 全量内嵌 |
@@ -311,12 +313,12 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 
 必选/可选字段以 §8.4 schema 为准；语义要点：
 
-- **requirements_baseline**：三要素 + `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 人工确认（`BASELINE_CONFIRMED` 后回填）；
+- **requirements_baseline**：三要素 + `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录；`draft` 不得作为下游冻结输入）；
 - **design_package**：summary + `decision_required` 标记与判据命中说明（§5.2）+（触发时）Decision Record；
 - **dev_handoff**：改动摘要 + 自验清单；
-- **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head`；review 另需 `independent_session=true`（不变量 2）；
-- **acceptance_package**：`assembled`（引用 review/test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，决策枚举 `accept`/`reject`/`user_accepted`，AI 不得代签）；
-- **closeout_summary**：交付清单 + 集成结果 + `records_retained=true`。
+- **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；`request_changes` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；
+- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）；
+- **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_outcome`（保留 `user_accepted` 异常到收口）** + `records_retained=true`。
 
 ### 8.4 Schema、示例与机械校验
 
@@ -340,7 +342,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 
 | 关联 issue | 方向要点 | 契约对齐位置 | 差异说明 |
 |---|---|---|---|
-| #71 全局《工作流设计原则》 | 建立通用设计原则与方法论文档（尚未落地） | §0/§2 遵循同一决断源（#102 A1–A5） | 无冲突：层不同——#71 是通用原则，本契约是建设业务语义；#71 落地后本契约引用之，不重复定义通用原则 |
+| #71 全局《工作流设计原则》 | 已落地：`docs/design/workflow-design-principles.md`（原则 10 人工验收业务阶段、原则 11 自动回退额度、Run Lifecycle、Node Outcome / Completion Type） | §3.6/§3.7（原则 10）；§4.2/§4.3（原则 11 同义）；§6.3/§6.4（Lifecycle `BLOCKED` 与节点业务 `blocked` 的区分、Completion 权威事实）；§8 | 无冲突：本契约是该原则在「建设」模板上的业务实例化；通用措辞以原则文档为权威，实现字段以各 Runtime issue 为权威 |
 | #77 Business Outcome Routing | 技术执行与业务结果分离；Producer/Router 分离；禁止 `next_node`；Node Result 权威；额度耗尽保留原 Outcome | §6 全节；§4.3 耗尽行为（`WAITING_HUMAN + MAX_ROUNDS_REACHED`） | 兼容 shim 而非分叉：Bootstrap 期 Controller 使用 §6.3/§6.4 基元枚举驱动；#77 落地后按 §6.6 映射为正式 field path + route + `countRound`，字段名以 #77 为权威 |
 | #72 受控人工决策 | Decision（方向取舍）与验收（是否通过）解耦；默认自动推进；决策包要素；Decision Record 不可覆盖；`BASELINE_UPDATED` 回基线；`USER_ACCEPTED` 不改写 baseline | §5 全节；§3.1 固定门；§3.2 条件门；§3.6 `USER_ACCEPTED` | 无冲突：本契约把 #72 框架能力实例化到建设主链固定位置（requirements 确认门 + design 条件门），不设独立 Decision 业务节点，符合「Decision 是框架能力」原则 |
 | #73 自动回退额度 | 额度统一解释为自动回退额度；路径显式声明是否消耗；初次执行/内部 REVISE/WAITING_HUMAN/技术重试不计；人工触发显式记录；额度只限制自动路由 | §4.2 计数原则；§4.3 耗尽行为 | 无冲突：契约默认额度 3 来自 #102 决断；`countRound` 等字段名由 #73 实现定，契约只保留产品语义 |
@@ -371,6 +373,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 | 版本 | 日期 | 变更 | 关联 |
 |---|---|---|---|
 | v0.1 | 2026-08-30 | 初版冻结：主链语义、Run/Workspace、七类交接包、一致性矩阵 | #112 #113 #114 |
+| v0.1.1 | 2026-08-30 | Codex Review 修复：`blocked` 路由（`hold` → Run `BLOCKED`）、`USER_ACCEPTED` 保留到 closeout、多根因单边回退计数、schema 九处条件收紧、示例链一致性修正 | PR #115 Review |
 
 ### 9.4 #103 九条验收清单证据映射
 

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,6 +1,6 @@
 # 建设 · 完整功能开发 Portable Contract
 
-> **版本**：**v0.1.6（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
+> **版本**：**v0.1.7（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
 > **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
 > **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
 > **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
@@ -302,7 +302,7 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 | 字段 | 语义 |
 |---|---|
 | `record_type` | 七者之一 |
-| `record_version` | 记录 schema 版本（当前 v0.1.5） |
+| `record_version` | 记录 schema 版本（以文档头版本行为准，见 §9.3） |
 | `created_at` | ISO 8601 时间 |
 | `produced_by` | 产生者 Role/会话标识 |
 | `run` | §7.1 portable run identity 全量内嵌 |
@@ -314,10 +314,10 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 必选/可选字段以 §8.4 schema 为准；语义要点：
 
 - **requirements_baseline**：三要素 + **整体 `outcome`**（`baseline_ready` / `awaiting_human_input` / `revised`，§6.3 基元）+ `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录，且**无残留 gaps、验收标准非空、goal/scope 非空**；`draft` 不得作为下游冻结输入）；`outcome=awaiting_human_input` 必须带非空 `gaps`，`outcome=baseline_ready` 必须无残留 gaps；
-- **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；门状态机两态：**命中条件门且未决 ⇒ `outcome=decision_required`**（schema 双向约束）且必须附非空 `decision_required_reasons`（§5.2），Controller 必须挂起不得放行；**人工决策记录后 ⇒ 翻转为 `package_ready`**，Decision Record 作为过门证据保留在该 package 上（schema 仅允许 Decision Record 出现在命中条件门的 package 上；`options` 至少一个候选且 `chosen` 必须属于候选集——Controller 按 §5.3 校验）；`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
+- **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；门状态机两态：**命中条件门且未决 ⇒ `outcome=decision_required`**（schema 双向约束）且必须附非空 `decision_required_reasons`（§5.2）与 **`decision_request` 待决包**（question / options≥1 / recommendation，§5.3），Controller 挂起呈递该包；**人工决策记录后 ⇒ 翻转为 `package_ready`**，`decision` 与 `decision_request` 并存（裁决上下文 + 已决记录），Decision Record 仅允许出现在命中条件门的 package 上，且 `chosen` 必须属于 `options` 候选集（Controller 按 §5.3 校验）；`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **dev_handoff**：改动摘要 + **整体 `outcome`**（`handoff_ready` / `blocked` / `design_issue` / `requirements_issue`，§6.3 基元）+ 自验清单；`outcome=blocked` 必须附 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定）；`outcome=handoff_ready` 要求自验清单非空且无 fail/blocked 项（§3.3 完成判定）；`design_issue`/`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；条件约束：`request_changes`/`fail` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；`blocked` 必须带 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定，§6.4）；
-- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② 普通 `accept` 要求 review `verdict=approve` 且 test `verdict=pass`；**`user_accepted` 例外**——允许携带 fail/blocked 证据链知情接受，但必须附 `feedback` 说明接受的差异（§3.6 特殊语义，不得伪造测试证据）；③ 全部引用同 Run / 同 workspace lineage（标识字段非空才可比较）；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）；⑤ 引用 baseline `status=confirmed` 且无残留 gaps；⑥ 引用 design `outcome=package_ready`（命中过条件门的必须已带 Decision Record，且 `chosen` 属于其 `options` 候选集）；⑦ 引用 dev `outcome=handoff_ready`；⑧ test `acceptance_mapping` 与引用 baseline 的验收标准逐条**完整且无重复**对应（防漏测项；`user_accepted` 场景下该项为「完整映射 + 已知差异说明」）；⑨ 引用 review/test 的 `produced_by` 必须与引用 dev handoff 的 `produced_by` 不同（§2 不变量 2 的机器可校验形式，配合各自 `independent_session=true`）——任一不满足即不得呈递或签收；
+- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。`assembled.integration_checkpoint` 为结构化记录：`target_ref` / `target_head_at_check` / `target_advanced` / `proofs_state`（`target_advanced=true` ⇒ `proofs_state=rerun_completed`，§7.3 可机检）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② 普通 `accept` 要求 review `verdict=approve` 且 test `verdict=pass`；**`user_accepted` 例外**——允许携带 fail/blocked 证据链知情接受，但必须附 `feedback` 说明接受的差异（§3.6 特殊语义，不得伪造测试证据）；③ 全部引用同 Run / 同 workspace lineage（标识字段非空才可比较）；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）；⑤ 引用 baseline `status=confirmed` 且无残留 gaps；⑥ 引用 design `outcome=package_ready`（命中过条件门的必须已带 Decision Record，且 `chosen` 属于其 `options` 候选集）；⑦ 引用 dev `outcome=handoff_ready`；⑧ test `acceptance_mapping` 与引用 baseline 的验收标准逐条**完整且无重复**对应（防漏测项；`user_accepted` 场景下该项为「完整映射 + 已知差异说明」）；⑨ 引用 review/test 的 `produced_by` 必须与引用 dev handoff 的 `produced_by` 不同（§2 不变量 2 的机器可校验形式，配合各自 `independent_session=true`）——任一不满足即不得呈递或签收；
 - **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。Controller 归档前双重校验：① 引用包 `status=decided`；② 引用包 `decision` ∈ {`accept`, `user_accepted`} 且与 `acceptance_outcome` 一致——引用包 `decision=reject` 时**不得归档**，按 §3.6 打回根因路由。
 
 ### 8.4 Schema、示例与机械校验
@@ -379,6 +379,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 | v0.1.4 | 2026-08-30 | Codex Review 修复（六）：证据链校验扩展上游完成态（baseline confirmed / design package_ready / dev handoff_ready）与验收映射完整覆盖、acceptance `verified_head` 补非空（上轮尾逗号漏网）、Run identity 8 字段与签名/引用/集成标识类字段全面非空约束 | PR #115 Review |
 | v0.1.5 | 2026-08-30 | Codex Review 修复（七）：design 门状态机改两态——未决 ⇒ outcome=decision_required，已决 ⇒ 翻转 package_ready 并保留 Decision Record 作过门证据（消除已决 gated package 永久无法验收的死锁）；user_accepted 例外通道——允许 fail/blocked 证据链知情接受但必须附 feedback 说明差异（§3.6 路径可达，无需伪造证据） | PR #115 Review |
 | v0.1.6 | 2026-08-30 | Codex Review 修复（八）：acceptance 证据链第 ⑨ 项（review/test 的 produced_by 必须异于 dev 产生者）、feedback/ blocked_reason 非空白约束、decision options ≥1 且 name 非空、全部字符串列表项拒绝空白项、§9.3 冻结标记改为以文档头为单一事实源 | PR #115 Review |
+| v0.1.7 | 2026-08-30 | Codex Review 修复（九）：design 新增 `decision_request` 待决决策包（question/options/recommendation，§5.3），与已决 `decision` 分离并存——pending 门挂起时人工可见完整候选方案；`integration_checkpoint` 结构化（target_advanced ⇒ proofs_state=rerun_completed 可机检）；§8.2 record_version 行改为引用文档头单一事实源 | PR #115 Review |
 
 ### 9.4 #103 九条验收清单证据映射
 

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -307,23 +307,23 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 | `produced_by` | 产生者 Role/会话标识 |
 | `run` | §7.1 portable run identity 全量内嵌 |
 
-信封保证每份记录自带 run/workspace/source HEAD 关联（#103 要求）。
+信封保证每份记录自带 run/workspace/source HEAD 关联（#103 要求）；`record_type` 与 `run.stage` 必须按 §8.1 的映射一一对应（如 `review_proof` 记录的 `run.stage` 必须为 `review`）。
 
 ### 8.3 payload 要素
 
 必选/可选字段以 §8.4 schema 为准；语义要点：
 
 - **requirements_baseline**：三要素 + `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录；`draft` 不得作为下游冻结输入）；
-- **design_package**：summary + `decision_required` 标记与判据命中说明（§5.2）+（触发时）Decision Record；
+- **design_package**：summary + `decision_required` 标记；`decision_required=true` 必须附非空 `decision_required_reasons`（§5.2）；Decision Record 只能出现在命中条件门的 package 上，Controller 在 `decision_required=true` 且无 Decision Record 时必须挂起（§5.2），不得放行；
 - **dev_handoff**：改动摘要 + 自验清单；
-- **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；`request_changes` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；
+- **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；条件约束：`request_changes`/`fail` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；`blocked` 必须带 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定，§6.4）；
 - **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）；
-- **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_outcome`（保留 `user_accepted` 异常到收口）** + `records_retained=true`。
+- **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包，Controller 归档前校验）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。
 
 ### 8.4 Schema、示例与机械校验
 
 - Schema：`docs/design/construction-workflow/handoff.schema.json`（JSON Schema draft-07）
-- 示例：`docs/design/construction-workflow/examples/01…07-*.json`（七类各一；取材于本契约开发 Run 的真实场景，其中 review/test/acceptance/closeout 为 **schema 演示值**，不代表本 Run 已发生对应的独立审核、测试或人工签收记录）
+- 示例：`docs/design/construction-workflow/examples/01…07-*.json`（七类各一；取材于本契约开发 Run 的真实场景，其中 review/test/acceptance/closeout 为 **schema 演示值**，不代表本 Run 已发生对应的独立审核、测试或人工签收记录）。示例链统一绑定到 **v0.1.1 内容完成点 HEAD（`c8d8625`）**：patch 级修订不前移示例链的 HEAD 绑定，仅 major/minor 语义变更时重新生成示例链
 - 机械校验（可执行验证）：
 
 ```bash

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -239,11 +239,100 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 
 ## 7. Portable Run / Workspace Contract
 
-> **由 #113 填充**：portable run identity 最小字段集、ISOLATED_WRITE workspace 规则、worktree/branch/HEAD 约束、Integration Checkpoint、与 #93/#79 的映射兼容声明。
+### 7.1 Portable Run Identity（最小字段集）
+
+每个 Run 自始至终携带以下最小身份字段（与 #103 列举一致）；七类交接记录的信封全量内嵌它（§8.2）：
+
+| 字段 | 语义 |
+|---|---|
+| `run_id` | 本 Run 的稳定标识，Profile 生成，Run 存续期不变 |
+| `issue_or_task_identity` | 驱动本 Run 的 issue/任务标识 |
+| `workspace_id` | 本 Run 的隔离 workspace 标识 |
+| `repository` | 目标仓库 |
+| `base_ref` | 起点 ref（如 main） |
+| `base_commit` | 起点 commit（开工时 target 的 HEAD） |
+| `work_branch` | 本 Run 的工作分支 |
+| `current_head` | 工作分支当前 HEAD，随 Run 推进更新 |
+| `stage` | 当前 Stage（§3 七者之一） |
+| `attempt` | 当前 Stage 执行轮次（从 1 起） |
+
+映射承诺：#79（Logical Run / Snapshot）落地后，`run_id` 映射 `logical_run_id`，其余字段映射 Snapshot 对应字段；映射必须可追溯，历史 Dogfood Run 不得因字段调整而丢失（#103 纪律：调整需有映射，不丢历史）。
+
+### 7.2 Workspace 规则
+
+- 默认 **`ISOLATED_WRITE`**（消费 #93）：每个 Run 使用独立 branch + 独立 worktree；禁止在共享 main cwd 中直接开发；
+- 同一 Run 的 requirements/design/dev/review/test/accept 记录引用**同一 workspace lineage**（同一 `workspace_id` + branch 谱系）；
+- 多 Agent 并行时不同 Run 的 workspace 相互隔离，避免同片代码混写；跨 Run 合流走 Integration Checkpoint（§7.3）；
+- Profile 差异只允许存在于 workspace 的创建/清理机制，不允许存在于隔离语义本身。
+
+### 7.3 Proof 绑定与 Integration Checkpoint
+
+- Proof 绑定沿用仓库既有命名：`verified_branch` / `verified_head`（对齐 equivalence-checklist 维度 5 约定）；workspace 关联由信封 `run.workspace_id` 承载（§8.2）；Proof 只对 `verified_head` 有效；
+- **Integration Checkpoint**：最终集成（PR/merge）前执行——若 target 已前进（`base_commit` 之后 target 有新提交），必须 sync 后**重跑受影响的 Proof**（至少 review/test；acceptance package 重组后才可签收）；
+- checkpoint 结果记入 acceptance package 的 `assembled.integration_checkpoint`（§8.3）。
+
+### 7.4 与 #93 的映射声明
+
+`ISOLATED_WRITE` 与 workspace/branch 隔离是 #93 Workspace/Resource Isolation 的 Bootstrap 前身：#93 Runtime 落地后，隔离强制职责移交 Runtime，`workspace_id` 映射 #93 的 workspace 标识；本节语义不与 #93 最终模型冲突，字段以其为权威。
 
 ## 8. Portable Handoff / Evidence Package
 
-> **由 #113 填充**：七类交接/证据包（requirements baseline / design package / dev handoff / review proof / test proof / acceptance package / closeout summary）的统一 schema、示例、与 #78 Formal Records 的映射承诺。
+### 8.1 七类记录
+
+两个 Profile 在每个 Stage 产出的可审计交接/证据包使用统一 schema：
+
+| 记录类型 | 产生 Stage | 作用 |
+|---|---|---|
+| `requirements_baseline` | requirements | 冻结需求基线 + 人工确认记录 |
+| `design_package` | design | 方案 + 决策点 + Decision Record |
+| `dev_handoff` | dev | 改动摘要 + 自验记录 |
+| `review_proof` | review | 独立审核结论 + findings（带根因分类） |
+| `test_proof` | test | 独立测试结果 + 验收标准映射 |
+| `acceptance_package` | human acceptance | 证据汇总 + 人工验收决策 |
+| `closeout_summary` | closeout | 交付清单 + 集成结果 + 保留声明 |
+
+这七类是 #78 Formal Records 的**兼容前身**：#78 落地后，Revision/依赖链/证明失效以 #78 为权威，本节记录映射过去，不丢历史。
+
+### 8.2 统一信封
+
+每份记录 = 信封 + payload。信封字段：
+
+| 字段 | 语义 |
+|---|---|
+| `record_type` | 七者之一 |
+| `record_version` | 记录 schema 版本（当前 v0.1） |
+| `created_at` | ISO 8601 时间 |
+| `produced_by` | 产生者 Role/会话标识 |
+| `run` | §7.1 portable run identity 全量内嵌 |
+
+信封保证每份记录自带 run/workspace/source HEAD 关联（#103 要求）。
+
+### 8.3 payload 要素
+
+必选/可选字段以 §8.4 schema 为准；语义要点：
+
+- **requirements_baseline**：三要素 + `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 人工确认（`BASELINE_CONFIRMED` 后回填）；
+- **design_package**：summary + `decision_required` 标记与判据命中说明（§5.2）+（触发时）Decision Record；
+- **dev_handoff**：改动摘要 + 自验清单；
+- **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head`；review 另需 `independent_session=true`（不变量 2）；
+- **acceptance_package**：`assembled`（引用 review/test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，决策枚举 `accept`/`reject`/`user_accepted`，AI 不得代签）；
+- **closeout_summary**：交付清单 + 集成结果 + `records_retained=true`。
+
+### 8.4 Schema、示例与机械校验
+
+- Schema：`docs/design/construction-workflow/handoff.schema.json`（JSON Schema draft-07）
+- 示例：`docs/design/construction-workflow/examples/01…07-*.json`（七类各一；取材于本契约开发 Run 的真实场景，其中 review/test/acceptance/closeout 为 **schema 演示值**，不代表本 Run 已发生对应的独立审核、测试或人工签收记录）
+- 机械校验（可执行验证）：
+
+```bash
+npm_config_cache=.scratch/npm-cache npx --yes ajv-cli@5 validate \
+  -s docs/design/construction-workflow/handoff.schema.json \
+  -d "docs/design/construction-workflow/examples/*.json"
+```
+
+### 8.5 保留要求
+
+Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 检索（对应 closeout 的 `records_retained`）；删除或清理归档记录属完整性违约，走 §4.4 升级，不作为回退。
 
 ## 9. 一致性矩阵、引用规范与冻结
 

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,6 +1,6 @@
 # 建设 · 完整功能开发 Portable Contract
 
-> **版本**：v0.1-draft（§1–§6 由 #112 落地；§7–§8 由 #113 填充；§9 由 #114 填充并执行整文档冻结）
+> **版本**：**v0.1（内容冻结 2026-08-30；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；冻结与修订规则见 §9.3；Run 级人工验收随 PR #115 进行）**
 > **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
 > **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
 > **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
@@ -336,4 +336,72 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 
 ## 9. 一致性矩阵、引用规范与冻结
 
-> **由 #114 填充**：与 #71/#77/#72/#73/#78/#93 的逐项一致性矩阵、双 Profile 引用规范条款、冻结版本标记与修订规则。
+### 9.1 关联 issue 一致性矩阵
+
+| 关联 issue | 方向要点 | 契约对齐位置 | 差异说明 |
+|---|---|---|---|
+| #71 全局《工作流设计原则》 | 建立通用设计原则与方法论文档（尚未落地） | §0/§2 遵循同一决断源（#102 A1–A5） | 无冲突：层不同——#71 是通用原则，本契约是建设业务语义；#71 落地后本契约引用之，不重复定义通用原则 |
+| #77 Business Outcome Routing | 技术执行与业务结果分离；Producer/Router 分离；禁止 `next_node`；Node Result 权威；额度耗尽保留原 Outcome | §6 全节；§4.3 耗尽行为（`WAITING_HUMAN + MAX_ROUNDS_REACHED`） | 兼容 shim 而非分叉：Bootstrap 期 Controller 使用 §6.3/§6.4 基元枚举驱动；#77 落地后按 §6.6 映射为正式 field path + route + `countRound`，字段名以 #77 为权威 |
+| #72 受控人工决策 | Decision（方向取舍）与验收（是否通过）解耦；默认自动推进；决策包要素；Decision Record 不可覆盖；`BASELINE_UPDATED` 回基线；`USER_ACCEPTED` 不改写 baseline | §5 全节；§3.1 固定门；§3.2 条件门；§3.6 `USER_ACCEPTED` | 无冲突：本契约把 #72 框架能力实例化到建设主链固定位置（requirements 确认门 + design 条件门），不设独立 Decision 业务节点，符合「Decision 是框架能力」原则 |
+| #73 自动回退额度 | 额度统一解释为自动回退额度；路径显式声明是否消耗；初次执行/内部 REVISE/WAITING_HUMAN/技术重试不计；人工触发显式记录；额度只限制自动路由 | §4.2 计数原则；§4.3 耗尽行为 | 无冲突：契约默认额度 3 来自 #102 决断；`countRound` 等字段名由 #73 实现定，契约只保留产品语义 |
+| #78 Formal Records / Provenance | 正式记录版本、依赖链与证明失效 | §8 全节；§7.1 映射承诺 | 兼容前身而非平行模型：七类记录是 #78 的轻量前身；#78 落地后 Revision/依赖链/证明失效以 #78 为权威，映射迁移不丢历史 |
+| #93 Workspace / Resource Isolation | Logical Run 工作区与共享资源隔离 Runtime | §7.2 `ISOLATED_WRITE`；§7.4 映射声明 | Bootstrap 先行：以 Profile 层 worktree/branch 纪律提前实现隔离语义，不等 #93 Runtime；#93 落地后强制职责移交 Runtime，`workspace_id` 映射其 workspace 标识 |
+
+补充关联：#79（Logical Run/Snapshot）在 §7.1 有映射承诺（`run_id` → `logical_run_id`）；#102 A1–A5 为上表全部行的共同决断源。
+
+**结论：六个关联 issue 逐项对齐，无未解释冲突。**
+
+### 9.2 双 Profile 引用规范
+
+1. DSH Profile（#105）与 External Profile（#104，Codex/Cursor）**只通过引用本契约获得业务语义**：Stage 语义、Role 职责、Handoff/Proof 类型、workspace/HEAD 要求、回退根因、Human Acceptance 规则；
+2. 禁止任一 Profile 复制契约正文片段到自身文档后独立维护；引用允许摘要 + 指向本文件小节锚点；
+3. 禁止 Profile 私有扩展业务语义：执行器差异只允许存在于调用/挂起/恢复/工具映射（Adapter 层）；认为语义不足时，走 §9.3 修订本契约，而不是在 Profile 侧先做；
+4. External Profile 的 runbook（#104）是「如何把契约映射到 Codex/Cursor 工具环境」的说明，不是第二份业务定义；
+5. 发现某 Profile 行为与本契约冲突时，以本契约为准裁决（§0 冲突裁决顺序）。
+
+### 9.3 冻结与修订规则
+
+- 本版冻结标记：**v0.1，2026-08-30**（#112 → #113 → #114 三工单依次落地后整文档冻结）；
+- 修订必须：① 在本节追加版本历史行（版本、日期、动机、关联 issue）；② 与受影响 Runtime issue（#77/#72/#73/#78/#79/#93）重新对齐矩阵（§9.1）；③ 先改契约、后改 Profile，禁止 Profile 先行分叉；
+- Runtime 字段调整纪律（继承 #103）：#77/#78/#79/#93 落地导致的字段命名调整，必须提供**新旧映射**且历史 Dogfood Run 可追溯，不丢历史；
+- 冻结解除条件：仅当主链结构、人工门、额度语义任一发生变化时升 major 版本；措辞/示例修正升 patch。
+
+版本历史：
+
+| 版本 | 日期 | 变更 | 关联 |
+|---|---|---|---|
+| v0.1 | 2026-08-30 | 初版冻结：主链语义、Run/Workspace、七类交接包、一致性矩阵 | #112 #113 #114 |
+
+### 9.4 #103 九条验收清单证据映射
+
+| #103 验收标准 | 证据小节 |
+|---|---|
+| 一份共享 Portable Contract 完整覆盖建设主链 | §2（主链与不变量）+ §3（七 Stage） |
+| 明确各 Stage 输入、专业输出、Proof、回退来源 | §3.1–3.7（每节四要素） |
+| 明确 Human Acceptance 与 Human Decision 边界 | §5.1–5.4 |
+| 明确 worktree/branch/HEAD/Integration Checkpoint | §7.2、§7.3 |
+| 明确 Dogfood portable run identity | §7.1 |
+| 明确七类交接/证据包 | §8.1–8.5 |
+| 与 #71、#77、#72、#73、#78、#93 无产品语义冲突 | §9.1（逐项矩阵，无未解释冲突） |
+| DSH/External Profile 只引用本 Contract，不复制语义 | §0 纪律 + §9.2 |
+| #105 可直接消费，不重新定义语义 | §9.5 |
+
+### 9.5 #105 可消费性核验
+
+#105「DSH Dogfood 验收」11 项逐项对应契约小节：
+
+| # | #105 验收项 | 契约小节 |
+|---|---|---|
+| 1 | Requirements baseline + 人确认 | §3.1 + §5.1（固定门） |
+| 2 | Design | §3.2 |
+| 3 | Dev 在独立 worktree | §3.3 + §7.2 |
+| 4 | Review 独立验证 | §3.4 + §2 不变量 2 |
+| 5 | Test 独立验证 | §3.5 |
+| 6 | Human Acceptance | §3.6 |
+| 7 | Closeout | §3.7 |
+| 8 | 至少 1 条业务打回路径 | §4.1 + §4.2（review/test 回退消耗额度） |
+| 9 | branch/HEAD Proof | §7.3 + §8.3 |
+| 10 | Integration Checkpoint | §7.3 + §8.3（`assembled.integration_checkpoint`） |
+| 11 | 最终 PR/merge 按仓库规则执行 | §3.7（Closeout 交付集成）+ §7.3 |
+
+**结论：#105 可直接引用本契约执行 Bootstrap Run，无需重新定义建设工作流语义。**

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,6 +1,6 @@
 # 建设 · 完整功能开发 Portable Contract
 
-> **版本**：**v0.1.1（2026-08-30 冻结，同日按 PR #115 Codex Review 修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
+> **版本**：**v0.1.2（2026-08-30 冻结，同日按 PR #115 Codex Review 两轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
 > **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
 > **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
 > **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
@@ -315,7 +315,7 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 
 - **requirements_baseline**：三要素 + `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录；`draft` 不得作为下游冻结输入）；
 - **design_package**：summary + `decision_required` 标记；`decision_required=true` 必须附非空 `decision_required_reasons`（§5.2）；Decision Record 只能出现在命中条件门的 package 上，Controller 在 `decision_required=true` 且无 Decision Record 时必须挂起（§5.2），不得放行；
-- **dev_handoff**：改动摘要 + 自验清单；
+- **dev_handoff**：改动摘要 + **整体 `outcome`**（`handoff_ready` / `blocked` / `design_issue` / `requirements_issue`，§6.3 基元）+ 自验清单；`outcome=blocked` 必须附 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定）；`design_issue`/`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；条件约束：`request_changes`/`fail` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；`blocked` 必须带 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定，§6.4）；
 - **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）；
 - **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包，Controller 归档前校验）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。
@@ -374,6 +374,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 |---|---|---|---|
 | v0.1 | 2026-08-30 | 初版冻结：主链语义、Run/Workspace、七类交接包、一致性矩阵 | #112 #113 #114 |
 | v0.1.1 | 2026-08-30 | Codex Review 修复：`blocked` 路由（`hold` → Run `BLOCKED`）、`USER_ACCEPTED` 保留到 closeout、多根因单边回退计数、schema 九处条件收紧、示例链一致性修正 | PR #115 Review |
+| v0.1.2 | 2026-08-30 | Codex Review 修复（二）：dev_handoff 增加整体 `outcome` 与 `blocked_reason` 条件、closeout 引用必须指向 decided 验收包的示例链修正、`record_type`↔`run.stage` 绑定、design 条件门双向约束 | PR #115 Review |
 
 ### 9.4 #103 九条验收清单证据映射
 

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,6 +1,6 @@
 # 建设 · 完整功能开发 Portable Contract
 
-> **版本**：**v0.1.2（2026-08-30 冻结，同日按 PR #115 Codex Review 两轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
+> **版本**：**v0.1.3（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
 > **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
 > **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
 > **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
@@ -302,7 +302,7 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 | 字段 | 语义 |
 |---|---|
 | `record_type` | 七者之一 |
-| `record_version` | 记录 schema 版本（当前 v0.1.2） |
+| `record_version` | 记录 schema 版本（当前 v0.1.3） |
 | `created_at` | ISO 8601 时间 |
 | `produced_by` | 产生者 Role/会话标识 |
 | `run` | §7.1 portable run identity 全量内嵌 |
@@ -313,11 +313,11 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 
 必选/可选字段以 §8.4 schema 为准；语义要点：
 
-- **requirements_baseline**：三要素 + `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录；`draft` 不得作为下游冻结输入）；
+- **requirements_baseline**：三要素 + **整体 `outcome`**（`baseline_ready` / `awaiting_human_input` / `revised`，§6.3 基元）+ `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录，且**无残留 gaps、验收标准非空、goal/scope 非空**；`draft` 不得作为下游冻结输入）；`outcome=awaiting_human_input` 必须带非空 `gaps`，`outcome=baseline_ready` 必须无残留 gaps；
 - **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；`outcome=decision_required` ⇔ `decision_required=true`（双向 schema 约束）且必须附非空 `decision_required_reasons`（§5.2）；Decision Record 只能出现在命中条件门的 package 上，Controller 在 `decision_required=true` 且无 Decision Record 时必须挂起（§5.2），不得放行；
 - **dev_handoff**：改动摘要 + **整体 `outcome`**（`handoff_ready` / `blocked` / `design_issue` / `requirements_issue`，§6.3 基元）+ 自验清单；`outcome=blocked` 必须附 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定）；`outcome=handoff_ready` 要求自验清单非空且无 fail/blocked 项（§3.3 完成判定）；`design_issue`/`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；条件约束：`request_changes`/`fail` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；`blocked` 必须带 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定，§6.4）；
-- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）；
+- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② review `verdict=approve`、test `verdict=pass`（fail/blocked 不得进入验收）；③ 全部引用同 Run / 同 workspace lineage；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）——任一不满足即不得呈递或签收；
 - **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。Controller 归档前双重校验：① 引用包 `status=decided`；② 引用包 `decision` ∈ {`accept`, `user_accepted`} 且与 `acceptance_outcome` 一致——引用包 `decision=reject` 时**不得归档**，按 §3.6 打回根因路由。
 
 ### 8.4 Schema、示例与机械校验
@@ -375,6 +375,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 | v0.1 | 2026-08-30 | 初版冻结：主链语义、Run/Workspace、七类交接包、一致性矩阵 | #112 #113 #114 |
 | v0.1.1 | 2026-08-30 | Codex Review 修复：`blocked` 路由（`hold` → Run `BLOCKED`）、`USER_ACCEPTED` 保留到 closeout、多根因单边回退计数、schema 九处条件收紧、示例链一致性修正 | PR #115 Review |
 | v0.1.2 | 2026-08-30 | Codex Review 修复（二/三）：dev/design 增加整体 `outcome` 基元与一致性双向约束、`handoff_ready` 自验非空约束、closeout 引用决策一致性规则、`record_type`↔`run.stage` 绑定、示例链 decided 修正 | PR #115 Review |
+| v0.1.3 | 2026-08-30 | Codex Review 修复（四/五）：requirements 整体 `outcome` 基元与缺口条件、confirmed 分支完整性收紧（无 gaps、要素非空）、全部 `verified_*` 绑定非空约束、acceptance 证据链五项 Controller 校验 | PR #115 Review |
 
 ### 9.4 #103 九条验收清单证据映射
 

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,6 +1,6 @@
 # 建设 · 完整功能开发 Portable Contract
 
-> **版本**：**v0.1.4（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
+> **版本**：**v0.1.5（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
 > **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
 > **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
 > **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
@@ -302,7 +302,7 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 | 字段 | 语义 |
 |---|---|
 | `record_type` | 七者之一 |
-| `record_version` | 记录 schema 版本（当前 v0.1.4） |
+| `record_version` | 记录 schema 版本（当前 v0.1.5） |
 | `created_at` | ISO 8601 时间 |
 | `produced_by` | 产生者 Role/会话标识 |
 | `run` | §7.1 portable run identity 全量内嵌 |
@@ -314,10 +314,10 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 必选/可选字段以 §8.4 schema 为准；语义要点：
 
 - **requirements_baseline**：三要素 + **整体 `outcome`**（`baseline_ready` / `awaiting_human_input` / `revised`，§6.3 基元）+ `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录，且**无残留 gaps、验收标准非空、goal/scope 非空**；`draft` 不得作为下游冻结输入）；`outcome=awaiting_human_input` 必须带非空 `gaps`，`outcome=baseline_ready` 必须无残留 gaps；
-- **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；`outcome=decision_required` ⇔ `decision_required=true`（双向 schema 约束）且必须附非空 `decision_required_reasons`（§5.2）；Decision Record 只能出现在命中条件门的 package 上，Controller 在 `decision_required=true` 且无 Decision Record 时必须挂起（§5.2），不得放行；
+- **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；门状态机两态：**命中条件门且未决 ⇒ `outcome=decision_required`**（schema 双向约束）且必须附非空 `decision_required_reasons`（§5.2），Controller 必须挂起不得放行；**人工决策记录后 ⇒ 翻转为 `package_ready`**，Decision Record 作为过门证据保留在该 package 上（schema 仅允许 Decision Record 出现在命中条件门的 package 上）；`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **dev_handoff**：改动摘要 + **整体 `outcome`**（`handoff_ready` / `blocked` / `design_issue` / `requirements_issue`，§6.3 基元）+ 自验清单；`outcome=blocked` 必须附 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定）；`outcome=handoff_ready` 要求自验清单非空且无 fail/blocked 项（§3.3 完成判定）；`design_issue`/`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；条件约束：`request_changes`/`fail` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；`blocked` 必须带 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定，§6.4）；
-- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② review `verdict=approve`、test `verdict=pass`（fail/blocked 不得进入验收）；③ 全部引用同 Run / 同 workspace lineage；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）；⑤ 引用 baseline `status=confirmed` 且无残留 gaps；⑥ 引用 design `outcome=package_ready`（命中过条件门的必须已带 Decision Record）；⑦ 引用 dev `outcome=handoff_ready`；⑧ test `acceptance_mapping` 与引用 baseline 的验收标准逐条**完整且无重复**对应（防漏测项）——任一不满足即不得呈递或签收；
+- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② 普通 `accept` 要求 review `verdict=approve` 且 test `verdict=pass`；**`user_accepted` 例外**——允许携带 fail/blocked 证据链知情接受，但必须附 `feedback` 说明接受的差异（§3.6 特殊语义，不得伪造测试证据）；③ 全部引用同 Run / 同 workspace lineage；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）；⑤ 引用 baseline `status=confirmed` 且无残留 gaps；⑥ 引用 design `outcome=package_ready`（命中过条件门的必须已带 Decision Record）；⑦ 引用 dev `outcome=handoff_ready`；⑧ test `acceptance_mapping` 与引用 baseline 的验收标准逐条**完整且无重复**对应（防漏测项；`user_accepted` 场景下该项为「完整映射 + 已知差异说明」）——任一不满足即不得呈递或签收；
 - **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。Controller 归档前双重校验：① 引用包 `status=decided`；② 引用包 `decision` ∈ {`accept`, `user_accepted`} 且与 `acceptance_outcome` 一致——引用包 `decision=reject` 时**不得归档**，按 §3.6 打回根因路由。
 
 ### 8.4 Schema、示例与机械校验
@@ -377,6 +377,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 | v0.1.2 | 2026-08-30 | Codex Review 修复（二/三）：dev/design 增加整体 `outcome` 基元与一致性双向约束、`handoff_ready` 自验非空约束、closeout 引用决策一致性规则、`record_type`↔`run.stage` 绑定、示例链 decided 修正 | PR #115 Review |
 | v0.1.3 | 2026-08-30 | Codex Review 修复（四/五）：requirements 整体 `outcome` 基元与缺口条件、confirmed 分支完整性收紧（无 gaps、要素非空）、全部 `verified_*` 绑定非空约束、acceptance 证据链五项 Controller 校验 | PR #115 Review |
 | v0.1.4 | 2026-08-30 | Codex Review 修复（六）：证据链校验扩展上游完成态（baseline confirmed / design package_ready / dev handoff_ready）与验收映射完整覆盖、acceptance `verified_head` 补非空（上轮尾逗号漏网）、Run identity 8 字段与签名/引用/集成标识类字段全面非空约束 | PR #115 Review |
+| v0.1.5 | 2026-08-30 | Codex Review 修复（七）：design 门状态机改两态——未决 ⇒ outcome=decision_required，已决 ⇒ 翻转 package_ready 并保留 Decision Record 作过门证据（消除已决 gated package 永久无法验收的死锁）；user_accepted 例外通道——允许 fail/blocked 证据链知情接受但必须附 feedback 说明差异（§3.6 路径可达，无需伪造证据） | PR #115 Review |
 
 ### 9.4 #103 九条验收清单证据映射
 

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,6 +1,6 @@
 # 建设 · 完整功能开发 Portable Contract
 
-> **版本**：**v0.1.3（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
+> **版本**：**v0.1.4（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
 > **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
 > **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
 > **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
@@ -302,7 +302,7 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 | 字段 | 语义 |
 |---|---|
 | `record_type` | 七者之一 |
-| `record_version` | 记录 schema 版本（当前 v0.1.3） |
+| `record_version` | 记录 schema 版本（当前 v0.1.4） |
 | `created_at` | ISO 8601 时间 |
 | `produced_by` | 产生者 Role/会话标识 |
 | `run` | §7.1 portable run identity 全量内嵌 |
@@ -317,13 +317,13 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 - **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；`outcome=decision_required` ⇔ `decision_required=true`（双向 schema 约束）且必须附非空 `decision_required_reasons`（§5.2）；Decision Record 只能出现在命中条件门的 package 上，Controller 在 `decision_required=true` 且无 Decision Record 时必须挂起（§5.2），不得放行；
 - **dev_handoff**：改动摘要 + **整体 `outcome`**（`handoff_ready` / `blocked` / `design_issue` / `requirements_issue`，§6.3 基元）+ 自验清单；`outcome=blocked` 必须附 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定）；`outcome=handoff_ready` 要求自验清单非空且无 fail/blocked 项（§3.3 完成判定）；`design_issue`/`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；条件约束：`request_changes`/`fail` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；`blocked` 必须带 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定，§6.4）；
-- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② review `verdict=approve`、test `verdict=pass`（fail/blocked 不得进入验收）；③ 全部引用同 Run / 同 workspace lineage；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）——任一不满足即不得呈递或签收；
+- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② review `verdict=approve`、test `verdict=pass`（fail/blocked 不得进入验收）；③ 全部引用同 Run / 同 workspace lineage；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）；⑤ 引用 baseline `status=confirmed` 且无残留 gaps；⑥ 引用 design `outcome=package_ready`（命中过条件门的必须已带 Decision Record）；⑦ 引用 dev `outcome=handoff_ready`；⑧ test `acceptance_mapping` 与引用 baseline 的验收标准逐条**完整且无重复**对应（防漏测项）——任一不满足即不得呈递或签收；
 - **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。Controller 归档前双重校验：① 引用包 `status=decided`；② 引用包 `decision` ∈ {`accept`, `user_accepted`} 且与 `acceptance_outcome` 一致——引用包 `decision=reject` 时**不得归档**，按 §3.6 打回根因路由。
 
 ### 8.4 Schema、示例与机械校验
 
 - Schema：`docs/design/construction-workflow/handoff.schema.json`（JSON Schema draft-07）
-- 示例：`docs/design/construction-workflow/examples/01…07-*.json`（七类各一；取材于本契约开发 Run 的真实场景，其中 review/test/acceptance/closeout 为 **schema 演示值**，不代表本 Run 已发生对应的独立审核、测试或人工签收记录）。示例链统一绑定到 **v0.1.1 内容完成点 HEAD（`c8d8625`）**：patch 级修订不前移示例链的 HEAD 绑定，仅 major/minor 语义变更时重新生成示例链
+- 示例：`docs/design/construction-workflow/examples/01…07-*.json`（七类各一；取材于本契约开发 Run 的真实场景，其中 review/test/acceptance/closeout 为 **schema 演示值**，不代表本 Run 已发生对应的独立审核、测试或人工签收记录）。示例链统一绑定到 **v0.1.1 内容完成点 HEAD（`c8d8625`）**：patch 级修订不前移示例链的 HEAD 绑定（各记录 `record_version` 随 schema 升级，但 `run.current_head`/`verified_head` 保持钉扎），仅 major/minor 语义变更时重新生成示例链
 - 机械校验（可执行验证）：
 
 ```bash
@@ -363,7 +363,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 
 ### 9.3 冻结与修订规则
 
-- 本版冻结标记：**v0.1，2026-08-30**（#112 → #113 → #114 三工单依次落地后整文档冻结）；
+- 本版冻结标记：**v0.1.4，2026-08-30**（#112 → #113 → #114 三工单依次落地整文档冻结后，同日按 PR #115 Review 修复升 patch 至 v0.1.4，见下方版本历史）；
 - 修订必须：① 在本节追加版本历史行（版本、日期、动机、关联 issue）；② 与受影响 Runtime issue（#77/#72/#73/#78/#79/#93）重新对齐矩阵（§9.1）；③ 先改契约、后改 Profile，禁止 Profile 先行分叉；
 - Runtime 字段调整纪律（继承 #103）：#77/#78/#79/#93 落地导致的字段命名调整，必须提供**新旧映射**且历史 Dogfood Run 可追溯，不丢历史；
 - 冻结解除条件：仅当主链结构、人工门、额度语义任一发生变化时升 major 版本；措辞/示例修正升 patch。
@@ -376,6 +376,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 | v0.1.1 | 2026-08-30 | Codex Review 修复：`blocked` 路由（`hold` → Run `BLOCKED`）、`USER_ACCEPTED` 保留到 closeout、多根因单边回退计数、schema 九处条件收紧、示例链一致性修正 | PR #115 Review |
 | v0.1.2 | 2026-08-30 | Codex Review 修复（二/三）：dev/design 增加整体 `outcome` 基元与一致性双向约束、`handoff_ready` 自验非空约束、closeout 引用决策一致性规则、`record_type`↔`run.stage` 绑定、示例链 decided 修正 | PR #115 Review |
 | v0.1.3 | 2026-08-30 | Codex Review 修复（四/五）：requirements 整体 `outcome` 基元与缺口条件、confirmed 分支完整性收紧（无 gaps、要素非空）、全部 `verified_*` 绑定非空约束、acceptance 证据链五项 Controller 校验 | PR #115 Review |
+| v0.1.4 | 2026-08-30 | Codex Review 修复（六）：证据链校验扩展上游完成态（baseline confirmed / design package_ready / dev handoff_ready）与验收映射完整覆盖、acceptance `verified_head` 补非空（上轮尾逗号漏网）、Run identity 8 字段与签名/引用/集成标识类字段全面非空约束 | PR #115 Review |
 
 ### 9.4 #103 九条验收清单证据映射
 

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,6 +1,6 @@
 # 建设 · 完整功能开发 Portable Contract
 
-> **版本**：**v0.1.5（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
+> **版本**：**v0.1.6（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
 > **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
 > **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
 > **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
@@ -314,10 +314,10 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 必选/可选字段以 §8.4 schema 为准；语义要点：
 
 - **requirements_baseline**：三要素 + **整体 `outcome`**（`baseline_ready` / `awaiting_human_input` / `revised`，§6.3 基元）+ `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录，且**无残留 gaps、验收标准非空、goal/scope 非空**；`draft` 不得作为下游冻结输入）；`outcome=awaiting_human_input` 必须带非空 `gaps`，`outcome=baseline_ready` 必须无残留 gaps；
-- **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；门状态机两态：**命中条件门且未决 ⇒ `outcome=decision_required`**（schema 双向约束）且必须附非空 `decision_required_reasons`（§5.2），Controller 必须挂起不得放行；**人工决策记录后 ⇒ 翻转为 `package_ready`**，Decision Record 作为过门证据保留在该 package 上（schema 仅允许 Decision Record 出现在命中条件门的 package 上）；`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
+- **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；门状态机两态：**命中条件门且未决 ⇒ `outcome=decision_required`**（schema 双向约束）且必须附非空 `decision_required_reasons`（§5.2），Controller 必须挂起不得放行；**人工决策记录后 ⇒ 翻转为 `package_ready`**，Decision Record 作为过门证据保留在该 package 上（schema 仅允许 Decision Record 出现在命中条件门的 package 上；`options` 至少一个候选且 `chosen` 必须属于候选集——Controller 按 §5.3 校验）；`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **dev_handoff**：改动摘要 + **整体 `outcome`**（`handoff_ready` / `blocked` / `design_issue` / `requirements_issue`，§6.3 基元）+ 自验清单；`outcome=blocked` 必须附 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定）；`outcome=handoff_ready` 要求自验清单非空且无 fail/blocked 项（§3.3 完成判定）；`design_issue`/`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；条件约束：`request_changes`/`fail` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；`blocked` 必须带 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定，§6.4）；
-- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② 普通 `accept` 要求 review `verdict=approve` 且 test `verdict=pass`；**`user_accepted` 例外**——允许携带 fail/blocked 证据链知情接受，但必须附 `feedback` 说明接受的差异（§3.6 特殊语义，不得伪造测试证据）；③ 全部引用同 Run / 同 workspace lineage；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）；⑤ 引用 baseline `status=confirmed` 且无残留 gaps；⑥ 引用 design `outcome=package_ready`（命中过条件门的必须已带 Decision Record）；⑦ 引用 dev `outcome=handoff_ready`；⑧ test `acceptance_mapping` 与引用 baseline 的验收标准逐条**完整且无重复**对应（防漏测项；`user_accepted` 场景下该项为「完整映射 + 已知差异说明」）——任一不满足即不得呈递或签收；
+- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② 普通 `accept` 要求 review `verdict=approve` 且 test `verdict=pass`；**`user_accepted` 例外**——允许携带 fail/blocked 证据链知情接受，但必须附 `feedback` 说明接受的差异（§3.6 特殊语义，不得伪造测试证据）；③ 全部引用同 Run / 同 workspace lineage（标识字段非空才可比较）；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）；⑤ 引用 baseline `status=confirmed` 且无残留 gaps；⑥ 引用 design `outcome=package_ready`（命中过条件门的必须已带 Decision Record，且 `chosen` 属于其 `options` 候选集）；⑦ 引用 dev `outcome=handoff_ready`；⑧ test `acceptance_mapping` 与引用 baseline 的验收标准逐条**完整且无重复**对应（防漏测项；`user_accepted` 场景下该项为「完整映射 + 已知差异说明」）；⑨ 引用 review/test 的 `produced_by` 必须与引用 dev handoff 的 `produced_by` 不同（§2 不变量 2 的机器可校验形式，配合各自 `independent_session=true`）——任一不满足即不得呈递或签收；
 - **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。Controller 归档前双重校验：① 引用包 `status=decided`；② 引用包 `decision` ∈ {`accept`, `user_accepted`} 且与 `acceptance_outcome` 一致——引用包 `decision=reject` 时**不得归档**，按 §3.6 打回根因路由。
 
 ### 8.4 Schema、示例与机械校验
@@ -363,7 +363,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 
 ### 9.3 冻结与修订规则
 
-- 本版冻结标记：**v0.1.4，2026-08-30**（#112 → #113 → #114 三工单依次落地整文档冻结后，同日按 PR #115 Review 修复升 patch 至 v0.1.4，见下方版本历史）；
+- 本版冻结标记以**文档头版本行**为单一事实源（初次冻结 2026-08-30；后续 patch 逐条记入下方版本历史，不再在此重复版本号以免脱节）；
 - 修订必须：① 在本节追加版本历史行（版本、日期、动机、关联 issue）；② 与受影响 Runtime issue（#77/#72/#73/#78/#79/#93）重新对齐矩阵（§9.1）；③ 先改契约、后改 Profile，禁止 Profile 先行分叉；
 - Runtime 字段调整纪律（继承 #103）：#77/#78/#79/#93 落地导致的字段命名调整，必须提供**新旧映射**且历史 Dogfood Run 可追溯，不丢历史；
 - 冻结解除条件：仅当主链结构、人工门、额度语义任一发生变化时升 major 版本；措辞/示例修正升 patch。
@@ -378,6 +378,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 | v0.1.3 | 2026-08-30 | Codex Review 修复（四/五）：requirements 整体 `outcome` 基元与缺口条件、confirmed 分支完整性收紧（无 gaps、要素非空）、全部 `verified_*` 绑定非空约束、acceptance 证据链五项 Controller 校验 | PR #115 Review |
 | v0.1.4 | 2026-08-30 | Codex Review 修复（六）：证据链校验扩展上游完成态（baseline confirmed / design package_ready / dev handoff_ready）与验收映射完整覆盖、acceptance `verified_head` 补非空（上轮尾逗号漏网）、Run identity 8 字段与签名/引用/集成标识类字段全面非空约束 | PR #115 Review |
 | v0.1.5 | 2026-08-30 | Codex Review 修复（七）：design 门状态机改两态——未决 ⇒ outcome=decision_required，已决 ⇒ 翻转 package_ready 并保留 Decision Record 作过门证据（消除已决 gated package 永久无法验收的死锁）；user_accepted 例外通道——允许 fail/blocked 证据链知情接受但必须附 feedback 说明差异（§3.6 路径可达，无需伪造证据） | PR #115 Review |
+| v0.1.6 | 2026-08-30 | Codex Review 修复（八）：acceptance 证据链第 ⑨ 项（review/test 的 produced_by 必须异于 dev 产生者）、feedback/ blocked_reason 非空白约束、decision options ≥1 且 name 非空、全部字符串列表项拒绝空白项、§9.3 冻结标记改为以文档头为单一事实源 | PR #115 Review |
 
 ### 9.4 #103 九条验收清单证据映射
 

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,6 +1,6 @@
 # 建设 · 完整功能开发 Portable Contract
 
-> **版本**：**v0.1.7（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
+> **版本**：**v0.1.8（2026-08-30 冻结，同日按 PR #115 Codex Review 多轮修复升 patch；§1–§6 由 #112、§7–§8 由 #113、§9 由 #114 依次落地；Run 级人工验收随 PR #115 进行）**
 > **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
 > **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
 > **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
@@ -270,7 +270,7 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 ### 7.3 Proof 绑定与 Integration Checkpoint
 
 - Proof 绑定沿用仓库既有命名：`verified_branch` / `verified_head`（对齐 equivalence-checklist 维度 5 约定）；workspace 关联由信封 `run.workspace_id` 承载（§8.2）；Proof 只对 `verified_head` 有效；
-- **Integration Checkpoint**：最终集成（PR/merge）前执行——若 target 已前进（`base_commit` 之后 target 有新提交），必须 sync 后**重跑受影响的 Proof**（至少 review/test；acceptance package 重组后才可签收）；
+- **Integration Checkpoint**：最终集成（PR/merge）前执行——`target_advanced` 必须由 Controller **从实际仓库状态计算**（比较 target 当前 HEAD 与 `base_commit`），不得信任产生者自报；若 target 已前进，必须 sync 后**重跑受影响的 Proof**（至少 review/test；acceptance package 重组后才可签收）；
 - checkpoint 结果记入 acceptance package 的 `assembled.integration_checkpoint`（§8.3）。
 
 ### 7.4 与 #93 的映射声明
@@ -314,10 +314,10 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 必选/可选字段以 §8.4 schema 为准；语义要点：
 
 - **requirements_baseline**：三要素 + **整体 `outcome`**（`baseline_ready` / `awaiting_human_input` / `revised`，§6.3 基元）+ `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录，且**无残留 gaps、验收标准非空、goal/scope 非空**；`draft` 不得作为下游冻结输入）；`outcome=awaiting_human_input` 必须带非空 `gaps`，`outcome=baseline_ready` 必须无残留 gaps；
-- **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；门状态机两态：**命中条件门且未决 ⇒ `outcome=decision_required`**（schema 双向约束）且必须附非空 `decision_required_reasons`（§5.2）与 **`decision_request` 待决包**（question / options≥1 / recommendation，§5.3），Controller 挂起呈递该包；**人工决策记录后 ⇒ 翻转为 `package_ready`**，`decision` 与 `decision_request` 并存（裁决上下文 + 已决记录），Decision Record 仅允许出现在命中条件门的 package 上，且 `chosen` 必须属于 `options` 候选集（Controller 按 §5.3 校验）；`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
+- **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；门状态机两态：**命中条件门且未决 ⇒ `outcome=decision_required`**（schema 双向约束）且必须附非空 `decision_required_reasons`（§5.2）与 **`decision_request` 待决包**（question / options≥1 / recommendation，§5.3），Controller 挂起呈递该包；**人工决策记录后 ⇒ 翻转为 `package_ready`**，`decision` 与 `decision_request` 并存（裁决上下文 + 已决记录），Decision Record 仅允许出现在命中条件门的 package 上，且**已决 package 必须保留裁决时呈递的 `decision_request`，`chosen` 必须属于 `decision_request.options` 呈递候选集**（schema 强制并存，Controller 校验候选集一致性，§5.3）；`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **dev_handoff**：改动摘要 + **整体 `outcome`**（`handoff_ready` / `blocked` / `design_issue` / `requirements_issue`，§6.3 基元）+ 自验清单；`outcome=blocked` 必须附 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定）；`outcome=handoff_ready` 要求自验清单非空且无 fail/blocked 项（§3.3 完成判定）；`design_issue`/`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；条件约束：`request_changes`/`fail` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；`blocked` 必须带 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定，§6.4）；
-- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。`assembled.integration_checkpoint` 为结构化记录：`target_ref` / `target_head_at_check` / `target_advanced` / `proofs_state`（`target_advanced=true` ⇒ `proofs_state=rerun_completed`，§7.3 可机检）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② 普通 `accept` 要求 review `verdict=approve` 且 test `verdict=pass`；**`user_accepted` 例外**——允许携带 fail/blocked 证据链知情接受，但必须附 `feedback` 说明接受的差异（§3.6 特殊语义，不得伪造测试证据）；③ 全部引用同 Run / 同 workspace lineage（标识字段非空才可比较）；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）；⑤ 引用 baseline `status=confirmed` 且无残留 gaps；⑥ 引用 design `outcome=package_ready`（命中过条件门的必须已带 Decision Record，且 `chosen` 属于其 `options` 候选集）；⑦ 引用 dev `outcome=handoff_ready`；⑧ test `acceptance_mapping` 与引用 baseline 的验收标准逐条**完整且无重复**对应（防漏测项；`user_accepted` 场景下该项为「完整映射 + 已知差异说明」）；⑨ 引用 review/test 的 `produced_by` 必须与引用 dev handoff 的 `produced_by` 不同（§2 不变量 2 的机器可校验形式，配合各自 `independent_session=true`）——任一不满足即不得呈递或签收；
+- **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）。`assembled.integration_checkpoint` 为结构化记录：`target_ref` / `target_head_at_check` / `target_advanced` / `proofs_state`（`target_advanced=true` ⇒ `proofs_state=rerun_completed`，§7.3 可机检）。Controller 在**呈递或签收前**必须校验证据链：① 各引用记录 `record_type` 与产生 Stage 正确；② 普通 `accept` 要求 review `verdict=approve` 且 test `verdict=pass`；**`user_accepted` 例外**——允许携带 fail/blocked 证据链知情接受，但必须附 `feedback` 说明接受的差异（§3.6 特殊语义，不得伪造测试证据）；③ 全部引用同 Run / 同 workspace lineage（标识字段非空才可比较）；④ 各 Proof `verified_head` 与当前 HEAD 一致（否则按 §7.3 重跑）；⑤ 引用 baseline `status=confirmed` 且无残留 gaps；⑥ 引用 design `outcome=package_ready`（命中过条件门的必须已带 Decision Record 与呈递时的 `decision_request`，且 `chosen` 属于呈递候选集）；⑦ 引用 dev `outcome=handoff_ready`；⑧ test `acceptance_mapping` 与引用 baseline 的验收标准逐条**完整且无重复**对应（防漏测项；`user_accepted` 场景下该项为「完整映射 + 已知差异说明」）；⑨ 引用 review/test 的 `produced_by` 必须与引用 dev handoff 的 `produced_by` 不同（§2 不变量 2 的机器可校验形式，配合各自 `independent_session=true`）——任一不满足即不得呈递或签收；
 - **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。Controller 归档前双重校验：① 引用包 `status=decided`；② 引用包 `decision` ∈ {`accept`, `user_accepted`} 且与 `acceptance_outcome` 一致——引用包 `decision=reject` 时**不得归档**，按 §3.6 打回根因路由。
 
 ### 8.4 Schema、示例与机械校验
@@ -380,6 +380,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 | v0.1.5 | 2026-08-30 | Codex Review 修复（七）：design 门状态机改两态——未决 ⇒ outcome=decision_required，已决 ⇒ 翻转 package_ready 并保留 Decision Record 作过门证据（消除已决 gated package 永久无法验收的死锁）；user_accepted 例外通道——允许 fail/blocked 证据链知情接受但必须附 feedback 说明差异（§3.6 路径可达，无需伪造证据） | PR #115 Review |
 | v0.1.6 | 2026-08-30 | Codex Review 修复（八）：acceptance 证据链第 ⑨ 项（review/test 的 produced_by 必须异于 dev 产生者）、feedback/ blocked_reason 非空白约束、decision options ≥1 且 name 非空、全部字符串列表项拒绝空白项、§9.3 冻结标记改为以文档头为单一事实源 | PR #115 Review |
 | v0.1.7 | 2026-08-30 | Codex Review 修复（九）：design 新增 `decision_request` 待决决策包（question/options/recommendation，§5.3），与已决 `decision` 分离并存——pending 门挂起时人工可见完整候选方案；`integration_checkpoint` 结构化（target_advanced ⇒ proofs_state=rerun_completed 可机检）；§8.2 record_version 行改为引用文档头单一事实源 | PR #115 Review |
+| v0.1.8 | 2026-08-30 | Codex Review 修复（十，收口轮）：checkpoint `target_advanced` 须由 Controller 从实际仓库状态计算（§7.3）、已决 gated package 强制保留 `decision_request` 且 `chosen` 属呈递候选集（§5.3 防换选项）、`tradeoffs` 非空白；**范围外加固类建议登记为遗留事项（另建 issue）** | PR #115 Review |
 
 ### 9.4 #103 九条验收清单证据映射
 

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -1,0 +1,250 @@
+# 建设 · 完整功能开发 Portable Contract
+
+> **版本**：v0.1-draft（§1–§6 由 #112 落地；§7–§8 由 #113 填充；§9 由 #114 填充并执行整文档冻结）
+> **来源**：#102（epic，A1–A5 节为本契约的决断依据）、#103（本契约的任务 issue）
+> **消费者**：DSH Execution Profile（#105）、External Coding Agent Profile（#104，Codex/Cursor）
+> **纪律**：两个 Profile 只通过引用本契约工作，不得复制或分叉业务语义；本契约是 executor 中立的，只定义产品语义，不定义实现字段（实现字段由各 Profile 的 Adapter 映射）。
+
+## 0. 定位
+
+本契约冻结「建设 · 完整功能开发」工作流的**可移植业务语义**：固定主链、各 Stage 的输入/专业输出/Proof/回退根因、人工门边界、回退与升级规则、Outcome/Routing 兼容原则。
+
+它**不是**：
+
+- 一份 DSH Runtime 实现说明（Runtime 由 #77/#72/#73/#78/#93/#79 逐项落地）；
+- 第二份 Workflow 业务定义（各 Profile 不得各自维护语义副本）；
+- legacy `dev-workflow-2-0` 的改名（legacy 主链无 requirements/design 阶段，与本契约主链不同）。
+
+冲突裁决顺序：本契约 > 各 Profile 私有说明 > 各执行器默认行为。与 #77/#72/#73/#78/#93 的正式 Runtime 能力收敛后，以正式 Runtime 语义为权威（见 §6.6、§9）。
+
+## 1. 术语
+
+| 术语 | 定义 |
+|---|---|
+| **Run** | 一次建设工作流的完整执行实例，对应一个 issue/逻辑任务（identity 字段见 §7） |
+| **Stage** | 主链上的一个固定业务阶段（§3 的七者之一） |
+| **Role** | 执行某个 Stage 专业工作的 agent 会话；只产出专业结果，不做路由决策 |
+| **Controller** | Portable Profile 内驱动流程的控制器/runbook；解析专业结果并决定路由、挂起、升级 |
+| **专业结果** | Role 对其 Stage 问题的结论、findings、证据的集合；是权威事实源 |
+| **Proof** | 与专业结果绑定的可验证证据，必须关联实际验证的 workspace/branch/HEAD（字段见 §7） |
+| **回退** | 已离开某 Stage 后，因后续阶段暴露问题而返回上游 Stage 重新产生成果 |
+| **自动回退额度** | Run 级计数，限制 Controller 自动执行回退路由的能力（§4） |
+| **挂起（AWAITING / WAITING_HUMAN）** | 流程暂停等待人工输入或决策；不是失败终态 |
+| **升级** | 额度耗尽或完整性违约时，把决策权交还人工；专业结果原样保留 |
+| **冻结基线** | 经人工确认后不再变动的产物版本；变动必须生成新 Revision 并重新确认 |
+
+## 2. 固定主链与不变量
+
+主链七阶段，顺序固定，任何 Profile 不得增删、改名或重排：
+
+```text
+requirements -> design -> dev -> review -> test -> human acceptance -> closeout
+```
+
+**不变量**：
+
+1. **顺序固定**：review 先于 test（review 通过的 HEAD 才进入 test）；human acceptance 先于 closeout。
+2. **独立证明者**：review 与 test 的执行会话必须独立于 dev 会话；允许顺序调用独立会话，禁止同一会话自证。
+3. **Proof 绑定真实现场**：一切 Proof 必须绑定实际验证的 workspace/branch/HEAD（§7 定义字段）。
+4. **无旁路**：不允许跳过 human acceptance 直接 closeout；不允许绕过 review/test 直接 acceptance（Profile 不得以工具限制为由取消独立证明）。
+5. **挂起优于编造**：任何 Stage 信息不足、等待人工、额度耗尽时，流程挂起并保留原始专业结果；禁止编造、篡改或静默改写。
+6. **一份语义**：两个 Profile 对上述全部语义只有本契约一个来源。
+
+## 3. Stage 契约
+
+每个 Stage 按四要素描述：**输入 / 专业输出 / Proof / 回退根因**。Role 只报告本 Stage 的专业结果；是否前进、回退、挂起由 Controller 依本节规则决定。
+
+### 3.1 Requirements — 需求基线
+
+- **目的**：把 issue/原始需求加工为可执行需求，经人工确认后冻结为 baseline，成为后续全部 Stage 的唯一范围依据。
+- **输入**：issue/需求原文与全部评论、仓库现状、既有契约/ADR、既往分析产物。
+- **专业输出**：requirements baseline——含三要素（任务目标 / 涉及范围 / 验收标准）与澄清决策记录；无法得出的要素必须显式标注「缺失 + 补齐建议」，不得编造。
+- **Proof**：baseline 文档（带版本标识）+ 人工确认记录（确认人、时间、被确认版本）。
+- **回退根因**：本 Stage 是**需求/范围类问题的根因汇入点**——接收下游一切需求类回退；被回退后生成新 Revision，重新走人工确认。
+- **完成判定**：baseline 通过人工确认（Decision Record：`BASELINE_CONFIRMED`，见 §5），形成冻结版本。
+- **挂起条件**：三要素存在缺口且无人可问 → 挂起（`awaiting-human-input`），保留缺口清单，等待人工补齐后重入。
+
+### 3.2 Design — 方案设计
+
+- **目的**：在冻结 baseline 范围内产出可执行方案与决策点清单。
+- **输入**：冻结的 requirements baseline。
+- **专业输出**：design package——方案、受影响模块/接口/数据、风险、未决问题清单、`decision_required` 标记（true/false + 判据命中说明，判据见 §5.2）。
+- **Proof**：design package；（条件门触发时）对应的 Human Decision Record。
+- **回退根因**：发现 baseline 缺陷、歧义或范围变化 → 回 **Requirements**（生成新 Revision，不直接修改 baseline）；本 Stage 同时接收下游一切设计类回退。
+- **完成判定**：package 完整，且 `decision_required=true` 时决策已记录。默认自动推进，不设固定人工门。
+
+### 3.3 Dev — 开发实现
+
+- **目的**：在隔离 workspace 中按冻结方案实现，自验满足验收标准。
+- **输入**：冻结 design package + 隔离 workspace（独立 branch/worktree，规则见 §7）。
+- **专业输出**：实现（代码/文档）+ dev handoff（改动摘要、自验记录与结果、影响面说明）。
+- **Proof**：实现与自验记录绑定 work_branch + current_head。
+- **回退根因**：开发中的内部迭代（实现问题自修复）**不算回退**（#73：节点内部 REVISE 不计额度）；本 Stage 接收下游一切实现类回退。
+- **完成判定**：自验通过且 dev handoff 完整。
+
+### 3.4 Review — 独立审核
+
+- **目的**：由独立会话审核实现与冻结方案/baseline 的一致性。
+- **输入**：dev handoff + 实际 workspace/branch/HEAD。
+- **专业输出**：review proof——结论（approve / request-changes）、逐条 findings、**每条 finding 的根因分类**（dev / design / requirements）、verified branch/HEAD。
+- **Proof**：review proof 绑定 verified workspace/branch/HEAD；审核会话与开发会话独立（不变量 2）。
+- **回退根因**：request-changes 时按每条 finding 的根因路由：实现 → **Dev**、设计 → **Design**、需求 → **Requirements**；未标注或确实无法分类的 finding，默认由 **Dev** 承接（Dev 判断属设计/需求问题后可再报告，由 Controller 按新根因再次路由，仍消耗该次回退额度）。
+- **完成判定**：approve 且 review proof 落盘。
+
+### 3.5 Test — 独立测试
+
+- **目的**：由独立会话验证行为满足 baseline 验收标准。
+- **输入**：review 结论为 approve 的 HEAD 所对应 workspace。
+- **专业输出**：test proof——执行结果、与验收标准的逐条映射、执行环境、失败项根因分类（dev / design / requirements）、verified branch/HEAD。
+- **Proof**：test proof 绑定**实际执行验证**的 HEAD，不得引用未验证的 HEAD。
+- **回退根因**：与 §3.4 相同的根因路由规则。
+- **完成判定**：baseline 全部验收标准有对应通过结果，test proof 落盘。
+
+### 3.6 Human Acceptance — 人工验收
+
+- **目的**：人工对交付成果做正式业务签收。这是主链上唯一的固定人工业务节点；**AI 不代签**。
+- **输入**：acceptance package——requirements baseline + design package + dev handoff + review proof + test proof（+ Integration Checkpoint 结果，规则见 §7）。
+- **输出**（人工，非 Role）：acceptance decision——accept / reject（reject 必须附 feedback 及其根因指向）。
+- **Proof**：acceptance proof——验收人、结论、时间、verified HEAD。
+- **回退根因**：reject 按 feedback 根因路由（默认 **Dev**；暴露设计/需求问题按根因回对应 Stage）。**人工打回不消耗自动回退额度**，但计入 Run 历史。
+- **特殊语义**：人工知情接受未完全满足 baseline 的结果时，使用 `USER_ACCEPTED`（#72），不得改写 baseline 制造 PASS。
+- **完成判定**：accept（或 USER_ACCEPTED）记录落盘，产生 acceptance proof。
+
+### 3.7 Closeout — 收口
+
+- **目的**：只整理、冻结、交付；不重新开发、测试或审查。
+- **输入**：通过的 acceptance proof + 本 Run 全部记录。
+- **专业输出**：closeout summary——交付清单、冻结记录、PR/merge 结果、遗留事项。
+- **Proof**：closeout summary + 最终集成结果（PR 编号/merge commit）。
+- **回退根因**：**无回退出口**。若发现交付物与 Proof 不符，属完整性违约，升级人工处理，不作为回退。
+- **完成判定**：交付完成，Run 归档（记录保留要求见 §7/§8）。
+
+## 4. 回退与升级语义
+
+### 4.1 根因路由
+
+| 根因分类 | 回退目标 | 典型来源 |
+|---|---|---|
+| 需求/范围问题 | Requirements（§3.1） | review/test 发现范围错、验收标准错、baseline 歧义 |
+| 设计问题 | Design（§3.2） | review/test 发现方案不可行、接口不成立 |
+| 实现问题 | Dev（§3.3） | review request-changes、test 失败的常规缺陷 |
+
+判定纪律：**产生 findings 的 Role 必须给出根因分类**（这是专业结果的一部分）；Controller 按分类路由，不重估专业判断。同一 findings 内允许多根因并存，Controller 拆分路由，分别消耗额度（见 4.2 的声明规则）。
+
+### 4.2 自动回退额度
+
+- 默认额度：**3 / Run**（语义对齐 #73：额度统一解释为自动回退额度，限制的是 Controller 的自动路由能力）。
+- 计数原则：
+  - 首次执行任何 Stage 不计；
+  - review / test 触发的回退边：**消耗额度**；
+  - Dev 内部迭代（自修复）：不计；
+  - 挂起（AWAITING / WAITING_HUMAN / PAUSED）不计；
+  - 技术重试（会话崩溃、工具故障重跑）不消耗业务额度；
+  - 人工触发（Decision / Acceptance 打回）不消耗自动额度，但显式记录；
+  - Human Decision 之后额度是否追加/重置，必须在 Decision Record 中显式记录，不得隐式恢复。
+
+### 4.3 额度耗尽行为
+
+额度耗尽且最新专业结果仍要求回退时：
+
+1. 原 Outcome **原样保留并持久化**，不篡改、不降级为失败；
+2. Controller 不执行该自动回退边；
+3. Run 进入挂起：`WAITING_HUMAN`，reason = `MAX_ROUNDS_REACHED`（对齐 #77/#73；**不是** legacy 的 `FAILED_MAX_ROUNDS` 终态）;
+4. 人工决策包必须展示：原 Outcome、历史尝试、剩余问题、继续的成本/收益/风险、可选方向（接受当前结果 / 追加额度 / 按根因回退 / 停止 / 派生新 Run）。
+
+### 4.4 升级（区别于回退）
+
+两类事件走升级而非回退：额度耗尽（§4.3）与完整性违约（Proof 与交付物不符、Closeout 发现证据链断裂）。升级保留全部现场，决策权交人工。
+
+## 5. Human Decision 与 Human Acceptance 边界
+
+### 5.1 概念边界（对齐 #72）
+
+| 维度 | Human Decision（受控人工决策） | Human Acceptance（人工验收） |
+|---|---|---|
+| 回答的问题 | 系统不能替用户做的**方向取舍**：选哪个选项、如何处理 | 交付成果**是否通过/完成** |
+| 在主链中的位置 | Stage 内的门（非独立业务节点）：requirements 的固定确认门、design 的条件门、额度耗尽等升级门 | 主链第六阶段的固定业务节点 |
+| 触发 | 固定门必然触发；条件门命中判据才触发；升级时必然触发 | 到达即触发，唯一且必须 |
+| 记录 | Decision Record（不可覆盖），注明选项与理由 | Acceptance Proof（验收人/结论/时间/HEAD） |
+| 打回语义 | 结果枚举如 `BASELINE_UPDATED`：目标/范围/硬要求改变 → 回 Requirements 生成新 Revision | reject 打回，按 feedback 根因路由 |
+| 挂起表现 | WAITING_HUMAN（持久化要求见 #72，映射见 §7/§8） | WAITING_HUMAN |
+
+### 5.2 Design 条件门判据
+
+`decision_required=true` 当且仅当命中下列之一（Role 报告命中情况，Controller 据此挂起，不重估专业判断）：
+
+1. 存在多个可行方案且权衡实质（成本/风险/架构方向），又无既有决策或契约可引用；
+2. 方案引入新的对外契约、新依赖或破坏性变更；
+3. 方案与既有决策/契约冲突，或需要推翻既有决策；
+4. 出现安全、数据、权限等高风险面的新决策点。
+
+未命中 → 自动推进，不打扰用户（#72：默认自动推进，不得因一般不确定性随意升级）。
+
+### 5.3 决策包要求
+
+任何 Human Decision 必须向决策者提供：目标、当前状态、决策点、候选项、各选项的成本/收益/风险/影响、推荐理由（对齐 #72）。决策缺失或超时 → 保持挂起，**不得由 AI 代答**。
+
+### 5.4 禁止事项
+
+- 禁止 AI 代签 Decision Record 或 Acceptance Proof；
+- 禁止改写 baseline / Outcome 制造 PASS（含用 `USER_ACCEPTED` 以外的任何方式表达「知情接受」）；
+- 禁止把本应回 Requirements 的范围变更当作 Design/Dev 内部决策处理（Human Decision ≠ 修改 Baseline）；
+- 禁止将 Acceptance 当 Decision 用（跳过验收直接做方向裁决），或反之。
+
+## 6. Outcome / Routing 兼容原则
+
+### 6.1 Producer / Router 分离
+
+- **Role = Outcome Producer**：只报告本 Stage 专业结果（结论、findings、根因分类、证据）；
+- **Controller = Router**：解析专业结果，依 §3/§4 决定前进、回退、挂起、升级；
+- **Role 不得输出 `next_node` 或任何拓扑目标字段**；路由意图只能由 Controller 判定。
+
+### 6.2 专业结果与流程状态两层分离
+
+- 合法的非 PASS 专业结果（review 的 request-changes、test 的失败项、design 的 decision_required）**不是 failure**，不得为适配执行器状态机而篡改；
+- 技术执行失败（会话崩溃、工具不可用）与业务结果区分记录；
+- 专业结果（Node Result）是权威事实源；Run 层只镜像 Completion 摘要（对齐 #77）。
+
+### 6.3 本契约的专业结果基元
+
+建设主链各 Stage 的专业结果必须可归纳为以下基元（Bootstrap 期间 Controller 可用自有枚举表达，但必须可无歧义映射）：
+
+| Stage | 专业结果基元 |
+|---|---|
+| requirements | baseline-ready（待人工确认）/ awaiting-human-input（缺口挂起）/ revised |
+| design | package-ready / decision-required / requirements-issue（根因回退报告） |
+| dev | handoff-ready / blocked（受阻说明）/ design-issue / requirements-issue |
+| review | approve / request-changes（逐条 finding 带根因分类） |
+| test | pass / fail（逐项带根因分类）/ blocked |
+| human acceptance | （人工）accept / reject / user-accepted |
+| closeout | delivered |
+
+### 6.4 路由动作基元
+
+Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, <root-cause>)`（回退，受额度约束）/ `await-human(<reason>)`（挂起）/ `escalate`（升级）。额度耗尽时 `rollback` 不可用，唯一出路是 `await-human(MAX_ROUNDS_REACHED)`。
+
+### 6.5 悬空禁止
+
+每个可路由的专业结果都必须有明确去向（前进、回退、挂起、升级之一），不得出现「规格提到了结果，但没有任何 route」的悬空状态（对齐 #77）。
+
+### 6.6 与 #77 正式 Runtime 的收敛
+
+#77（Business Outcome Routing 与 Completion Mapping）落地后：
+
+- §6.3/§6.4 的基元映射为正式 Outcome field path + route + `countRound` 声明（是否消耗额度，对齐 #73）；
+- 字段命名以 #77 实现为权威，本契约只保留产品语义；
+- 映射必须完整且不丢历史（Bootstrap 期间的 Run 记录仍可追溯）。
+
+---
+
+## 7. Portable Run / Workspace Contract
+
+> **由 #113 填充**：portable run identity 最小字段集、ISOLATED_WRITE workspace 规则、worktree/branch/HEAD 约束、Integration Checkpoint、与 #93/#79 的映射兼容声明。
+
+## 8. Portable Handoff / Evidence Package
+
+> **由 #113 填充**：七类交接/证据包（requirements baseline / design package / dev handoff / review proof / test proof / acceptance package / closeout summary）的统一 schema、示例、与 #78 Formal Records 的映射承诺。
+
+## 9. 一致性矩阵、引用规范与冻结
+
+> **由 #114 填充**：与 #71/#77/#72/#73/#78/#93 的逐项一致性矩阵、双 Profile 引用规范条款、冻结版本标记与修订规则。

--- a/docs/design/construction-workflow-portable-contract.md
+++ b/docs/design/construction-workflow-portable-contract.md
@@ -302,7 +302,7 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 | 字段 | 语义 |
 |---|---|
 | `record_type` | 七者之一 |
-| `record_version` | 记录 schema 版本（当前 v0.1.1） |
+| `record_version` | 记录 schema 版本（当前 v0.1.2） |
 | `created_at` | ISO 8601 时间 |
 | `produced_by` | 产生者 Role/会话标识 |
 | `run` | §7.1 portable run identity 全量内嵌 |
@@ -314,11 +314,11 @@ Controller 的路由动作限定为：`proceed`（前进）/ `rollback(<stage>, 
 必选/可选字段以 §8.4 schema 为准；语义要点：
 
 - **requirements_baseline**：三要素 + `gaps`（缺失必须显式，不得编造）+ 澄清决策 + 状态机 `draft` → `confirmed`（`confirmed` 必须含 `baseline_revision` 与人工确认记录；`draft` 不得作为下游冻结输入）；
-- **design_package**：summary + `decision_required` 标记；`decision_required=true` 必须附非空 `decision_required_reasons`（§5.2）；Decision Record 只能出现在命中条件门的 package 上，Controller 在 `decision_required=true` 且无 Decision Record 时必须挂起（§5.2），不得放行；
-- **dev_handoff**：改动摘要 + **整体 `outcome`**（`handoff_ready` / `blocked` / `design_issue` / `requirements_issue`，§6.3 基元）+ 自验清单；`outcome=blocked` 必须附 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定）；`design_issue`/`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
+- **design_package**：summary + **整体 `outcome`**（`package_ready` / `decision_required` / `requirements_issue`，§6.3 基元）+ `decision_required` 标记；`outcome=decision_required` ⇔ `decision_required=true`（双向 schema 约束）且必须附非空 `decision_required_reasons`（§5.2）；Decision Record 只能出现在命中条件门的 package 上，Controller 在 `decision_required=true` 且无 Decision Record 时必须挂起（§5.2），不得放行；
+- **dev_handoff**：改动摘要 + **整体 `outcome`**（`handoff_ready` / `blocked` / `design_issue` / `requirements_issue`，§6.3 基元）+ 自验清单；`outcome=blocked` 必须附 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定）；`outcome=handoff_ready` 要求自验清单非空且无 fail/blocked 项（§3.3 完成判定）；`design_issue`/`requirements_issue` 为根因上报，由 Controller 按 §4.1 路由；
 - **review_proof / test_proof**：结论 + 逐项 findings（带根因分类 dev/design/requirements，§4.1）+ `verified_branch`/`verified_head` + `independent_session=true`（不变量 2，review 与 test 同样要求）；条件约束：`request_changes`/`fail` 必须至少含一条 finding；`pass` 必须带非空且逐项全 pass 的验收映射；`blocked` 必须带 `blocked_reason`（供 `hold(<reason>)` 路由与恢复判定，§6.4）；
 - **acceptance_package**：`assembled`（**五类前置记录引用**：baseline / design package / dev handoff / review proof / test proof + checkpoint 结果）+ 人工决策状态机（`awaiting_decision` → `decided`，两态字段互斥；`decided` 必含 `verified_branch`/`verified_head`；`reject` 必含 `feedback` 与 `rejection_root_cause`；AI 不得代签）；
-- **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包，Controller 归档前校验）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。
+- **closeout_summary**：交付清单 + 集成结果（PR / merge commit 至少其一）+ **`acceptance_package_ref`（必须指向已 `decided` 的验收包）** + `acceptance_outcome`（保留 `user_accepted` 异常到收口）+ `records_retained=true`。Controller 归档前双重校验：① 引用包 `status=decided`；② 引用包 `decision` ∈ {`accept`, `user_accepted`} 且与 `acceptance_outcome` 一致——引用包 `decision=reject` 时**不得归档**，按 §3.6 打回根因路由。
 
 ### 8.4 Schema、示例与机械校验
 
@@ -374,7 +374,7 @@ Closeout 归档时，七类记录与全部 Proof 必须保留并可按 `run_id` 
 |---|---|---|---|
 | v0.1 | 2026-08-30 | 初版冻结：主链语义、Run/Workspace、七类交接包、一致性矩阵 | #112 #113 #114 |
 | v0.1.1 | 2026-08-30 | Codex Review 修复：`blocked` 路由（`hold` → Run `BLOCKED`）、`USER_ACCEPTED` 保留到 closeout、多根因单边回退计数、schema 九处条件收紧、示例链一致性修正 | PR #115 Review |
-| v0.1.2 | 2026-08-30 | Codex Review 修复（二）：dev_handoff 增加整体 `outcome` 与 `blocked_reason` 条件、closeout 引用必须指向 decided 验收包的示例链修正、`record_type`↔`run.stage` 绑定、design 条件门双向约束 | PR #115 Review |
+| v0.1.2 | 2026-08-30 | Codex Review 修复（二/三）：dev/design 增加整体 `outcome` 基元与一致性双向约束、`handoff_ready` 自验非空约束、closeout 引用决策一致性规则、`record_type`↔`run.stage` 绑定、示例链 decided 修正 | PR #115 Review |
 
 ### 9.4 #103 九条验收清单证据映射
 

--- a/docs/design/construction-workflow/examples/01-requirements-baseline.json
+++ b/docs/design/construction-workflow/examples/01-requirements-baseline.json
@@ -1,6 +1,6 @@
 {
   "record_type": "requirements_baseline",
-  "record_version": "v0.1.6",
+  "record_version": "v0.1.7",
   "created_at": "2026-08-30T06:30:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/01-requirements-baseline.json
+++ b/docs/design/construction-workflow/examples/01-requirements-baseline.json
@@ -1,6 +1,6 @@
 {
   "record_type": "requirements_baseline",
-  "record_version": "v0.1.5",
+  "record_version": "v0.1.6",
   "created_at": "2026-08-30T06:30:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/01-requirements-baseline.json
+++ b/docs/design/construction-workflow/examples/01-requirements-baseline.json
@@ -1,6 +1,6 @@
 {
   "record_type": "requirements_baseline",
-  "record_version": "v0.1.7",
+  "record_version": "v0.1.8",
   "created_at": "2026-08-30T06:30:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/01-requirements-baseline.json
+++ b/docs/design/construction-workflow/examples/01-requirements-baseline.json
@@ -1,6 +1,6 @@
 {
   "record_type": "requirements_baseline",
-  "record_version": "v0.1",
+  "record_version": "v0.1.1",
   "created_at": "2026-08-30T06:30:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {
@@ -47,6 +47,11 @@
         "decision": "#103 显式授权实现期结合仓库现状确定"
       }
     ],
-    "baseline_revision": "v1"
+    "status": "confirmed",
+    "baseline_revision": "v1",
+    "human_confirmation": {
+      "confirmed_by": "crystepj-max",
+      "confirmed_at": "2026-08-30T07:05:00Z"
+    }
   }
 }

--- a/docs/design/construction-workflow/examples/01-requirements-baseline.json
+++ b/docs/design/construction-workflow/examples/01-requirements-baseline.json
@@ -1,6 +1,6 @@
 {
   "record_type": "requirements_baseline",
-  "record_version": "v0.1.3",
+  "record_version": "v0.1.4",
   "created_at": "2026-08-30T06:30:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/01-requirements-baseline.json
+++ b/docs/design/construction-workflow/examples/01-requirements-baseline.json
@@ -1,6 +1,6 @@
 {
   "record_type": "requirements_baseline",
-  "record_version": "v0.1.2",
+  "record_version": "v0.1.3",
   "created_at": "2026-08-30T06:30:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {
@@ -37,6 +37,7 @@
       "Design 自动推进 vs 条件式 Human Decision 判据明确"
     ],
     "gaps": [],
+    "outcome": "baseline_ready",
     "clarification_decisions": [
       {
         "topic": "主链语义决断",

--- a/docs/design/construction-workflow/examples/01-requirements-baseline.json
+++ b/docs/design/construction-workflow/examples/01-requirements-baseline.json
@@ -1,6 +1,6 @@
 {
   "record_type": "requirements_baseline",
-  "record_version": "v0.1.1",
+  "record_version": "v0.1.2",
   "created_at": "2026-08-30T06:30:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/01-requirements-baseline.json
+++ b/docs/design/construction-workflow/examples/01-requirements-baseline.json
@@ -1,6 +1,6 @@
 {
   "record_type": "requirements_baseline",
-  "record_version": "v0.1.4",
+  "record_version": "v0.1.5",
   "created_at": "2026-08-30T06:30:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/01-requirements-baseline.json
+++ b/docs/design/construction-workflow/examples/01-requirements-baseline.json
@@ -1,0 +1,52 @@
+{
+  "record_type": "requirements_baseline",
+  "record_version": "v0.1",
+  "created_at": "2026-08-30T06:30:00Z",
+  "produced_by": "dsh:construction-bootstrap",
+  "run": {
+    "run_id": "cwf-103-bootstrap-01",
+    "issue_or_task_identity": "#112",
+    "workspace_id": "wt-dev-102serias",
+    "repository": "crystepj-max/workflow-manager",
+    "base_ref": "main",
+    "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+    "work_branch": "dev-#102serias",
+    "current_head": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+    "stage": "requirements",
+    "attempt": 1
+  },
+  "payload": {
+    "goal": "产出一文档形式冻结的建设·完整功能开发 Portable Contract，作为 DSH Profile 与 External Profile 的共同唯一业务语义源",
+    "scope": {
+      "include": [
+        "docs/design/construction-workflow-portable-contract.md 契约正文",
+        "共享 handoff schema 与示例"
+      ],
+      "exclude": [
+        "DSH Runtime 实现 / #105 Profile",
+        "External Profile runbook（#104）",
+        "templates/*.json 蓝图与生成产物",
+        "legacy dev-workflow-2-0 改名复用"
+      ]
+    },
+    "acceptance": [
+      "7 阶段逐一覆盖，每阶段含输入/专业输出/Proof/回退根因",
+      "Human Acceptance 与 Human Decision 边界明确",
+      "回退语义：默认额度 3、按根因回节点、耗尽升级人工、不篡改专业结果",
+      "Outcome/Routing 兼容原则成文",
+      "Design 自动推进 vs 条件式 Human Decision 判据明确"
+    ],
+    "gaps": [],
+    "clarification_decisions": [
+      {
+        "topic": "主链语义决断",
+        "decision": "由父 epic #102 A1–A5 预先做出，本 Run 无需重新决断"
+      },
+      {
+        "topic": "文件布局",
+        "decision": "#103 显式授权实现期结合仓库现状确定"
+      }
+    ],
+    "baseline_revision": "v1"
+  }
+}

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "design_package",
-  "record_version": "v0.1.5",
+  "record_version": "v0.1.6",
   "created_at": "2026-08-30T06:45:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "design_package",
-  "record_version": "v0.1.2",
+  "record_version": "v0.1.3",
   "created_at": "2026-08-30T06:45:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "design_package",
-  "record_version": "v0.1.7",
+  "record_version": "v0.1.8",
   "created_at": "2026-08-30T06:45:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "design_package",
-  "record_version": "v0.1.1",
+  "record_version": "v0.1.2",
   "created_at": "2026-08-30T06:45:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -1,0 +1,34 @@
+{
+  "record_type": "design_package",
+  "record_version": "v0.1",
+  "created_at": "2026-08-30T06:45:00Z",
+  "produced_by": "dsh:construction-bootstrap",
+  "run": {
+    "run_id": "cwf-103-bootstrap-01",
+    "issue_or_task_identity": "#112",
+    "workspace_id": "wt-dev-102serias",
+    "repository": "crystepj-max/workflow-manager",
+    "base_ref": "main",
+    "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+    "work_branch": "dev-#102serias",
+    "current_head": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+    "stage": "design",
+    "attempt": 1
+  },
+  "payload": {
+    "summary": "契约文档按 §0 定位 / §1 术语 / §2 主链不变量 / §3 Stage 四要素 / §4 回退升级 / §5 人工门边界 / §6 Outcome-Routing 兼容组织；§7–§9 稳定占位给 #113/#114",
+    "affected_modules": [
+      "docs/design/construction-workflow-portable-contract.md"
+    ],
+    "risks": [
+      "与 legacy dev-workflow-2-0 语义混淆（已用 §0 显式切割）",
+      "额度耗尽语义若沿用 legacy FAILED_MAX_ROUNDS 将与 #73 冲突（已采用 WAITING_HUMAN）"
+    ],
+    "open_questions": [],
+    "decision_required": false,
+    "decision_required_reasons": [
+      "主链决断已由 #102 A1–A5 预先做出",
+      "文件布局由 #103 授权实现期确定，属执行自由度而非方向取舍"
+    ]
+  }
+}

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "design_package",
-  "record_version": "v0.1.4",
+  "record_version": "v0.1.5",
   "created_at": "2026-08-30T06:45:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "design_package",
-  "record_version": "v0.1.6",
+  "record_version": "v0.1.7",
   "created_at": "2026-08-30T06:45:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "design_package",
-  "record_version": "v0.1",
+  "record_version": "v0.1.1",
   "created_at": "2026-08-30T06:45:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -17,6 +17,7 @@
   },
   "payload": {
     "summary": "契约文档按 §0 定位 / §1 术语 / §2 主链不变量 / §3 Stage 四要素 / §4 回退升级 / §5 人工门边界 / §6 Outcome-Routing 兼容组织；§7–§9 稳定占位给 #113/#114",
+    "outcome": "package_ready",
     "affected_modules": [
       "docs/design/construction-workflow-portable-contract.md"
     ],

--- a/docs/design/construction-workflow/examples/02-design-package.json
+++ b/docs/design/construction-workflow/examples/02-design-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "design_package",
-  "record_version": "v0.1.3",
+  "record_version": "v0.1.4",
   "created_at": "2026-08-30T06:45:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -1,6 +1,6 @@
 {
   "record_type": "dev_handoff",
-  "record_version": "v0.1",
+  "record_version": "v0.1.1",
   "created_at": "2026-08-30T07:10:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -11,23 +11,32 @@
     "base_ref": "main",
     "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
     "work_branch": "dev-#102serias",
-    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "current_head": "c8d86254b963435bae107c9259ac2145cf04ef82",
     "stage": "dev",
-    "attempt": 1
+    "attempt": 2
   },
   "payload": {
-    "summary": "落地 Portable Contract v0.1-draft §0–§6（主链 Stage 语义与回退/路由原则），提交 2b5a7c7",
+    "summary": "落地 Portable Contract v0.1.1 全量（#112 §0–§6、#113 §7–§8 + schema/示例、#114 §9 一致性矩阵与冻结、PR #115 Review 修复），最终提交 c8d8625",
     "changes": [
       {
         "area": "docs/design/construction-workflow-portable-contract.md",
-        "description": "新增 250 行：固定主链与六条不变量、7 Stage 四要素、根因路由与回退额度 3、WAITING_HUMAN 耗尽语义、Decision/Acceptance 边界、Design 条件门判据、Outcome/Routing 兼容原则，§7–§9 骨架占位"
+        "description": "契约正文 v0.1.1：固定主链与不变量、7 Stage 四要素、根因路由与单边回退额度 3、WAITING_HUMAN 耗尽语义、hold/BLOCKED 路由、Decision/Acceptance 边界、Outcome/Routing 兼容、Run/Workspace、七类交接包、一致性矩阵与引用规范、冻结"
+      },
+      {
+        "area": "docs/design/construction-workflow/handoff.schema.json",
+        "description": "七类交接包统一 schema v0.1.1：draft-07，含 13 处条件收紧（独立会话、五类前置引用、状态机互斥、pass/fail/blocked 条件、record_type↔stage 绑定等）"
+      },
+      {
+        "area": "docs/design/construction-workflow/examples/",
+        "description": "七类示例各一，取材本 Run 真实场景，绑定 v0.1.1 完成点 HEAD"
       }
     ],
     "self_check": [
       { "check": "7 Stage × 四要素覆盖脚本核验", "result": "pass" },
       { "check": "章节结构 §0–§9 完整性核验", "result": "pass" },
+      { "check": "schema 机械校验：7 正例 valid + 16 负例全部 invalid（ajv-cli，精确匹配）", "result": "pass" },
       { "check": "npm run generate / npm run validate", "result": "not_applicable" }
     ],
-    "notes": "纯文档变更，未修改蓝图与生成规则"
+    "notes": "纯文档变更，未修改蓝图与生成规则；attempt 2 = PR #115 首轮 Review 打回后的修复轮"
   }
 }

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -1,6 +1,6 @@
 {
   "record_type": "dev_handoff",
-  "record_version": "v0.1.3",
+  "record_version": "v0.1.4",
   "created_at": "2026-08-30T07:10:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -1,6 +1,6 @@
 {
   "record_type": "dev_handoff",
-  "record_version": "v0.1.4",
+  "record_version": "v0.1.5",
   "created_at": "2026-08-30T07:10:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -1,6 +1,6 @@
 {
   "record_type": "dev_handoff",
-  "record_version": "v0.1.5",
+  "record_version": "v0.1.6",
   "created_at": "2026-08-30T07:10:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -1,6 +1,6 @@
 {
   "record_type": "dev_handoff",
-  "record_version": "v0.1.6",
+  "record_version": "v0.1.7",
   "created_at": "2026-08-30T07:10:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -1,6 +1,6 @@
 {
   "record_type": "dev_handoff",
-  "record_version": "v0.1.2",
+  "record_version": "v0.1.3",
   "created_at": "2026-08-30T07:10:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -1,6 +1,6 @@
 {
   "record_type": "dev_handoff",
-  "record_version": "v0.1.1",
+  "record_version": "v0.1.2",
   "created_at": "2026-08-30T07:10:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {
@@ -17,6 +17,7 @@
   },
   "payload": {
     "summary": "落地 Portable Contract v0.1.1 全量（#112 §0–§6、#113 §7–§8 + schema/示例、#114 §9 一致性矩阵与冻结、PR #115 Review 修复），最终提交 c8d8625",
+    "outcome": "handoff_ready",
     "changes": [
       {
         "area": "docs/design/construction-workflow-portable-contract.md",

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -1,6 +1,6 @@
 {
   "record_type": "dev_handoff",
-  "record_version": "v0.1.7",
+  "record_version": "v0.1.8",
   "created_at": "2026-08-30T07:10:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/03-dev-handoff.json
+++ b/docs/design/construction-workflow/examples/03-dev-handoff.json
@@ -1,0 +1,33 @@
+{
+  "record_type": "dev_handoff",
+  "record_version": "v0.1",
+  "created_at": "2026-08-30T07:10:00Z",
+  "produced_by": "dsh:construction-bootstrap",
+  "run": {
+    "run_id": "cwf-103-bootstrap-01",
+    "issue_or_task_identity": "#112",
+    "workspace_id": "wt-dev-102serias",
+    "repository": "crystepj-max/workflow-manager",
+    "base_ref": "main",
+    "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+    "work_branch": "dev-#102serias",
+    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "stage": "dev",
+    "attempt": 1
+  },
+  "payload": {
+    "summary": "落地 Portable Contract v0.1-draft §0–§6（主链 Stage 语义与回退/路由原则），提交 2b5a7c7",
+    "changes": [
+      {
+        "area": "docs/design/construction-workflow-portable-contract.md",
+        "description": "新增 250 行：固定主链与六条不变量、7 Stage 四要素、根因路由与回退额度 3、WAITING_HUMAN 耗尽语义、Decision/Acceptance 边界、Design 条件门判据、Outcome/Routing 兼容原则，§7–§9 骨架占位"
+      }
+    ],
+    "self_check": [
+      { "check": "7 Stage × 四要素覆盖脚本核验", "result": "pass" },
+      { "check": "章节结构 §0–§9 完整性核验", "result": "pass" },
+      { "check": "npm run generate / npm run validate", "result": "not_applicable" }
+    ],
+    "notes": "纯文档变更，未修改蓝图与生成规则"
+  }
+}

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "review_proof",
-  "record_version": "v0.1.5",
+  "record_version": "v0.1.6",
   "created_at": "2026-08-30T07:30:00Z",
   "produced_by": "external:codex-reviewer",
   "run": {

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "review_proof",
-  "record_version": "v0.1.2",
+  "record_version": "v0.1.3",
   "created_at": "2026-08-30T07:30:00Z",
   "produced_by": "external:codex-reviewer",
   "run": {

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -11,15 +11,15 @@
     "base_ref": "main",
     "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
     "work_branch": "dev-#102serias",
-    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "current_head": "c8d86254b963435bae107c9259ac2145cf04ef82",
     "stage": "review",
-    "attempt": 1
+    "attempt": 2
   },
   "payload": {
     "verdict": "approve",
     "findings": [],
     "verified_branch": "dev-#102serias",
-    "verified_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "verified_head": "c8d86254b963435bae107c9259ac2145cf04ef82",
     "independent_session": true
   }
 }

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "review_proof",
-  "record_version": "v0.1.3",
+  "record_version": "v0.1.4",
   "created_at": "2026-08-30T07:30:00Z",
   "produced_by": "external:codex-reviewer",
   "run": {

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -1,0 +1,30 @@
+{
+  "record_type": "review_proof",
+  "record_version": "v0.1",
+  "created_at": "2026-08-30T07:30:00Z",
+  "produced_by": "external:codex-reviewer",
+  "run": {
+    "run_id": "cwf-103-bootstrap-01",
+    "issue_or_task_identity": "#112",
+    "workspace_id": "wt-dev-102serias",
+    "repository": "crystepj-max/workflow-manager",
+    "base_ref": "main",
+    "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+    "work_branch": "dev-#102serias",
+    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "stage": "review",
+    "attempt": 1
+  },
+  "payload": {
+    "verdict": "request_changes",
+    "findings": [
+      {
+        "finding": "§4.2 计数原则中「同一 findings 多根因拆分路由」的额度消耗描述与 §4.1 表格未互相引用，易误读",
+        "root_cause": "dev"
+      }
+    ],
+    "verified_branch": "dev-#102serias",
+    "verified_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "independent_session": true
+  }
+}

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "review_proof",
-  "record_version": "v0.1.6",
+  "record_version": "v0.1.7",
   "created_at": "2026-08-30T07:30:00Z",
   "produced_by": "external:codex-reviewer",
   "run": {

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "review_proof",
-  "record_version": "v0.1.1",
+  "record_version": "v0.1.2",
   "created_at": "2026-08-30T07:30:00Z",
   "produced_by": "external:codex-reviewer",
   "run": {

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "review_proof",
-  "record_version": "v0.1.7",
+  "record_version": "v0.1.8",
   "created_at": "2026-08-30T07:30:00Z",
   "produced_by": "external:codex-reviewer",
   "run": {

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "review_proof",
-  "record_version": "v0.1.4",
+  "record_version": "v0.1.5",
   "created_at": "2026-08-30T07:30:00Z",
   "produced_by": "external:codex-reviewer",
   "run": {

--- a/docs/design/construction-workflow/examples/04-review-proof.json
+++ b/docs/design/construction-workflow/examples/04-review-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "review_proof",
-  "record_version": "v0.1",
+  "record_version": "v0.1.1",
   "created_at": "2026-08-30T07:30:00Z",
   "produced_by": "external:codex-reviewer",
   "run": {
@@ -16,13 +16,8 @@
     "attempt": 1
   },
   "payload": {
-    "verdict": "request_changes",
-    "findings": [
-      {
-        "finding": "§4.2 计数原则中「同一 findings 多根因拆分路由」的额度消耗描述与 §4.1 表格未互相引用，易误读",
-        "root_cause": "dev"
-      }
-    ],
+    "verdict": "approve",
+    "findings": [],
     "verified_branch": "dev-#102serias",
     "verified_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
     "independent_session": true

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -11,23 +11,25 @@
     "base_ref": "main",
     "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
     "work_branch": "dev-#102serias",
-    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "current_head": "c8d86254b963435bae107c9259ac2145cf04ef82",
     "stage": "test",
-    "attempt": 1
+    "attempt": 2
   },
   "payload": {
     "verdict": "pass",
     "acceptance_mapping": [
       { "acceptance_item": "7 阶段逐一覆盖且每阶段含四要素", "result": "pass" },
       { "acceptance_item": "Decision/Acceptance 边界明确", "result": "pass" },
-      { "acceptance_item": "回退语义（额度 3/根因路由/耗尽升级/不篡改）成文", "result": "pass" },
-      { "acceptance_item": "Outcome/Routing 兼容原则成文", "result": "pass" },
+      { "acceptance_item": "回退语义（额度 3/单边根因路由/耗尽升级/不篡改）成文", "result": "pass" },
+      { "acceptance_item": "Outcome/Routing 兼容原则（含 blocked→hold 路由）成文", "result": "pass" },
       { "acceptance_item": "Design 条件门判据明确", "result": "pass" },
-      { "acceptance_item": "根因分回 Requirements/Design/Dev 的规则成文", "result": "pass" }
+      { "acceptance_item": "Run/Workspace 契约与七类交接包 schema 成文且机械校验通过", "result": "pass" },
+      { "acceptance_item": "一致性矩阵、引用规范与冻结条款完整", "result": "pass" }
     ],
     "findings": [],
-    "environment": "workspace .scratch/worktrees/dev-#102serias @ 2b5a7c7，结构核验脚本",
+    "environment": "workspace .scratch/worktrees/dev-#102serias @ c8d8625，结构核验脚本 + ajv-cli 正负例校验",
     "verified_branch": "dev-#102serias",
-    "verified_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d"
+    "verified_head": "c8d86254b963435bae107c9259ac2145cf04ef82",
+    "independent_session": true
   }
 }

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "test_proof",
-  "record_version": "v0.1.4",
+  "record_version": "v0.1.5",
   "created_at": "2026-08-30T07:45:00Z",
   "produced_by": "external:cursor-tester",
   "run": {

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "test_proof",
-  "record_version": "v0.1.7",
+  "record_version": "v0.1.8",
   "created_at": "2026-08-30T07:45:00Z",
   "produced_by": "external:cursor-tester",
   "run": {

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "test_proof",
-  "record_version": "v0.1",
+  "record_version": "v0.1.1",
   "created_at": "2026-08-30T07:45:00Z",
   "produced_by": "external:cursor-tester",
   "run": {

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "test_proof",
-  "record_version": "v0.1.1",
+  "record_version": "v0.1.2",
   "created_at": "2026-08-30T07:45:00Z",
   "produced_by": "external:cursor-tester",
   "run": {

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "test_proof",
-  "record_version": "v0.1.3",
+  "record_version": "v0.1.4",
   "created_at": "2026-08-30T07:45:00Z",
   "produced_by": "external:cursor-tester",
   "run": {

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "test_proof",
-  "record_version": "v0.1.6",
+  "record_version": "v0.1.7",
   "created_at": "2026-08-30T07:45:00Z",
   "produced_by": "external:cursor-tester",
   "run": {

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -1,0 +1,33 @@
+{
+  "record_type": "test_proof",
+  "record_version": "v0.1",
+  "created_at": "2026-08-30T07:45:00Z",
+  "produced_by": "external:cursor-tester",
+  "run": {
+    "run_id": "cwf-103-bootstrap-01",
+    "issue_or_task_identity": "#112",
+    "workspace_id": "wt-dev-102serias",
+    "repository": "crystepj-max/workflow-manager",
+    "base_ref": "main",
+    "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+    "work_branch": "dev-#102serias",
+    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "stage": "test",
+    "attempt": 1
+  },
+  "payload": {
+    "verdict": "pass",
+    "acceptance_mapping": [
+      { "acceptance_item": "7 阶段逐一覆盖且每阶段含四要素", "result": "pass" },
+      { "acceptance_item": "Decision/Acceptance 边界明确", "result": "pass" },
+      { "acceptance_item": "回退语义（额度 3/根因路由/耗尽升级/不篡改）成文", "result": "pass" },
+      { "acceptance_item": "Outcome/Routing 兼容原则成文", "result": "pass" },
+      { "acceptance_item": "Design 条件门判据明确", "result": "pass" },
+      { "acceptance_item": "根因分回 Requirements/Design/Dev 的规则成文", "result": "pass" }
+    ],
+    "findings": [],
+    "environment": "workspace .scratch/worktrees/dev-#102serias @ 2b5a7c7，结构核验脚本",
+    "verified_branch": "dev-#102serias",
+    "verified_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d"
+  }
+}

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "test_proof",
-  "record_version": "v0.1.2",
+  "record_version": "v0.1.3",
   "created_at": "2026-08-30T07:45:00Z",
   "produced_by": "external:cursor-tester",
   "run": {

--- a/docs/design/construction-workflow/examples/05-test-proof.json
+++ b/docs/design/construction-workflow/examples/05-test-proof.json
@@ -1,6 +1,6 @@
 {
   "record_type": "test_proof",
-  "record_version": "v0.1.5",
+  "record_version": "v0.1.6",
   "created_at": "2026-08-30T07:45:00Z",
   "produced_by": "external:cursor-tester",
   "run": {

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -11,7 +11,7 @@
     "base_ref": "main",
     "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
     "work_branch": "dev-#102serias",
-    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "current_head": "c8d86254b963435bae107c9259ac2145cf04ef82",
     "stage": "human_acceptance",
     "attempt": 1
   },

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "acceptance_package",
-  "record_version": "v0.1.6",
+  "record_version": "v0.1.7",
   "created_at": "2026-08-30T08:00:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {
@@ -23,7 +23,13 @@
       "dev_handoff_ref": "examples/03-dev-handoff.json",
       "review_proof_ref": "examples/04-review-proof.json",
       "test_proof_ref": "examples/05-test-proof.json",
-      "integration_checkpoint": "PR #115 target=main，base_commit 为 target 祖先最新状态，无需重跑 Proof"
+      "integration_checkpoint": {
+        "target_ref": "main",
+        "target_head_at_check": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+        "target_advanced": false,
+        "proofs_state": "still_valid",
+        "notes": "PR #115 target=main，base_commit 为 target 祖先最新状态，无需重跑 Proof"
+      }
     },
     "decision": "accept",
     "decided_by": "human:maintainer",

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "acceptance_package",
-  "record_version": "v0.1",
+  "record_version": "v0.1.1",
   "created_at": "2026-08-30T08:00:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {
@@ -18,6 +18,9 @@
   "payload": {
     "status": "awaiting_decision",
     "assembled": {
+      "requirements_baseline_ref": "examples/01-requirements-baseline.json",
+      "design_package_ref": "examples/02-design-package.json",
+      "dev_handoff_ref": "examples/03-dev-handoff.json",
       "review_proof_ref": "examples/04-review-proof.json",
       "test_proof_ref": "examples/05-test-proof.json",
       "integration_checkpoint": "PR #115 target=main，base_commit 为 target 祖先最新状态，无需重跑 Proof"

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "acceptance_package",
-  "record_version": "v0.1.2",
+  "record_version": "v0.1.3",
   "created_at": "2026-08-30T08:00:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "acceptance_package",
-  "record_version": "v0.1.3",
+  "record_version": "v0.1.4",
   "created_at": "2026-08-30T08:00:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "acceptance_package",
-  "record_version": "v0.1.1",
+  "record_version": "v0.1.2",
   "created_at": "2026-08-30T08:00:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {
@@ -16,7 +16,7 @@
     "attempt": 1
   },
   "payload": {
-    "status": "awaiting_decision",
+    "status": "decided",
     "assembled": {
       "requirements_baseline_ref": "examples/01-requirements-baseline.json",
       "design_package_ref": "examples/02-design-package.json",
@@ -24,6 +24,11 @@
       "review_proof_ref": "examples/04-review-proof.json",
       "test_proof_ref": "examples/05-test-proof.json",
       "integration_checkpoint": "PR #115 target=main，base_commit 为 target 祖先最新状态，无需重跑 Proof"
-    }
+    },
+    "decision": "accept",
+    "decided_by": "human:maintainer",
+    "decided_at": "2026-08-30T08:05:00Z",
+    "verified_branch": "dev-#102serias",
+    "verified_head": "c8d86254b963435bae107c9259ac2145cf04ef82"
   }
 }

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -1,0 +1,26 @@
+{
+  "record_type": "acceptance_package",
+  "record_version": "v0.1",
+  "created_at": "2026-08-30T08:00:00Z",
+  "produced_by": "dsh:construction-bootstrap",
+  "run": {
+    "run_id": "cwf-103-bootstrap-01",
+    "issue_or_task_identity": "#112",
+    "workspace_id": "wt-dev-102serias",
+    "repository": "crystepj-max/workflow-manager",
+    "base_ref": "main",
+    "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+    "work_branch": "dev-#102serias",
+    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "stage": "human_acceptance",
+    "attempt": 1
+  },
+  "payload": {
+    "status": "awaiting_decision",
+    "assembled": {
+      "review_proof_ref": "examples/04-review-proof.json",
+      "test_proof_ref": "examples/05-test-proof.json",
+      "integration_checkpoint": "PR #115 target=main，base_commit 为 target 祖先最新状态，无需重跑 Proof"
+    }
+  }
+}

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "acceptance_package",
-  "record_version": "v0.1.4",
+  "record_version": "v0.1.5",
   "created_at": "2026-08-30T08:00:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "acceptance_package",
-  "record_version": "v0.1.7",
+  "record_version": "v0.1.8",
   "created_at": "2026-08-30T08:00:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/06-acceptance-package.json
+++ b/docs/design/construction-workflow/examples/06-acceptance-package.json
@@ -1,6 +1,6 @@
 {
   "record_type": "acceptance_package",
-  "record_version": "v0.1.5",
+  "record_version": "v0.1.6",
   "created_at": "2026-08-30T08:00:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -1,0 +1,33 @@
+{
+  "record_type": "closeout_summary",
+  "record_version": "v0.1",
+  "created_at": "2026-08-30T08:20:00Z",
+  "produced_by": "dsh:construction-bootstrap",
+  "run": {
+    "run_id": "cwf-103-bootstrap-01",
+    "issue_or_task_identity": "#112",
+    "workspace_id": "wt-dev-102serias",
+    "repository": "crystepj-max/workflow-manager",
+    "base_ref": "main",
+    "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
+    "work_branch": "dev-#102serias",
+    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "stage": "closeout",
+    "attempt": 1
+  },
+  "payload": {
+    "deliverables": [
+      "docs/design/construction-workflow-portable-contract.md §0–§6（主链 Stage 语义与回退/路由原则）",
+      "docs/design/construction-workflow/handoff.schema.json",
+      "docs/design/construction-workflow/examples/ 七类示例"
+    ],
+    "integration": {
+      "pr": "#115",
+      "checkpoint": "PR #115 合并前执行 Integration Checkpoint，target 未前进，Proof 无需重跑"
+    },
+    "leftovers": [
+      "#114 一致性矩阵与整文档冻结"
+    ],
+    "records_retained": true
+  }
+}

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -1,6 +1,6 @@
 {
   "record_type": "closeout_summary",
-  "record_version": "v0.1.7",
+  "record_version": "v0.1.8",
   "created_at": "2026-08-30T08:20:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -1,6 +1,6 @@
 {
   "record_type": "closeout_summary",
-  "record_version": "v0.1.6",
+  "record_version": "v0.1.7",
   "created_at": "2026-08-30T08:20:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -1,6 +1,6 @@
 {
   "record_type": "closeout_summary",
-  "record_version": "v0.1.4",
+  "record_version": "v0.1.5",
   "created_at": "2026-08-30T08:20:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -1,6 +1,6 @@
 {
   "record_type": "closeout_summary",
-  "record_version": "v0.1.2",
+  "record_version": "v0.1.3",
   "created_at": "2026-08-30T08:20:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -1,6 +1,6 @@
 {
   "record_type": "closeout_summary",
-  "record_version": "v0.1.1",
+  "record_version": "v0.1.2",
   "created_at": "2026-08-30T08:20:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -1,6 +1,6 @@
 {
   "record_type": "closeout_summary",
-  "record_version": "v0.1",
+  "record_version": "v0.1.1",
   "created_at": "2026-08-30T08:20:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {
@@ -28,6 +28,7 @@
     "leftovers": [
       "#114 一致性矩阵与整文档冻结"
     ],
+    "acceptance_outcome": "accept",
     "records_retained": true
   }
 }

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -1,6 +1,6 @@
 {
   "record_type": "closeout_summary",
-  "record_version": "v0.1.3",
+  "record_version": "v0.1.4",
   "created_at": "2026-08-30T08:20:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -11,23 +11,22 @@
     "base_ref": "main",
     "base_commit": "fc5ce7750fe644b86cba7cbd3914d6a158f41060",
     "work_branch": "dev-#102serias",
-    "current_head": "2b5a7c79a0c3a61392611a363c25062b9074f98d",
+    "current_head": "c8d86254b963435bae107c9259ac2145cf04ef82",
     "stage": "closeout",
     "attempt": 1
   },
   "payload": {
     "deliverables": [
-      "docs/design/construction-workflow-portable-contract.md §0–§6（主链 Stage 语义与回退/路由原则）",
-      "docs/design/construction-workflow/handoff.schema.json",
+      "docs/design/construction-workflow-portable-contract.md（契约全文 v0.1.1，§0–§9）",
+      "docs/design/construction-workflow/handoff.schema.json（v0.1.1）",
       "docs/design/construction-workflow/examples/ 七类示例"
     ],
     "integration": {
       "pr": "#115",
       "checkpoint": "PR #115 合并前执行 Integration Checkpoint，target 未前进，Proof 无需重跑"
     },
-    "leftovers": [
-      "#114 一致性矩阵与整文档冻结"
-    ],
+    "leftovers": [],
+    "acceptance_package_ref": "examples/06-acceptance-package.json",
     "acceptance_outcome": "accept",
     "records_retained": true
   }

--- a/docs/design/construction-workflow/examples/07-closeout-summary.json
+++ b/docs/design/construction-workflow/examples/07-closeout-summary.json
@@ -1,6 +1,6 @@
 {
   "record_type": "closeout_summary",
-  "record_version": "v0.1.5",
+  "record_version": "v0.1.6",
   "created_at": "2026-08-30T08:20:00Z",
   "produced_by": "dsh:construction-bootstrap",
   "run": {

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "docs/design/construction-workflow/handoff.schema.json",
   "title": "Construction Workflow Portable Handoff / Evidence Record",
-  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.7，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
+  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.8，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
   "type": "object",
   "additionalProperties": false,
   "required": ["record_type", "record_version", "created_at", "produced_by", "run", "payload"],
@@ -21,7 +21,7 @@
     },
     "record_version": {
       "description": "记录 schema 版本，与契约版本同步",
-      "const": "v0.1.7"
+      "const": "v0.1.8"
     },
     "created_at": {
       "$ref": "#/definitions/isoDateTime"
@@ -295,7 +295,7 @@
                 "required": ["name", "tradeoffs"],
                 "properties": {
                   "name": { "$ref": "#/definitions/nonEmptyText" },
-                  "tradeoffs": { "type": "string" }
+                  "tradeoffs": { "$ref": "#/definitions/nonEmptyText" }
                 }
               }
             },
@@ -318,7 +318,7 @@
                 "required": ["name", "tradeoffs"],
                 "properties": {
                   "name": { "$ref": "#/definitions/nonEmptyText" },
-                  "tradeoffs": { "type": "string" }
+                  "tradeoffs": { "$ref": "#/definitions/nonEmptyText" }
                 }
               }
             },
@@ -346,8 +346,8 @@
             "properties": { "decision": { "type": "object" } }
           },
           "then": {
-            "description": "Decision Record 只能出现在命中 §5.2 条件门的 package 上",
-            "required": ["decision_required"],
+            "description": "Decision Record 只能出现在命中 §5.2 条件门的 package 上，且必须保留裁决时呈递的 decision_request（chosen 必须属于呈递候选集，契约 §5.3）",
+            "required": ["decision_required", "decision_request"],
             "properties": { "decision_required": { "const": true } }
           }
         },

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -42,49 +42,56 @@
       "required": ["record_type", "payload"],
       "properties": {
         "record_type": { "const": "requirements_baseline" },
-        "payload": { "$ref": "#/definitions/requirementsBaselinePayload" }
+        "payload": { "$ref": "#/definitions/requirementsBaselinePayload" },
+        "run": { "properties": { "stage": { "const": "requirements" } } }
       }
     },
     {
       "required": ["record_type", "payload"],
       "properties": {
         "record_type": { "const": "design_package" },
-        "payload": { "$ref": "#/definitions/designPackagePayload" }
+        "payload": { "$ref": "#/definitions/designPackagePayload" },
+        "run": { "properties": { "stage": { "const": "design" } } }
       }
     },
     {
       "required": ["record_type", "payload"],
       "properties": {
         "record_type": { "const": "dev_handoff" },
-        "payload": { "$ref": "#/definitions/devHandoffPayload" }
+        "payload": { "$ref": "#/definitions/devHandoffPayload" },
+        "run": { "properties": { "stage": { "const": "dev" } } }
       }
     },
     {
       "required": ["record_type", "payload"],
       "properties": {
         "record_type": { "const": "review_proof" },
-        "payload": { "$ref": "#/definitions/reviewProofPayload" }
+        "payload": { "$ref": "#/definitions/reviewProofPayload" },
+        "run": { "properties": { "stage": { "const": "review" } } }
       }
     },
     {
       "required": ["record_type", "payload"],
       "properties": {
         "record_type": { "const": "test_proof" },
-        "payload": { "$ref": "#/definitions/testProofPayload" }
+        "payload": { "$ref": "#/definitions/testProofPayload" },
+        "run": { "properties": { "stage": { "const": "test" } } }
       }
     },
     {
       "required": ["record_type", "payload"],
       "properties": {
         "record_type": { "const": "acceptance_package" },
-        "payload": { "$ref": "#/definitions/acceptancePackagePayload" }
+        "payload": { "$ref": "#/definitions/acceptancePackagePayload" },
+        "run": { "properties": { "stage": { "const": "human_acceptance" } } }
       }
     },
     {
       "required": ["record_type", "payload"],
       "properties": {
         "record_type": { "const": "closeout_summary" },
-        "payload": { "$ref": "#/definitions/closeoutSummaryPayload" }
+        "payload": { "$ref": "#/definitions/closeoutSummaryPayload" },
+        "run": { "properties": { "stage": { "const": "closeout" } } }
       }
     }
   ],
@@ -230,7 +237,9 @@
           "type": "boolean"
         },
         "decision_required_reasons": {
+          "description": "命中判据的说明；decision_required=true 时必填（契约 §5.2）",
           "type": "array",
+          "minItems": 1,
           "items": { "type": "string" }
         },
         "decision": {
@@ -258,7 +267,30 @@
             "decided_at": { "$ref": "#/definitions/isoDateTime" }
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["decision_required"],
+            "properties": { "decision_required": { "const": true } }
+          },
+          "then": {
+            "description": "命中 §5.2 条件门必须说明判据依据，供人工决策包使用",
+            "required": ["decision_required_reasons"]
+          }
+        },
+        {
+          "if": {
+            "required": ["decision"],
+            "properties": { "decision": { "type": "object" } }
+          },
+          "then": {
+            "description": "Decision Record 只能出现在命中 §5.2 条件门的 package 上",
+            "required": ["decision_required"],
+            "properties": { "decision_required": { "const": true } }
+          }
+        }
+      ]
     },
     "devHandoffPayload": {
       "type": "object",
@@ -362,6 +394,11 @@
           }
         },
         "environment": { "type": "string" },
+        "blocked_reason": {
+          "description": "verdict=blocked 时必填：可恢复的外部/技术条件说明，供 hold(<reason>) 路由与恢复判定（契约 §6.3/§6.4）",
+          "type": "string",
+          "minLength": 1
+        },
         "verified_branch": { "type": "string" },
         "verified_head": { "type": "string" },
         "independent_session": {
@@ -369,24 +406,51 @@
           "enum": [true]
         }
       },
-      "if": {
-        "required": ["verdict"],
-        "properties": { "verdict": { "const": "pass" } }
-      },
-      "then": {
-        "description": "pass 要求非空且逐项全 pass 的验收映射（契约 §3.5 完成判定）",
-        "required": ["acceptance_mapping"],
-        "properties": {
-          "acceptance_mapping": {
-            "minItems": 1,
-            "items": {
-              "properties": {
-                "result": { "const": "pass" }
+      "allOf": [
+        {
+          "if": {
+            "required": ["verdict"],
+            "properties": { "verdict": { "const": "pass" } }
+          },
+          "then": {
+            "description": "pass 要求非空且逐项全 pass 的验收映射（契约 §3.5 完成判定）",
+            "required": ["acceptance_mapping"],
+            "properties": {
+              "acceptance_mapping": {
+                "minItems": 1,
+                "items": {
+                  "properties": {
+                    "result": { "const": "pass" }
+                  }
+                }
               }
             }
           }
+        },
+        {
+          "if": {
+            "required": ["verdict"],
+            "properties": { "verdict": { "const": "fail" } }
+          },
+          "then": {
+            "description": "fail 必须至少携带一条带根因分类的 finding，否则 §4.1 路由悬空（契约 §6.5）",
+            "required": ["findings"],
+            "properties": {
+              "findings": { "minItems": 1 }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["verdict"],
+            "properties": { "verdict": { "const": "blocked" } }
+          },
+          "then": {
+            "description": "blocked 必须说明可恢复条件，供 hold(<reason>) 路由（契约 §6.4）",
+            "required": ["blocked_reason"]
+          }
         }
-      }
+      ]
     },
     "acceptancePackagePayload": {
       "type": "object",
@@ -465,9 +529,13 @@
     "closeoutSummaryPayload": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["deliverables", "integration", "records_retained", "acceptance_outcome"],
+      "required": ["deliverables", "integration", "records_retained", "acceptance_outcome", "acceptance_package_ref"],
       "properties": {
         "deliverables": { "type": "array", "items": { "type": "string" } },
+        "acceptance_package_ref": {
+          "description": "必须指向已 decided 的 acceptance package；Controller 归档前校验其 status=decided（契约 §3.6→§3.7 审计链）",
+          "type": "string"
+        },
         "integration": {
           "type": "object",
           "additionalProperties": false,

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "docs/design/construction-workflow/handoff.schema.json",
   "title": "Construction Workflow Portable Handoff / Evidence Record",
-  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1，#113；#78 Formal Records 的兼容前身）",
+  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.1，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
   "type": "object",
   "additionalProperties": false,
   "required": ["record_type", "record_version", "created_at", "produced_by", "run", "payload"],
@@ -21,7 +21,7 @@
     },
     "record_version": {
       "description": "记录 schema 版本，与契约版本同步",
-      "const": "v0.1"
+      "const": "v0.1.1"
     },
     "created_at": {
       "$ref": "#/definitions/isoDateTime"
@@ -137,10 +137,20 @@
       "description": "回退根因分类（契约 §4.1）",
       "enum": ["dev", "design", "requirements"]
     },
+    "verifiedBinding": {
+      "description": "Proof 绑定：只对 verified_head 有效（契约 §7.3）",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verified_branch", "verified_head"],
+      "properties": {
+        "verified_branch": { "type": "string" },
+        "verified_head": { "type": "string" }
+      }
+    },
     "requirementsBaselinePayload": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["goal", "scope", "acceptance", "gaps"],
+      "required": ["goal", "scope", "acceptance", "gaps", "status"],
       "properties": {
         "goal": { "type": "string" },
         "scope": {
@@ -178,9 +188,13 @@
             }
           }
         },
+        "status": {
+          "description": "draft 不得作为下游冻结输入；confirmed 才是 BASELINE_CONFIRMED（契约 §3.1/§5.1）",
+          "enum": ["draft", "confirmed"]
+        },
         "baseline_revision": { "type": "string" },
         "human_confirmation": {
-          "description": "人工确认后回填（BASELINE_CONFIRMED）",
+          "description": "人工确认记录（BASELINE_CONFIRMED），AI 不得代填",
           "type": "object",
           "additionalProperties": false,
           "required": ["confirmed_by", "confirmed_at"],
@@ -189,7 +203,18 @@
             "confirmed_at": { "$ref": "#/definitions/isoDateTime" }
           }
         }
-      }
+      },
+      "oneOf": [
+        {
+          "required": ["status"],
+          "properties": { "status": { "const": "draft" } },
+          "not": { "required": ["human_confirmation"] }
+        },
+        {
+          "required": ["status", "baseline_revision", "human_confirmation"],
+          "properties": { "status": { "const": "confirmed" } }
+        }
+      ]
     },
     "designPackagePayload": {
       "type": "object",
@@ -292,12 +317,23 @@
           "description": "独立证明者原则：审核会话必须独立于开发会话（契约 §2 不变量 2）",
           "enum": [true]
         }
+      },
+      "if": {
+        "required": ["verdict"],
+        "properties": { "verdict": { "const": "request_changes" } }
+      },
+      "then": {
+        "description": "request-changes 必须至少携带一条带根因分类的 finding，否则路由悬空（契约 §3.4/§6.5）",
+        "required": ["findings"],
+        "properties": {
+          "findings": { "minItems": 1 }
+        }
       }
     },
     "testProofPayload": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["verdict", "acceptance_mapping", "verified_branch", "verified_head"],
+      "required": ["verdict", "acceptance_mapping", "verified_branch", "verified_head", "independent_session"],
       "properties": {
         "verdict": { "enum": ["pass", "fail", "blocked"] },
         "acceptance_mapping": {
@@ -327,7 +363,29 @@
         },
         "environment": { "type": "string" },
         "verified_branch": { "type": "string" },
-        "verified_head": { "type": "string" }
+        "verified_head": { "type": "string" },
+        "independent_session": {
+          "description": "独立证明者原则：测试会话必须独立于开发会话（契约 §2 不变量 2）",
+          "enum": [true]
+        }
+      },
+      "if": {
+        "required": ["verdict"],
+        "properties": { "verdict": { "const": "pass" } }
+      },
+      "then": {
+        "description": "pass 要求非空且逐项全 pass 的验收映射（契约 §3.5 完成判定）",
+        "required": ["acceptance_mapping"],
+        "properties": {
+          "acceptance_mapping": {
+            "minItems": 1,
+            "items": {
+              "properties": {
+                "result": { "const": "pass" }
+              }
+            }
+          }
+        }
       }
     },
     "acceptancePackagePayload": {
@@ -337,11 +395,21 @@
       "properties": {
         "status": { "enum": ["awaiting_decision", "decided"] },
         "assembled": {
-          "description": "证据汇总：引用 review/test proof 与 Integration Checkpoint 结果",
+          "description": "证据汇总：§3.6 定义的五类前置记录引用 + Integration Checkpoint 结果",
           "type": "object",
           "additionalProperties": false,
-          "required": ["review_proof_ref", "test_proof_ref", "integration_checkpoint"],
+          "required": [
+            "requirements_baseline_ref",
+            "design_package_ref",
+            "dev_handoff_ref",
+            "review_proof_ref",
+            "test_proof_ref",
+            "integration_checkpoint"
+          ],
           "properties": {
+            "requirements_baseline_ref": { "type": "string" },
+            "design_package_ref": { "type": "string" },
+            "dev_handoff_ref": { "type": "string" },
             "review_proof_ref": { "type": "string" },
             "test_proof_ref": { "type": "string" },
             "integration_checkpoint": { "type": "string" }
@@ -353,23 +421,51 @@
         },
         "decided_by": { "type": "string" },
         "decided_at": { "$ref": "#/definitions/isoDateTime" },
-        "feedback": { "type": "string" }
+        "feedback": { "type": "string" },
+        "rejection_root_cause": { "$ref": "#/definitions/rootCause" },
+        "verified_branch": { "type": "string" },
+        "verified_head": { "type": "string" }
       },
       "oneOf": [
         {
           "required": ["status"],
-          "properties": { "status": { "const": "awaiting_decision" } }
+          "properties": { "status": { "const": "awaiting_decision" } },
+          "not": {
+            "anyOf": [
+              { "required": ["decision"] },
+              { "required": ["decided_by"] },
+              { "required": ["decided_at"] },
+              { "required": ["feedback"] },
+              { "required": ["rejection_root_cause"] },
+              { "required": ["verified_head"] }
+            ]
+          }
         },
         {
-          "required": ["status", "decision", "decided_by", "decided_at"],
+          "required": [
+            "status",
+            "decision",
+            "decided_by",
+            "decided_at",
+            "verified_branch",
+            "verified_head"
+          ],
           "properties": { "status": { "const": "decided" } }
         }
-      ]
+      ],
+      "if": {
+        "required": ["decision"],
+        "properties": { "decision": { "const": "reject" } }
+      },
+      "then": {
+        "description": "reject 必须携带 feedback 与根因指向，否则 Controller 无法按 §3.6 路由",
+        "required": ["feedback", "rejection_root_cause"]
+      }
     },
     "closeoutSummaryPayload": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["deliverables", "integration", "records_retained"],
+      "required": ["deliverables", "integration", "records_retained", "acceptance_outcome"],
       "properties": {
         "deliverables": { "type": "array", "items": { "type": "string" } },
         "integration": {
@@ -380,9 +476,17 @@
             "pr": { "type": "string" },
             "merge_commit": { "type": "string" },
             "checkpoint": { "type": "string" }
-          }
+          },
+          "anyOf": [
+            { "required": ["pr"] },
+            { "required": ["merge_commit"] }
+          ]
         },
         "leftovers": { "type": "array", "items": { "type": "string" } },
+        "acceptance_outcome": {
+          "description": "保留验收决议：user_accepted 异常必须延续到收口，作为 Completion 权威事实，不得洗成普通交付（契约 §3.7/§6.3）",
+          "enum": ["accept", "user_accepted"]
+        },
         "records_retained": {
           "description": "归档保留声明（契约 §8.5）",
           "enum": [true]

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -21,7 +21,7 @@
     },
     "record_version": {
       "description": "记录 schema 版本，与契约版本同步",
-      "const": "v0.1.1"
+      "const": "v0.1.2"
     },
     "created_at": {
       "$ref": "#/definitions/isoDateTime"
@@ -295,9 +295,18 @@
     "devHandoffPayload": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["summary", "changes", "self_check"],
+      "required": ["summary", "outcome", "changes", "self_check"],
       "properties": {
         "summary": { "type": "string" },
+        "outcome": {
+          "description": "Dev 阶段整体专业结果（契约 §6.3 基元：handoff-ready / blocked / design-issue / requirements-issue）",
+          "enum": ["handoff_ready", "blocked", "design_issue", "requirements_issue"]
+        },
+        "blocked_reason": {
+          "description": "outcome=blocked 时必填：可恢复的外部/技术条件说明，供 hold(<reason>) 路由与恢复判定（契约 §6.3/§6.4）",
+          "type": "string",
+          "minLength": 1
+        },
         "changes": {
           "type": "array",
           "items": {
@@ -323,7 +332,19 @@
           }
         },
         "notes": { "type": "string" }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["outcome"],
+            "properties": { "outcome": { "const": "blocked" } }
+          },
+          "then": {
+            "description": "blocked 必须说明可恢复条件，供 hold(<reason>) 路由（契约 §6.4）",
+            "required": ["blocked_reason"]
+          }
+        }
+      ]
     },
     "reviewProofPayload": {
       "type": "object",

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "docs/design/construction-workflow/handoff.schema.json",
   "title": "Construction Workflow Portable Handoff / Evidence Record",
-  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.6，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
+  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.7，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
   "type": "object",
   "additionalProperties": false,
   "required": ["record_type", "record_version", "created_at", "produced_by", "run", "payload"],
@@ -21,7 +21,7 @@
     },
     "record_version": {
       "description": "记录 schema 版本，与契约版本同步",
-      "const": "v0.1.6"
+      "const": "v0.1.7"
     },
     "created_at": {
       "$ref": "#/definitions/isoDateTime"
@@ -279,8 +279,31 @@
           "minItems": 1,
           "items": { "$ref": "#/definitions/nonEmptyText" }
         },
+        "decision_request": {
+          "description": "待决决策包（契约 §5.3）：挂起人工裁决前必须携带的决策点、候选项与推荐理由；与已决 decision 不同字段，已决后保留作为裁决上下文",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["question", "options", "recommendation"],
+          "properties": {
+            "question": { "$ref": "#/definitions/nonEmptyText" },
+            "options": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "tradeoffs"],
+                "properties": {
+                  "name": { "$ref": "#/definitions/nonEmptyText" },
+                  "tradeoffs": { "type": "string" }
+                }
+              }
+            },
+            "recommendation": { "$ref": "#/definitions/nonEmptyText" }
+          }
+        },
         "decision": {
-          "description": "Human Decision Record（不可覆盖，契约 §5）",
+          "description": "Human Decision Record（不可覆盖，契约 §5）：人工已决记录；仅允许出现在命中条件门的 package 上",
           "type": "object",
           "additionalProperties": false,
           "required": ["question", "options", "chosen", "rationale", "decided_by", "decided_at"],
@@ -346,10 +369,21 @@
             "properties": { "outcome": { "const": "decision_required" } }
           },
           "then": {
-            "description": "outcome=decision_required ⇒ 门标记置位且未决（已决的过门 package 翻转为 package_ready 并保留 Decision Record 作为过门证据）",
-            "required": ["decision_required"],
+            "description": "outcome=decision_required ⇒ 门标记置位、未决（decision 缺席）且必须携带 decision_request 决策包供人工裁决（契约 §5.2/§5.3）",
+            "required": ["decision_required", "decision_request"],
             "properties": { "decision_required": { "const": true } },
             "not": { "required": ["decision"] }
+          }
+        },
+        {
+          "if": {
+            "required": ["decision_request"],
+            "properties": { "decision_request": { "type": "object" } }
+          },
+          "then": {
+            "description": "decision_request 只能出现在命中条件门的 package 上",
+            "required": ["decision_required"],
+            "properties": { "decision_required": { "const": true } }
           }
         }
       ]
@@ -577,7 +611,27 @@
             "dev_handoff_ref": { "$ref": "#/definitions/nonEmptyText" },
             "review_proof_ref": { "$ref": "#/definitions/nonEmptyText" },
             "test_proof_ref": { "$ref": "#/definitions/nonEmptyText" },
-            "integration_checkpoint": { "type": "string" }
+            "integration_checkpoint": {
+            "description": "结构化 checkpoint 结果（契约 §7.3）：target 已前进时必须已重跑受影响 Proof",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["target_ref", "target_head_at_check", "target_advanced", "proofs_state"],
+            "properties": {
+              "target_ref": { "$ref": "#/definitions/nonEmptyText" },
+              "target_head_at_check": { "$ref": "#/definitions/nonEmptyText" },
+              "target_advanced": { "type": "boolean" },
+              "proofs_state": { "enum": ["still_valid", "rerun_completed"] },
+              "notes": { "type": "string" }
+            },
+            "if": {
+              "required": ["target_advanced"],
+              "properties": { "target_advanced": { "const": true } }
+            },
+            "then": {
+              "description": "target 已前进 ⇒ 受影响 Proof 必须已重跑（契约 §7.3）",
+              "properties": { "proofs_state": { "const": "rerun_completed" } }
+            }
+          }
           }
         },
         "decision": {

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -1,0 +1,393 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "docs/design/construction-workflow/handoff.schema.json",
+  "title": "Construction Workflow Portable Handoff / Evidence Record",
+  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1，#113；#78 Formal Records 的兼容前身）",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["record_type", "record_version", "created_at", "produced_by", "run", "payload"],
+  "properties": {
+    "record_type": {
+      "description": "七类记录之一",
+      "enum": [
+        "requirements_baseline",
+        "design_package",
+        "dev_handoff",
+        "review_proof",
+        "test_proof",
+        "acceptance_package",
+        "closeout_summary"
+      ]
+    },
+    "record_version": {
+      "description": "记录 schema 版本，与契约版本同步",
+      "const": "v0.1"
+    },
+    "created_at": {
+      "$ref": "#/definitions/isoDateTime"
+    },
+    "produced_by": {
+      "description": "产生者 Role/会话标识",
+      "type": "string"
+    },
+    "run": {
+      "$ref": "#/definitions/portableRunIdentity"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "oneOf": [
+    {
+      "required": ["record_type", "payload"],
+      "properties": {
+        "record_type": { "const": "requirements_baseline" },
+        "payload": { "$ref": "#/definitions/requirementsBaselinePayload" }
+      }
+    },
+    {
+      "required": ["record_type", "payload"],
+      "properties": {
+        "record_type": { "const": "design_package" },
+        "payload": { "$ref": "#/definitions/designPackagePayload" }
+      }
+    },
+    {
+      "required": ["record_type", "payload"],
+      "properties": {
+        "record_type": { "const": "dev_handoff" },
+        "payload": { "$ref": "#/definitions/devHandoffPayload" }
+      }
+    },
+    {
+      "required": ["record_type", "payload"],
+      "properties": {
+        "record_type": { "const": "review_proof" },
+        "payload": { "$ref": "#/definitions/reviewProofPayload" }
+      }
+    },
+    {
+      "required": ["record_type", "payload"],
+      "properties": {
+        "record_type": { "const": "test_proof" },
+        "payload": { "$ref": "#/definitions/testProofPayload" }
+      }
+    },
+    {
+      "required": ["record_type", "payload"],
+      "properties": {
+        "record_type": { "const": "acceptance_package" },
+        "payload": { "$ref": "#/definitions/acceptancePackagePayload" }
+      }
+    },
+    {
+      "required": ["record_type", "payload"],
+      "properties": {
+        "record_type": { "const": "closeout_summary" },
+        "payload": { "$ref": "#/definitions/closeoutSummaryPayload" }
+      }
+    }
+  ],
+  "definitions": {
+    "isoDateTime": {
+      "description": "ISO 8601 UTC 时间",
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$"
+    },
+    "portableRunIdentity": {
+      "description": "Portable Run Identity 最小字段集（#103 列举，契约 §7.1）",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_id",
+        "issue_or_task_identity",
+        "workspace_id",
+        "repository",
+        "base_ref",
+        "base_commit",
+        "work_branch",
+        "current_head",
+        "stage",
+        "attempt"
+      ],
+      "properties": {
+        "run_id": { "type": "string" },
+        "issue_or_task_identity": { "type": "string" },
+        "workspace_id": { "type": "string" },
+        "repository": { "type": "string" },
+        "base_ref": { "type": "string" },
+        "base_commit": { "type": "string" },
+        "work_branch": { "type": "string" },
+        "current_head": { "type": "string" },
+        "stage": {
+          "enum": [
+            "requirements",
+            "design",
+            "dev",
+            "review",
+            "test",
+            "human_acceptance",
+            "closeout"
+          ]
+        },
+        "attempt": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "rootCause": {
+      "description": "回退根因分类（契约 §4.1）",
+      "enum": ["dev", "design", "requirements"]
+    },
+    "requirementsBaselinePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["goal", "scope", "acceptance", "gaps"],
+      "properties": {
+        "goal": { "type": "string" },
+        "scope": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["include", "exclude"],
+          "properties": {
+            "include": { "type": "array", "items": { "type": "string" } },
+            "exclude": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "acceptance": { "type": "array", "items": { "type": "string" } },
+        "gaps": {
+          "description": "缺失要素必须显式列出，不得编造（契约 §3.1）",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["element", "suggestion"],
+            "properties": {
+              "element": { "type": "string" },
+              "suggestion": { "type": "string" }
+            }
+          }
+        },
+        "clarification_decisions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["topic", "decision"],
+            "properties": {
+              "topic": { "type": "string" },
+              "decision": { "type": "string" }
+            }
+          }
+        },
+        "baseline_revision": { "type": "string" },
+        "human_confirmation": {
+          "description": "人工确认后回填（BASELINE_CONFIRMED）",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["confirmed_by", "confirmed_at"],
+          "properties": {
+            "confirmed_by": { "type": "string" },
+            "confirmed_at": { "$ref": "#/definitions/isoDateTime" }
+          }
+        }
+      }
+    },
+    "designPackagePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "decision_required"],
+      "properties": {
+        "summary": { "type": "string" },
+        "affected_modules": { "type": "array", "items": { "type": "string" } },
+        "risks": { "type": "array", "items": { "type": "string" } },
+        "open_questions": { "type": "array", "items": { "type": "string" } },
+        "decision_required": {
+          "description": "true 时 Controller 挂起等人工决策（契约 §5.2 判据）",
+          "type": "boolean"
+        },
+        "decision_required_reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "decision": {
+          "description": "Human Decision Record（不可覆盖，契约 §5）",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["question", "options", "chosen", "rationale", "decided_by", "decided_at"],
+          "properties": {
+            "question": { "type": "string" },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "tradeoffs"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "tradeoffs": { "type": "string" }
+                }
+              }
+            },
+            "chosen": { "type": "string" },
+            "rationale": { "type": "string" },
+            "decided_by": { "type": "string" },
+            "decided_at": { "$ref": "#/definitions/isoDateTime" }
+          }
+        }
+      }
+    },
+    "devHandoffPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "changes", "self_check"],
+      "properties": {
+        "summary": { "type": "string" },
+        "changes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["area", "description"],
+            "properties": {
+              "area": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        },
+        "self_check": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["check", "result"],
+            "properties": {
+              "check": { "type": "string" },
+              "result": { "enum": ["pass", "fail", "blocked", "not_applicable"] }
+            }
+          }
+        },
+        "notes": { "type": "string" }
+      }
+    },
+    "reviewProofPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verdict", "findings", "verified_branch", "verified_head", "independent_session"],
+      "properties": {
+        "verdict": { "enum": ["approve", "request_changes"] },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["finding", "root_cause"],
+            "properties": {
+              "finding": { "type": "string" },
+              "root_cause": { "$ref": "#/definitions/rootCause" }
+            }
+          }
+        },
+        "verified_branch": { "type": "string" },
+        "verified_head": { "type": "string" },
+        "independent_session": {
+          "description": "独立证明者原则：审核会话必须独立于开发会话（契约 §2 不变量 2）",
+          "enum": [true]
+        }
+      }
+    },
+    "testProofPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verdict", "acceptance_mapping", "verified_branch", "verified_head"],
+      "properties": {
+        "verdict": { "enum": ["pass", "fail", "blocked"] },
+        "acceptance_mapping": {
+          "description": "与 baseline 验收标准逐条映射",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["acceptance_item", "result"],
+            "properties": {
+              "acceptance_item": { "type": "string" },
+              "result": { "enum": ["pass", "fail", "blocked", "not_verified"] }
+            }
+          }
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["finding", "root_cause"],
+            "properties": {
+              "finding": { "type": "string" },
+              "root_cause": { "$ref": "#/definitions/rootCause" }
+            }
+          }
+        },
+        "environment": { "type": "string" },
+        "verified_branch": { "type": "string" },
+        "verified_head": { "type": "string" }
+      }
+    },
+    "acceptancePackagePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "assembled"],
+      "properties": {
+        "status": { "enum": ["awaiting_decision", "decided"] },
+        "assembled": {
+          "description": "证据汇总：引用 review/test proof 与 Integration Checkpoint 结果",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["review_proof_ref", "test_proof_ref", "integration_checkpoint"],
+          "properties": {
+            "review_proof_ref": { "type": "string" },
+            "test_proof_ref": { "type": "string" },
+            "integration_checkpoint": { "type": "string" }
+          }
+        },
+        "decision": {
+          "description": "人工决策，AI 不得代签（契约 §3.6）",
+          "enum": ["accept", "reject", "user_accepted"]
+        },
+        "decided_by": { "type": "string" },
+        "decided_at": { "$ref": "#/definitions/isoDateTime" },
+        "feedback": { "type": "string" }
+      },
+      "oneOf": [
+        {
+          "required": ["status"],
+          "properties": { "status": { "const": "awaiting_decision" } }
+        },
+        {
+          "required": ["status", "decision", "decided_by", "decided_at"],
+          "properties": { "status": { "const": "decided" } }
+        }
+      ]
+    },
+    "closeoutSummaryPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["deliverables", "integration", "records_retained"],
+      "properties": {
+        "deliverables": { "type": "array", "items": { "type": "string" } },
+        "integration": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["checkpoint"],
+          "properties": {
+            "pr": { "type": "string" },
+            "merge_commit": { "type": "string" },
+            "checkpoint": { "type": "string" }
+          }
+        },
+        "leftovers": { "type": "array", "items": { "type": "string" } },
+        "records_retained": {
+          "description": "归档保留声明（契约 §8.5）",
+          "enum": [true]
+        }
+      }
+    }
+  }
+}

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "docs/design/construction-workflow/handoff.schema.json",
   "title": "Construction Workflow Portable Handoff / Evidence Record",
-  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.1，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
+  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.2，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
   "type": "object",
   "additionalProperties": false,
   "required": ["record_type", "record_version", "created_at", "produced_by", "run", "payload"],
@@ -226,9 +226,13 @@
     "designPackagePayload": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["summary", "decision_required"],
+      "required": ["summary", "outcome", "decision_required"],
       "properties": {
         "summary": { "type": "string" },
+        "outcome": {
+          "description": "Design 阶段整体专业结果（契约 §6.3 基元：package-ready / decision-required / requirements-issue）",
+          "enum": ["package_ready", "decision_required", "requirements_issue"]
+        },
         "affected_modules": { "type": "array", "items": { "type": "string" } },
         "risks": { "type": "array", "items": { "type": "string" } },
         "open_questions": { "type": "array", "items": { "type": "string" } },
@@ -289,6 +293,28 @@
             "required": ["decision_required"],
             "properties": { "decision_required": { "const": true } }
           }
+        },
+        {
+          "if": {
+            "required": ["decision_required"],
+            "properties": { "decision_required": { "const": true } }
+          },
+          "then": {
+            "description": "命中条件门时整体 outcome 必须为 decision_required（契约 §6.3 一致性）",
+            "required": ["outcome"],
+            "properties": { "outcome": { "const": "decision_required" } }
+          }
+        },
+        {
+          "if": {
+            "required": ["outcome"],
+            "properties": { "outcome": { "const": "decision_required" } }
+          },
+          "then": {
+            "description": "outcome=decision_required 时必须置位条件门标记（契约 §6.3 一致性）",
+            "required": ["decision_required"],
+            "properties": { "decision_required": { "const": true } }
+          }
         }
       ]
     },
@@ -342,6 +368,26 @@
           "then": {
             "description": "blocked 必须说明可恢复条件，供 hold(<reason>) 路由（契约 §6.4）",
             "required": ["blocked_reason"]
+          }
+        },
+        {
+          "if": {
+            "required": ["outcome"],
+            "properties": { "outcome": { "const": "handoff_ready" } }
+          },
+          "then": {
+            "description": "handoff_ready 要求自验清单非空且无 fail/blocked 项（契约 §3.3 完成判定）",
+            "required": ["self_check"],
+            "properties": {
+              "self_check": {
+                "minItems": 1,
+                "items": {
+                  "properties": {
+                    "result": { "enum": ["pass", "not_applicable"] }
+                  }
+                }
+              }
+            }
           }
         }
       ]

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "docs/design/construction-workflow/handoff.schema.json",
   "title": "Construction Workflow Portable Handoff / Evidence Record",
-  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.2，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
+  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.3，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
   "type": "object",
   "additionalProperties": false,
   "required": ["record_type", "record_version", "created_at", "produced_by", "run", "payload"],
@@ -21,7 +21,7 @@
     },
     "record_version": {
       "description": "记录 schema 版本，与契约版本同步",
-      "const": "v0.1.2"
+      "const": "v0.1.3"
     },
     "created_at": {
       "$ref": "#/definitions/isoDateTime"
@@ -144,22 +144,21 @@
       "description": "回退根因分类（契约 §4.1）",
       "enum": ["dev", "design", "requirements"]
     },
-    "verifiedBinding": {
-      "description": "Proof 绑定：只对 verified_head 有效（契约 §7.3）",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["verified_branch", "verified_head"],
-      "properties": {
-        "verified_branch": { "type": "string" },
-        "verified_head": { "type": "string" }
-      }
+    "nonEmptyText": {
+      "description": "非空白字符串（proof 绑定等，契约 §7.3）",
+      "type": "string",
+      "pattern": "\\S"
     },
     "requirementsBaselinePayload": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["goal", "scope", "acceptance", "gaps", "status"],
+      "required": ["goal", "scope", "acceptance", "gaps", "status", "outcome"],
       "properties": {
         "goal": { "type": "string" },
+        "outcome": {
+          "description": "Requirements 阶段整体专业结果（契约 §6.3 基元：baseline-ready 待确认 / awaiting-human-input 缺口挂起 / revised 回退后重出）",
+          "enum": ["baseline_ready", "awaiting_human_input", "revised"]
+        },
         "scope": {
           "type": "object",
           "additionalProperties": false,
@@ -219,7 +218,41 @@
         },
         {
           "required": ["status", "baseline_revision", "human_confirmation"],
-          "properties": { "status": { "const": "confirmed" } }
+          "properties": {
+            "status": { "const": "confirmed" },
+            "gaps": { "maxItems": 0 },
+            "acceptance": { "minItems": 1 },
+            "goal": { "$ref": "#/definitions/nonEmptyText" },
+            "scope": {
+              "properties": {
+                "include": { "minItems": 1 },
+                "exclude": { "minItems": 1 }
+              }
+            }
+          }
+        }
+      ],
+      "allOf": [
+        {
+          "if": {
+            "required": ["outcome"],
+            "properties": { "outcome": { "const": "awaiting_human_input" } }
+          },
+          "then": {
+            "description": "挂起等输入时必须显式声明缺口（契约 §3.1，不得编造也不得空挂）",
+            "required": ["gaps"],
+            "properties": { "gaps": { "minItems": 1 } }
+          }
+        },
+        {
+          "if": {
+            "required": ["outcome"],
+            "properties": { "outcome": { "const": "baseline_ready" } }
+          },
+          "then": {
+            "description": "基线就绪（待人工确认）时不得残留未解决缺口",
+            "properties": { "gaps": { "maxItems": 0 } }
+          }
         }
       ]
     },
@@ -410,8 +443,8 @@
             }
           }
         },
-        "verified_branch": { "type": "string" },
-        "verified_head": { "type": "string" },
+        "verified_branch": { "$ref": "#/definitions/nonEmptyText" },
+        "verified_head": { "$ref": "#/definitions/nonEmptyText" },
         "independent_session": {
           "description": "独立证明者原则：审核会话必须独立于开发会话（契约 §2 不变量 2）",
           "enum": [true]
@@ -466,8 +499,8 @@
           "type": "string",
           "minLength": 1
         },
-        "verified_branch": { "type": "string" },
-        "verified_head": { "type": "string" },
+        "verified_branch": { "$ref": "#/definitions/nonEmptyText" },
+        "verified_head": { "$ref": "#/definitions/nonEmptyText" },
         "independent_session": {
           "description": "独立证明者原则：测试会话必须独立于开发会话（契约 §2 不变量 2）",
           "enum": [true]
@@ -554,7 +587,7 @@
         "decided_at": { "$ref": "#/definitions/isoDateTime" },
         "feedback": { "type": "string" },
         "rejection_root_cause": { "$ref": "#/definitions/rootCause" },
-        "verified_branch": { "type": "string" },
+        "verified_branch": { "$ref": "#/definitions/nonEmptyText" },
         "verified_head": { "type": "string" }
       },
       "oneOf": [

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "docs/design/construction-workflow/handoff.schema.json",
   "title": "Construction Workflow Portable Handoff / Evidence Record",
-  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.5，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
+  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.6，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
   "type": "object",
   "additionalProperties": false,
   "required": ["record_type", "record_version", "created_at", "produced_by", "run", "payload"],
@@ -21,7 +21,7 @@
     },
     "record_version": {
       "description": "记录 schema 版本，与契约版本同步",
-      "const": "v0.1.5"
+      "const": "v0.1.6"
     },
     "created_at": {
       "$ref": "#/definitions/isoDateTime"
@@ -164,11 +164,11 @@
           "additionalProperties": false,
           "required": ["include", "exclude"],
           "properties": {
-            "include": { "type": "array", "items": { "type": "string" } },
-            "exclude": { "type": "array", "items": { "type": "string" } }
+            "include": { "type": "array", "items": { "$ref": "#/definitions/nonEmptyText" } },
+            "exclude": { "type": "array", "items": { "$ref": "#/definitions/nonEmptyText" } }
           }
         },
-        "acceptance": { "type": "array", "items": { "type": "string" } },
+        "acceptance": { "type": "array", "items": { "$ref": "#/definitions/nonEmptyText" } },
         "gaps": {
           "description": "缺失要素必须显式列出，不得编造（契约 §3.1）",
           "type": "array",
@@ -266,9 +266,9 @@
           "description": "Design 阶段整体专业结果（契约 §6.3 基元：package-ready / decision-required / requirements-issue）",
           "enum": ["package_ready", "decision_required", "requirements_issue"]
         },
-        "affected_modules": { "type": "array", "items": { "type": "string" } },
-        "risks": { "type": "array", "items": { "type": "string" } },
-        "open_questions": { "type": "array", "items": { "type": "string" } },
+        "affected_modules": { "type": "array", "items": { "$ref": "#/definitions/nonEmptyText" } },
+        "risks": { "type": "array", "items": { "$ref": "#/definitions/nonEmptyText" } },
+        "open_questions": { "type": "array", "items": { "$ref": "#/definitions/nonEmptyText" } },
         "decision_required": {
           "description": "true 时 Controller 挂起等人工决策（契约 §5.2 判据）",
           "type": "boolean"
@@ -277,7 +277,7 @@
           "description": "命中判据的说明；decision_required=true 时必填（契约 §5.2）",
           "type": "array",
           "minItems": 1,
-          "items": { "type": "string" }
+          "items": { "$ref": "#/definitions/nonEmptyText" }
         },
         "decision": {
           "description": "Human Decision Record（不可覆盖，契约 §5）",
@@ -288,12 +288,13 @@
             "question": { "type": "string" },
             "options": {
               "type": "array",
+              "minItems": 1,
               "items": {
                 "type": "object",
                 "additionalProperties": false,
                 "required": ["name", "tradeoffs"],
                 "properties": {
-                  "name": { "type": "string" },
+                  "name": { "$ref": "#/definitions/nonEmptyText" },
                   "tradeoffs": { "type": "string" }
                 }
               }
@@ -365,8 +366,7 @@
         },
         "blocked_reason": {
           "description": "outcome=blocked 时必填：可恢复的外部/技术条件说明，供 hold(<reason>) 路由与恢复判定（契约 §6.3/§6.4）",
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/nonEmptyText"
         },
         "changes": {
           "type": "array",
@@ -498,8 +498,7 @@
         "environment": { "type": "string" },
         "blocked_reason": {
           "description": "verdict=blocked 时必填：可恢复的外部/技术条件说明，供 hold(<reason>) 路由与恢复判定（契约 §6.3/§6.4）",
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/nonEmptyText"
         },
         "verified_branch": { "$ref": "#/definitions/nonEmptyText" },
         "verified_head": { "$ref": "#/definitions/nonEmptyText" },
@@ -587,7 +586,7 @@
         },
         "decided_by": { "$ref": "#/definitions/nonEmptyText" },
         "decided_at": { "$ref": "#/definitions/isoDateTime" },
-        "feedback": { "type": "string" },
+        "feedback": { "$ref": "#/definitions/nonEmptyText" },
         "rejection_root_cause": { "$ref": "#/definitions/rootCause" },
         "verified_branch": { "$ref": "#/definitions/nonEmptyText" },
         "verified_head": { "$ref": "#/definitions/nonEmptyText" }
@@ -647,7 +646,7 @@
       "additionalProperties": false,
       "required": ["deliverables", "integration", "records_retained", "acceptance_outcome", "acceptance_package_ref"],
       "properties": {
-        "deliverables": { "type": "array", "items": { "type": "string" } },
+        "deliverables": { "type": "array", "items": { "$ref": "#/definitions/nonEmptyText" } },
         "acceptance_package_ref": {
           "description": "必须指向已 decided 的 acceptance package；Controller 归档前校验其 status=decided（契约 §3.6→§3.7 审计链）",
           "$ref": "#/definitions/nonEmptyText"
@@ -666,7 +665,7 @@
             { "required": ["merge_commit"] }
           ]
         },
-        "leftovers": { "type": "array", "items": { "type": "string" } },
+        "leftovers": { "type": "array", "items": { "$ref": "#/definitions/nonEmptyText" } },
         "acceptance_outcome": {
           "description": "保留验收决议：user_accepted 异常必须延续到收口，作为 Completion 权威事实，不得洗成普通交付（契约 §3.7/§6.3）",
           "enum": ["accept", "user_accepted"]

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "docs/design/construction-workflow/handoff.schema.json",
   "title": "Construction Workflow Portable Handoff / Evidence Record",
-  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.4，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
+  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.5，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
   "type": "object",
   "additionalProperties": false,
   "required": ["record_type", "record_version", "created_at", "produced_by", "run", "payload"],
@@ -21,7 +21,7 @@
     },
     "record_version": {
       "description": "记录 schema 版本，与契约版本同步",
-      "const": "v0.1.4"
+      "const": "v0.1.5"
     },
     "created_at": {
       "$ref": "#/definitions/isoDateTime"
@@ -330,10 +330,11 @@
         {
           "if": {
             "required": ["decision_required"],
-            "properties": { "decision_required": { "const": true } }
+            "properties": { "decision_required": { "const": true } },
+            "not": { "required": ["decision"] }
           },
           "then": {
-            "description": "命中条件门时整体 outcome 必须为 decision_required（契约 §6.3 一致性）",
+            "description": "条件门命中且未决 ⇒ outcome=decision_required（Controller 挂起等人工决策，契约 §5.2）",
             "required": ["outcome"],
             "properties": { "outcome": { "const": "decision_required" } }
           }
@@ -344,9 +345,10 @@
             "properties": { "outcome": { "const": "decision_required" } }
           },
           "then": {
-            "description": "outcome=decision_required 时必须置位条件门标记（契约 §6.3 一致性）",
+            "description": "outcome=decision_required ⇒ 门标记置位且未决（已决的过门 package 翻转为 package_ready 并保留 Decision Record 作为过门证据）",
             "required": ["decision_required"],
-            "properties": { "decision_required": { "const": true } }
+            "properties": { "decision_required": { "const": true } },
+            "not": { "required": ["decision"] }
           }
         }
       ]
@@ -617,14 +619,28 @@
           "properties": { "status": { "const": "decided" } }
         }
       ],
-      "if": {
-        "required": ["decision"],
-        "properties": { "decision": { "const": "reject" } }
-      },
-      "then": {
-        "description": "reject 必须携带 feedback 与根因指向，否则 Controller 无法按 §3.6 路由",
-        "required": ["feedback", "rejection_root_cause"]
-      }
+      "allOf": [
+        {
+          "if": {
+            "required": ["decision"],
+            "properties": { "decision": { "const": "reject" } }
+          },
+          "then": {
+            "description": "reject 必须携带 feedback 与根因指向，否则 Controller 无法按 §3.6 路由",
+            "required": ["feedback", "rejection_root_cause"]
+          }
+        },
+        {
+          "if": {
+            "required": ["decision"],
+            "properties": { "decision": { "const": "user_accepted" } }
+          },
+          "then": {
+            "description": "user_accepted 必须以 feedback 说明知情接受的差异（契约 §3.6 特殊语义）",
+            "required": ["feedback"]
+          }
+        }
+      ]
     },
     "closeoutSummaryPayload": {
       "type": "object",

--- a/docs/design/construction-workflow/handoff.schema.json
+++ b/docs/design/construction-workflow/handoff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "docs/design/construction-workflow/handoff.schema.json",
   "title": "Construction Workflow Portable Handoff / Evidence Record",
-  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.3，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
+  "description": "建设·完整功能开发 Portable Contract 七类交接/证据包统一 schema（v0.1.4，#113 + #115 Review 修复；#78 Formal Records 的兼容前身）",
   "type": "object",
   "additionalProperties": false,
   "required": ["record_type", "record_version", "created_at", "produced_by", "run", "payload"],
@@ -21,14 +21,14 @@
     },
     "record_version": {
       "description": "记录 schema 版本，与契约版本同步",
-      "const": "v0.1.3"
+      "const": "v0.1.4"
     },
     "created_at": {
       "$ref": "#/definitions/isoDateTime"
     },
     "produced_by": {
       "description": "产生者 Role/会话标识",
-      "type": "string"
+      "$ref": "#/definitions/nonEmptyText"
     },
     "run": {
       "$ref": "#/definitions/portableRunIdentity"
@@ -118,14 +118,14 @@
         "attempt"
       ],
       "properties": {
-        "run_id": { "type": "string" },
-        "issue_or_task_identity": { "type": "string" },
-        "workspace_id": { "type": "string" },
-        "repository": { "type": "string" },
-        "base_ref": { "type": "string" },
-        "base_commit": { "type": "string" },
-        "work_branch": { "type": "string" },
-        "current_head": { "type": "string" },
+        "run_id": { "$ref": "#/definitions/nonEmptyText" },
+        "issue_or_task_identity": { "$ref": "#/definitions/nonEmptyText" },
+        "workspace_id": { "$ref": "#/definitions/nonEmptyText" },
+        "repository": { "$ref": "#/definitions/nonEmptyText" },
+        "base_ref": { "$ref": "#/definitions/nonEmptyText" },
+        "base_commit": { "$ref": "#/definitions/nonEmptyText" },
+        "work_branch": { "$ref": "#/definitions/nonEmptyText" },
+        "current_head": { "$ref": "#/definitions/nonEmptyText" },
         "stage": {
           "enum": [
             "requirements",
@@ -154,7 +154,7 @@
       "additionalProperties": false,
       "required": ["goal", "scope", "acceptance", "gaps", "status", "outcome"],
       "properties": {
-        "goal": { "type": "string" },
+        "goal": { "$ref": "#/definitions/nonEmptyText" },
         "outcome": {
           "description": "Requirements 阶段整体专业结果（契约 §6.3 基元：baseline-ready 待确认 / awaiting-human-input 缺口挂起 / revised 回退后重出）",
           "enum": ["baseline_ready", "awaiting_human_input", "revised"]
@@ -205,7 +205,7 @@
           "additionalProperties": false,
           "required": ["confirmed_by", "confirmed_at"],
           "properties": {
-            "confirmed_by": { "type": "string" },
+            "confirmed_by": { "$ref": "#/definitions/nonEmptyText" },
             "confirmed_at": { "$ref": "#/definitions/isoDateTime" }
           }
         }
@@ -298,9 +298,9 @@
                 }
               }
             },
-            "chosen": { "type": "string" },
+            "chosen": { "$ref": "#/definitions/nonEmptyText" },
             "rationale": { "type": "string" },
-            "decided_by": { "type": "string" },
+            "decided_by": { "$ref": "#/definitions/nonEmptyText" },
             "decided_at": { "$ref": "#/definitions/isoDateTime" }
           }
         }
@@ -571,11 +571,11 @@
             "integration_checkpoint"
           ],
           "properties": {
-            "requirements_baseline_ref": { "type": "string" },
-            "design_package_ref": { "type": "string" },
-            "dev_handoff_ref": { "type": "string" },
-            "review_proof_ref": { "type": "string" },
-            "test_proof_ref": { "type": "string" },
+            "requirements_baseline_ref": { "$ref": "#/definitions/nonEmptyText" },
+            "design_package_ref": { "$ref": "#/definitions/nonEmptyText" },
+            "dev_handoff_ref": { "$ref": "#/definitions/nonEmptyText" },
+            "review_proof_ref": { "$ref": "#/definitions/nonEmptyText" },
+            "test_proof_ref": { "$ref": "#/definitions/nonEmptyText" },
             "integration_checkpoint": { "type": "string" }
           }
         },
@@ -583,12 +583,12 @@
           "description": "人工决策，AI 不得代签（契约 §3.6）",
           "enum": ["accept", "reject", "user_accepted"]
         },
-        "decided_by": { "type": "string" },
+        "decided_by": { "$ref": "#/definitions/nonEmptyText" },
         "decided_at": { "$ref": "#/definitions/isoDateTime" },
         "feedback": { "type": "string" },
         "rejection_root_cause": { "$ref": "#/definitions/rootCause" },
         "verified_branch": { "$ref": "#/definitions/nonEmptyText" },
-        "verified_head": { "type": "string" }
+        "verified_head": { "$ref": "#/definitions/nonEmptyText" }
       },
       "oneOf": [
         {
@@ -634,15 +634,15 @@
         "deliverables": { "type": "array", "items": { "type": "string" } },
         "acceptance_package_ref": {
           "description": "必须指向已 decided 的 acceptance package；Controller 归档前校验其 status=decided（契约 §3.6→§3.7 审计链）",
-          "type": "string"
+          "$ref": "#/definitions/nonEmptyText"
         },
         "integration": {
           "type": "object",
           "additionalProperties": false,
           "required": ["checkpoint"],
           "properties": {
-            "pr": { "type": "string" },
-            "merge_commit": { "type": "string" },
+            "pr": { "$ref": "#/definitions/nonEmptyText" },
+            "merge_commit": { "$ref": "#/definitions/nonEmptyText" },
             "checkpoint": { "type": "string" }
           },
           "anyOf": [


### PR DESCRIPTION
> *This was generated by AI during triage.*

## 关联

- 关闭目标：#112（01 · 冻结主链 Stage 语义与回退/路由原则）
- 系列：#102 Slice 1 / #103 契约任务。#113/#114 为同链后继工单，将在本分支继续追加提交（阻塞链 #112 → #113 → #114）。

## 变更内容

新增 `docs/design/construction-workflow-portable-contract.md`（v0.1-draft，250 行）：

- §0–§1 定位、术语与冲突裁决顺序
- §2 固定七阶段主链与六条不变量（顺序固定、独立证明者、Proof 绑定真实现场、无旁路、挂起优于编造、一份语义）
- §3 各 Stage 输入 / 专业输出 / Proof / 回退根因四要素（§3.1–3.7）
- §4 回退与升级语义：根因路由表、自动回退额度 3 与计数原则、耗尽进 WAITING_HUMAN 并保留原 Outcome（对齐 #73/#77）、升级与回退的区分
- §5 Human Decision 与 Human Acceptance 边界（对齐 #72）、Design 条件门四条判据、决策包要求、禁止事项
- §6 Outcome/Routing 兼容原则：Producer/Router 分离、禁止 `next_node`、专业结果基元与路由动作基元、悬空禁止、#77 收敛映射承诺
- §7–§9 为 #113/#114 预留稳定骨架

## 对用户/工作流程的影响

- 为 DSH Profile（#105）与 External Profile（#104）提供共同唯一业务语义源的主链部分；下游工单 #113（Run/Workspace/交接包）与 #114（一致性矩阵/冻结）依赖本文件。
- 不改变现有蓝图行为与生成产物。

## 已运行的校验

- 纯文档变更（新增 docs/design/ 下一个文件），未修改蓝图与生成规则，`npm run generate`/`npm run validate` 不适用；
- 结构自验：7 Stage × 四要素覆盖、章节完整性已脚本核验（验收映射见 #112 工单报告）。

## 蓝图影响

- 无（`templates/*.json` 未改动，`.generated/` 未触碰）。