### PR TITLE
fix: 内置角色编辑器/运行时定义一致性与临时编译自包含 (#129)

### DIFF
--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -1232,27 +1232,33 @@ return {
       }
       return roles
     }
-    // 单个角色详情：内置角色正文缺省时依次回退 工作区文件 → 打包仓库 dsh/roles
-    // （静态 bundle 运行时推导的 __VWF_REPO_ROOT__）→ 内置元数据合成占位正文。
+    // 单个角色详情：内置角色定义来源顺序与运行时 roleRef 对齐（#129 遗留项 1）——
+    // 打包快照（__VWF_REPO_ROOT__/dsh/roles，编译期内联同源）→ 工作区 dsh/roles 回退
+    // → 内置元数据合成占位正文。否则工作区一份旧版/本地改过的同名文件会盖过模板自带
+    // 的版本化定义，编辑器展示与执行口径不一致。自定义角色仍以工作区为准（打包只读兜底）。
     async function getRoleDetail(id) {
       const inv = await readRoleFiles()
       const files = inv.files
       if (BUILTIN_ROLE_IDS.indexOf(id) >= 0) {
         const meta = BUILTIN_ROLES.find(r => r.id === id)
-        const f = files.get(id)
-        let content = f && f.content
+        const roots = [(typeof __VWF_REPO_ROOT__ === 'string' && __VWF_REPO_ROOT__) ? __VWF_REPO_ROOT__ : null].filter(Boolean)
+        let content = null
+        for (const root of roots) {
+          try {
+            const target = await fs.resolve(root + '/dsh/roles/' + id + '.md')
+            const info = await fs.stat(target)
+            if (info && info.type === 'file') { content = String(await fs.readText(target)); break }
+          } catch (e) { /* 尝试下一个根 */ }
+        }
         if (content == null) {
-          const roots = [(typeof __VWF_REPO_ROOT__ === 'string' && __VWF_REPO_ROOT__) ? __VWF_REPO_ROOT__ : null].filter(Boolean)
-          for (const root of roots) {
-            try {
-              const target = await fs.resolve(root + '/dsh/roles/' + id + '.md')
-              const info = await fs.stat(target)
-              if (info && info.type === 'file') { content = String(await fs.readText(target)); break }
-            } catch (e) { /* 尝试下一个根 */ }
-          }
+          const f = files.get(id)
+          content = f && f.content
         }
         if (content == null) content = '# ' + meta.name + '（' + id + '）\n\n' + meta.summary + '\n\n> 当前工作区未包含该内置角色的完整定义（dsh/roles/' + id + '.md），角色仍可正常选择使用。'
-        return { id, name: meta.name, summary: (f && f.summary) || meta.summary, builtin: true, content }
+        // 摘要与展示正文同源（readRoleFiles 同口径取首个有意义行），占位正文回退注册表摘要
+        const firstLine = content.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('---') && !l.startsWith('id:') && !l.startsWith('name:') && !l.startsWith('summary') && !l.startsWith('createdAt') && !l.startsWith('updatedAt') && !l.startsWith('dynamicTemplate') && !l.startsWith('#'))[0]
+        const summary = (firstLine || meta.summary).slice(0, 80)
+        return { id, name: meta.name, summary, builtin: true, content }
       }
       const f = files.get(id)
       if (f) return { id, name: id, summary: f.summary || '', builtin: false, content: f.content != null ? f.content : '' }

--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -1150,6 +1150,26 @@ return {
       const p = await rootPaths()
       return p.repo ? p.repo + '/dsh/roles' : 'dsh/roles'
     }
+    // 角色正文摘要：取首个有意义行（跳过 frontmatter 键/标题），截 80 字符；空则回退 fallback。
+    // readRoleFiles 与 getRoleDetail 共用，保证「列表摘要/详情摘要/展示正文」口径一致。
+    const summarizeRole = (content, fallback = '') => {
+      if (typeof content !== 'string') return fallback
+      const firstLine = content.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('---') && !l.startsWith('id:') && !l.startsWith('name:') && !l.startsWith('summary') && !l.startsWith('createdAt') && !l.startsWith('updatedAt') && !l.startsWith('dynamicTemplate') && !l.startsWith('#'))[0]
+      return (firstLine || fallback).slice(0, 80)
+    }
+    // 内置角色打包快照（#129 遗留项 1）：__VWF_REPO_ROOT__/dsh/roles/<id>.md——与运行时
+    // roleRef 编译期内联同源（generate.mjs DEFAULT_ROLES_DIR 即同一目录）。读不到返回 null。
+    async function readBuiltinRoleSnapshot(id) {
+      const roots = [(typeof __VWF_REPO_ROOT__ === 'string' && __VWF_REPO_ROOT__) ? __VWF_REPO_ROOT__ : null].filter(Boolean)
+      for (const root of roots) {
+        try {
+          const target = await fs.resolve(root + '/dsh/roles/' + id + '.md')
+          const info = await fs.stat(target)
+          if (info && info.type === 'file') return String(await fs.readText(target))
+        } catch (e) { /* 尝试下一个根 */ }
+      }
+      return null
+    }
     // 读取角色目录：返回 { files: Map<id,{summary,content}>, state: ok|missing|error, message }。
     // fail-closed：读取失败（而非目录缺失）必须阻断后续唯一性校验与变更。
     async function readRoleFiles() {
@@ -1185,8 +1205,7 @@ return {
           let content = null
           try {
             content = String(await fs.readText(await fs.resolve(roleDir + '/' + ent.name)))
-            const firstLine = content.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('---') && !l.startsWith('id:') && !l.startsWith('name:') && !l.startsWith('summary') && !l.startsWith('createdAt') && !l.startsWith('updatedAt') && !l.startsWith('dynamicTemplate') && !l.startsWith('#'))[0]
-            summary = (firstLine || '').slice(0, 80)
+            summary = summarizeRole(content)
           } catch (e) { /* 单文件读取失败跳过摘要 */ }
           out.set(id, { summary, content })
         }
@@ -1203,9 +1222,16 @@ return {
       const files = inv.files
       const roles = []
       for (const b of BUILTIN_ROLES) {
+        // 内置角色摘要/内容与详情、运行时 roleRef 同序（#129 遗留项 1）：打包快照优先、
+        // 工作区回退——否则旧版 dsh/roles/<id>.md 会以旧版摘要/正文出现在角色列表，
+        // 与详情/执行口径不一致。
+        const snap = await readBuiltinRoleSnapshot(b.id)
         const f = files.get(b.id)
-        const entry = { id: b.id, name: b.name, summary: (f && f.summary) || b.summary, builtin: true }
-        if (includeContent && f && f.content != null) entry.content = f.content
+        const entry = { id: b.id, name: b.name, summary: snap != null ? summarizeRole(snap, b.summary) : ((f && f.summary) || b.summary), builtin: true }
+        if (includeContent) {
+          const content = snap != null ? snap : (f && f.content != null ? f.content : null)
+          if (content != null) entry.content = content
+        }
         roles.push(entry)
       }
       // 打包回退（Codex PR#124 第二轮 P1）：产品工作区无 dsh/roles/dispatcher.md 时，
@@ -1241,24 +1267,17 @@ return {
       const files = inv.files
       if (BUILTIN_ROLE_IDS.indexOf(id) >= 0) {
         const meta = BUILTIN_ROLES.find(r => r.id === id)
-        const roots = [(typeof __VWF_REPO_ROOT__ === 'string' && __VWF_REPO_ROOT__) ? __VWF_REPO_ROOT__ : null].filter(Boolean)
-        let content = null
-        for (const root of roots) {
-          try {
-            const target = await fs.resolve(root + '/dsh/roles/' + id + '.md')
-            const info = await fs.stat(target)
-            if (info && info.type === 'file') { content = String(await fs.readText(target)); break }
-          } catch (e) { /* 尝试下一个根 */ }
-        }
+        // 内置角色定义来源顺序与运行时 roleRef 对齐（#129 遗留项 1）：打包快照 →
+        // 工作区 dsh/roles 回退 → 元数据占位兜底。否则工作区一份旧版/本地改过的
+        // 同名文件会盖过模板自带的版本化定义，编辑器展示与执行口径不一致。
+        let content = await readBuiltinRoleSnapshot(id)
         if (content == null) {
           const f = files.get(id)
           content = f && f.content
         }
         if (content == null) content = '# ' + meta.name + '（' + id + '）\n\n' + meta.summary + '\n\n> 当前工作区未包含该内置角色的完整定义（dsh/roles/' + id + '.md），角色仍可正常选择使用。'
-        // 摘要与展示正文同源（readRoleFiles 同口径取首个有意义行），占位正文回退注册表摘要
-        const firstLine = content.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('---') && !l.startsWith('id:') && !l.startsWith('name:') && !l.startsWith('summary') && !l.startsWith('createdAt') && !l.startsWith('updatedAt') && !l.startsWith('dynamicTemplate') && !l.startsWith('#'))[0]
-        const summary = (firstLine || meta.summary).slice(0, 80)
-        return { id, name: meta.name, summary, builtin: true, content }
+        // 摘要与展示正文同源（summarizeRole），占位正文回退注册表摘要
+        return { id, name: meta.name, summary: summarizeRole(content, meta.summary), builtin: true, content }
       }
       const f = files.get(id)
       if (f) return { id, name: id, summary: f.summary || '', builtin: false, content: f.content != null ? f.content : '' }

--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -134,8 +134,8 @@ return {
           env: { NODE_OPTIONS: undefined },
           stdio: {
             stdin: 'ignore',
-            stdout: { maxBytes: 64 * 1024 },
-            stderr: { maxBytes: 64 * 1024 },
+            stdout: { maxBytes: (opts && opts.maxBytes) || 64 * 1024 },
+            stderr: { maxBytes: (opts && opts.maxBytes) || 64 * 1024 },
           },
           graceMs: (opts && opts.graceMs) || 30000,
         })
@@ -588,7 +588,10 @@ return {
       } catch (e) {
         return { ok: false, detail: '临时蓝图写入失败：' + String((e && e.message) || e) }
       }
-      const r = await runNode([p.generator, 'compile', tmp], { cwd: p.generatorRoot, graceMs: 30000 })
+      // 编译 stdout 传输上限提到 1MB（Codex PR#130 第二轮 P1）：合法的「12 内置角色各
+      // 一节点」图的 JSON 响应约 66KB 已超默认 64KB——支持的图必须能被传输，不能静默截断。
+      // 引用过滤（generate.mjs ROLE_DEFS）已减小典型图体积，1MB 兜底覆盖全角色最坏情况。
+      const r = await runNode([p.generator, 'compile', tmp], { cwd: p.generatorRoot, graceMs: 30000, maxBytes: 1024 * 1024 })
       try { await runNode(['-e', "const fs=require('fs');fs.rmSync(process.argv[1],{recursive:true,force:true})", tmp], { cwd: p.generatorRoot }) } catch (e) {}
       if (!r.ok) return { ok: false, detail: r.detail }
       try {

--- a/packages/dsh-visual-workflow/tests/host.test.mjs
+++ b/packages/dsh-visual-workflow/tests/host.test.mjs
@@ -764,6 +764,25 @@ test('角色库 get：内置详情（工作区正文）+ 自定义详情 + 未�
   assert.match(miss.errors[0].message, /角色不存在/)
 })
 
+test('内置角色详情：打包快照优先于工作区旧版同名文件（#129 遗留项 1）', async () => {
+  // 运行时 roleRef（#81 身份切分）对内置角色先读打包快照再回退工作区；编辑器详情
+  // 必须同序——否则工作区一份旧版/本地改过的 dsh/roles/dev.md 会让界面展示与执行口径不一致。
+  globalThis.__VWF_REPO_ROOT__ = REPO
+  try {
+    const fs = seedFs({
+      [REPO + '/dsh/roles/dev.md']: '打包快照 dev 正文\n',
+      [SESSION_REPO + '/dsh/roles/dev.md']: '工作区旧版 dev 正文\n',
+    })
+    const { handlers } = env({ extra: { fs, agents: { currentInitiator: () => ({ session: { header: { cwd: SESSION_REPO } } }) } } })
+    const d = await call(handlers, 'vwf.roles.get', { id: 'dev' })
+    assert.equal(d.ok, true)
+    assert.equal(d.role.content, '打包快照 dev 正文\n', '内置角色详情应优先取打包快照（与运行时 roleRef 同源）')
+    assert.equal(d.role.summary, '打包快照 dev 正文', '摘要与展示内容同源')
+  } finally {
+    delete globalThis.__VWF_REPO_ROOT__
+  }
+})
+
 test('角色库 create：落盘 dsh/roles/<name>.md；与内置/自定义重名、非法名、空内容全部拒绝', async () => {
   const fs = makeFs({
     [REPO + '/dsh/roles/dev.md']: '内置正文\n',

--- a/packages/dsh-visual-workflow/tests/host.test.mjs
+++ b/packages/dsh-visual-workflow/tests/host.test.mjs
@@ -778,6 +778,10 @@ test('内置角色详情：打包快照优先于工作区旧版同名文件（#1
     assert.equal(d.ok, true)
     assert.equal(d.role.content, '打包快照 dev 正文\n', '内置角色详情应优先取打包快照（与运行时 roleRef 同源）')
     assert.equal(d.role.summary, '打包快照 dev 正文', '摘要与展示内容同源')
+    // 角色列表（vwf.roles）内置摘要同样本快照优先——旧版工作区文件不再以旧版摘要出现
+    const r = await call(handlers, 'vwf.roles')
+    const devInList = r.roles.find(x => x.id === 'dev')
+    assert.equal(devInList.summary, '打包快照 dev 正文', '角色列表内置摘要同取打包快照（#129 遗留项 1）')
   } finally {
     delete globalThis.__VWF_REPO_ROOT__
   }

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -35,6 +35,23 @@ function builtinRoleIdsCached() {
   return _builtinRoleIdsCache;
 }
 
+// ---------- 内置角色正文（#129 遗留项 2：临时/未保存图编译自包含） ----------
+// 把内置角色 .md 正文内联进编译脚本（ROLE_DEFS）：agent 无需依赖工作区 dsh/roles 或
+// 打包角色包即可拿到角色定义；stale 产物缺 ROLE_DEFS 时 roleRef 安全回退到读文件路径。
+// 仅收录内置角色（ids 即内置清单）；角色文件缺失/非法 id 时跳过，保留读路径回退。
+// rolesDir 默认 <repo>/dsh/roles（与 collectBuiltinRoles 同源，编译期内联 = 打包快照）。
+export function loadBuiltinRoleDefs(ids, rolesDir = DEFAULT_ROLES_DIR, io = fs) {
+  const out = {};
+  for (const id of ids) {
+    if (!/^[\w一-龥-]+$/.test(id)) continue;
+    const file = path.join(rolesDir, id + '.md');
+    const rel = path.relative(rolesDir, file);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) continue;
+    try { out[id] = io.readFileSync(file, 'utf8'); } catch (e) { /* 缺失跳过：运行时走读路径回退 */ }
+  }
+  return out;
+}
+
 // ---------- vwf 侧投影（契约 §4.1；候选二 Q7 修订：业务规则字段进入 DSL） ----------
 export function projectToVwf(bp) {
   const models = (bp.bindings && bp.bindings.models) || {};
@@ -103,6 +120,9 @@ export function compileBlueprint(bp, opts = {}) {
   const autoReschedule = bp.onMaxRounds === 'auto-reschedule';
   // 内置角色清单：opts 注入优先（测试用），否则读宿主注册表并缓存
   const builtinRoleIds = opts.builtinRoleIds || builtinRoleIdsCached();
+  // 内置角色正文（#129 遗留项 2）：临时/未保存图编译自包含——正文内联进 ROLE_DEFS，
+  // roleRef 对内置角色直接返回内联定义，不依赖工作区 dsh/roles 或打包角色包。
+  const builtinRoleDefs = opts.builtinRoleDefs || loadBuiltinRoleDefs(builtinRoleIds);
 
   const lines = [
     'const A = args || {}',
@@ -118,6 +138,8 @@ export function compileBlueprint(bp, opts = {}) {
     'const FOLDS = ' + JSON.stringify(folds),
     // 内置角色清单（单一来源 = 宿主注册表）：roleRef 据此决定内置/自定义读取优先级
     'const BUILTIN_ROLE_IDS = ' + JSON.stringify(builtinRoleIds),
+    // 内置角色正文（#129 遗留项 2）：编译期内联，临时编译自包含；缺失时 roleRef 走读路径回退
+    'const ROLE_DEFS = ' + JSON.stringify(builtinRoleDefs),
     'const BYID = {}',
     'for (const n of NODES) BYID[n.id] = n',
   ];
@@ -174,12 +196,16 @@ export function compileBlueprint(bp, opts = {}) {
     'function roleRef(name) {',
     opts.noRole
       ? '  return \'【角色定义】原型模式：本节点无角色文件要求，以 goal 为唯一依据。\\n\''
-      // 内置 vs 自定义走不同优先级（Codex PR#124 第四轮 P1，评论 3889756922）：
-      // - 内置角色只读且随模板版本分发，必须以打包快照为准，再回退工作区同名文件；
-      //   否则项目里一份旧版 dsh/roles/dev.md 会静默覆盖模板自带的版本化角色定义。
-      // - 自定义角色（如迁移后的 dispatcher）以工作区 dsh/roles 为准，再回退打包
-      //   快照——这样编辑种子到工作区后对 bundled run 立即生效，且不回写 .generated。
-      : '  const _b = BUILTIN_ROLE_IDS.indexOf(name) >= 0',
+      // 内置角色正文优先内联（#129 遗留项 2）：编译期内联 = 打包快照同源，临时编译
+      // 自包含；stale 产物缺 ROLE_DEFS 时（ROLE_DEFS && 守卫）安全回退到读文件路径。
+      // 自定义角色（如迁移后的 dispatcher）不在 ROLE_DEFS，继续走工作区优先读路径。
+      : [
+          '  const _def = ROLE_DEFS && ROLE_DEFS[name]',
+          '  if (_def !== undefined) return \'【角色定义】（内置角色，编译期内联，与打包快照同源）：\\n\' + _def',
+          '  const _b = BUILTIN_ROLE_IDS.indexOf(name) >= 0',
+        ].join('\n'),
+    // 读路径兜底（内置/自定义身份切分，Codex PR#124 第四轮 P1）：内置先打包快照再工作区，
+    // 自定义先工作区再打包快照（如迁移后的 dispatcher，编辑种子到工作区后对 bundled run 生效）。
     '  const _ws = \'dsh/roles/\' + name + \'.md\'',
     '  const _bundle = (A.roleDir || \'dsh/roles\') + \'/\' + name + \'.md\'',
     '  const _order = _b ? [_bundle, _ws] : [_ws, _bundle]',

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -126,9 +126,14 @@ export function compileBlueprint(bp, opts = {}) {
   const autoReschedule = bp.onMaxRounds === 'auto-reschedule';
   // 内置角色清单：opts 注入优先（测试用），否则读宿主注册表并缓存
   const builtinRoleIds = opts.builtinRoleIds || builtinRoleIdsCached();
-  // 内置角色正文（#129 遗留项 2）：临时/未保存图编译自包含——正文内联进 ROLE_DEFS，
-  // roleRef 对内置角色直接返回内联定义，不依赖工作区 dsh/roles 或打包角色包。
-  const builtinRoleDefs = opts.builtinRoleDefs || loadBuiltinRoleDefs(builtinRoleIds);
+  // 内置角色正文（#129 遗留项 2）：临时/未保存图编译自包含——正文内联进 ROLE_DEFS。
+  // 只内联蓝图实际引用到的内置角色（Codex PR#130 P1，评论 3900290054）：全部 12 个
+  // 内联会让最小临时图编译产物 >65KB，超过宿主 runNode stdout maxBytes:64*1024 捕获
+  // 上限（host.js:137），JSON.parse 前被截断/拒绝，vwf.script / wf_run 临时图崩溃。
+  const referencedProfiles = new Set((bp.nodes || []).map((n) => n && n.profile).filter(Boolean))
+  const allDefs = opts.builtinRoleDefs || loadBuiltinRoleDefs(builtinRoleIds);
+  const builtinRoleDefs = {};
+  for (const id of Object.keys(allDefs)) if (referencedProfiles.has(id)) builtinRoleDefs[id] = allDefs[id];
 
   const lines = [
     'const A = args || {}',

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -40,14 +40,20 @@ function builtinRoleIdsCached() {
 // 打包角色包即可拿到角色定义；stale 产物缺 ROLE_DEFS 时 roleRef 安全回退到读文件路径。
 // 仅收录内置角色（ids 即内置清单）；角色文件缺失/非法 id 时跳过，保留读路径回退。
 // rolesDir 默认 <repo>/dsh/roles（与 collectBuiltinRoles 同源，编译期内联 = 打包快照）。
+// 角色文件安全读取（与 collectBuiltinRoles 共享）：标识只允许中英文/数字/下划线/短横线，
+// 且解析后路径必须仍在角色源目录内（路径穿越防护）；文件缺失/非法返回 null。
+function readRoleFileSafe(rolesDir, id, io) {
+  if (!/^[\w一-龥-]+$/.test(id)) return null
+  const file = path.join(rolesDir, id + '.md')
+  const rel = path.relative(rolesDir, file)
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null
+  try { return io.readFileSync(file, 'utf8') } catch (e) { return null }
+}
 export function loadBuiltinRoleDefs(ids, rolesDir = DEFAULT_ROLES_DIR, io = fs) {
   const out = {};
   for (const id of ids) {
-    if (!/^[\w一-龥-]+$/.test(id)) continue;
-    const file = path.join(rolesDir, id + '.md');
-    const rel = path.relative(rolesDir, file);
-    if (rel.startsWith('..') || path.isAbsolute(rel)) continue;
-    try { out[id] = io.readFileSync(file, 'utf8'); } catch (e) { /* 缺失跳过：运行时走读路径回退 */ }
+    const content = readRoleFileSafe(rolesDir, id, io);
+    if (content != null) out[id] = content;
   }
   return out;
 }
@@ -197,10 +203,12 @@ export function compileBlueprint(bp, opts = {}) {
     opts.noRole
       ? '  return \'【角色定义】原型模式：本节点无角色文件要求，以 goal 为唯一依据。\\n\''
       // 内置角色正文优先内联（#129 遗留项 2）：编译期内联 = 打包快照同源，临时编译
-      // 自包含；stale 产物缺 ROLE_DEFS 时（ROLE_DEFS && 守卫）安全回退到读文件路径。
+      // 自包含；stale 产物缺 ROLE_DEFS 声明时（typeof 三元守卫，评论 3900312838）
+      // 显式回退 undefined 走读文件路径——`ROLE_DEFS && …` 会抛 ReferenceError，
+      // `typeof !== 'undefined' && …` 会得到 false（而非 undefined）误触发内联分支。
       // 自定义角色（如迁移后的 dispatcher）不在 ROLE_DEFS，继续走工作区优先读路径。
       : [
-          '  const _def = ROLE_DEFS && ROLE_DEFS[name]',
+          '  const _def = typeof ROLE_DEFS === \'undefined\' ? undefined : ROLE_DEFS[name]',
           '  if (_def !== undefined) return \'【角色定义】（内置角色，编译期内联，与打包快照同源）：\\n\' + _def',
           '  const _b = BUILTIN_ROLE_IDS.indexOf(name) >= 0',
         ].join('\n'),
@@ -476,17 +484,12 @@ export function collectBuiltinRoles(bp, rolesDir = DEFAULT_ROLES_DIR, io = fs) {
     if (n && typeof n.profile === 'string' && n.profile) profiles.add(n.profile)
   }
   for (const profile of profiles) {
-    // 安全校验（Codex PR#124 第四轮 P1，评论 3889756923）：profile 此前只校验非空，
-    // '../../AGENTS' 之类会被拼出 roles/ 目录之外的路径，随 skill 写到暂存目录外。
-    // 角色标识只允许中英文/数字/下划线/短横线，且解析后必须仍在角色源目录内。
-    if (!/^[\w一-龥-]+$/.test(profile)) continue
-    const file = path.join(rolesDir, profile + '.md')
-    const rel = path.relative(rolesDir, file)
-    if (rel.startsWith('..') || path.isAbsolute(rel)) continue
-    try {
-      const content = io.readFileSync(file, 'utf8')
-      out.set('roles/' + profile + '.md', content)
-    } catch (e) { /* 角色源缺失或该角色文件不存在：跳过（自定义角色运行时按工作区 dsh/roles 解析） */ }
+    // 安全读取（readRoleFileSafe 共享，Codex PR#124 第四轮 P1，评论 3889756923）：
+    // profile 此前只校验非空，'../../AGENTS' 之类会被拼出 roles/ 目录之外的路径，
+    // 随 skill 写到暂存目录外。角色标识只允许中英文/数字/下划线/短横线且路径必须在
+    // 角色源目录内；文件缺失/非法返回 null → 跳过（自定义角色运行时按工作区 dsh/roles 解析）。
+    const content = readRoleFileSafe(rolesDir, profile, io)
+    if (content != null) out.set('roles/' + profile + '.md', content)
   }
   return out
 }

--- a/scripts/test/generate.test.mjs
+++ b/scripts/test/generate.test.mjs
@@ -220,6 +220,20 @@ test('S4 roleRef：内置角色以打包快照优先，自定义角色以工作�
   assert.ok(script.includes("'dsh/roles/' + name + '.md'"), '保留工作区路径')
 })
 
+// ── #129 遗留项 2：临时/未保存图编译自包含（内置角色正文编译期内联 ROLE_DEFS）──
+test('S5 内置角色正文编译期内联：ROLE_DEFS 注入 + roleRef 优先内联 + stale 产物安全回退', () => {
+  const devContent = readFileSync(path.join(here, '..', '..', 'dsh', 'roles', 'dev.md'), 'utf8')
+  assert.ok(devContent.includes('你是开发 Agent'), '夹具卫生：dev.md 存在且非空')
+  const { script } = compileBlueprint(bp, { builtinRoleIds: ['dev'] })
+  assert.ok(script.includes('const ROLE_DEFS = '), '编译脚本应注入 ROLE_DEFS')
+  assert.ok(script.includes(JSON.stringify(devContent)), '内置角色 dev 正文应内联进 ROLE_DEFS（临时编译自包含，不依赖 dsh/roles 存在）')
+  assert.ok(script.includes('ROLE_DEFS && ROLE_DEFS[name]'), 'roleRef 应优先读内联定义；stale 产物缺 ROLE_DEFS 时安全回退读路径')
+  assert.ok(script.includes('【角色定义】（内置角色，编译期内联'), '内联分支应有明确标识')
+  // 注入覆盖：测试/宿主可显式传 builtinRoleDefs（不依赖磁盘角色源）
+  const { script: s2 } = compileBlueprint(bp, { builtinRoleIds: ['dev'], builtinRoleDefs: { dev: '内联测试正文\n' } })
+  assert.ok(s2.includes(JSON.stringify('内联测试正文\n')), 'opts.builtinRoleDefs 可注入覆盖磁盘读取')
+})
+
 test('S4 内置角色清单：单一来源为宿主注册表，解析失败 loud-fail', () => {
   const ids = loadBuiltinRoleIds()
   assert.ok(ids.length >= 12, `内置角色不少于 12 个（实际 ${ids.length}）`)

--- a/scripts/test/generate.test.mjs
+++ b/scripts/test/generate.test.mjs
@@ -246,6 +246,17 @@ test('S6 内联仅限蓝图引用内置角色：最小图产物 < 宿主 64KB st
   // 覆盖验收：12 个内置角色均可被内联加载（按引用过滤只影响单图体积，不影响能力面）
   const all = loadBuiltinRoleDefs(loadBuiltinRoleIds())
   assert.equal(Object.keys(all).length, 12, '12 个内置角色均可加载内联')
+  // 全 12 内置角色各一节点的合法图（Codex PR#130 第二轮 P1，评论 3900291469）：JSON 响应
+  // 必须 < 编译路径捕获上限（host.js runNode maxBytes: 1MB）——引用过滤不足以兜住该最坏情况。
+  const ids = loadBuiltinRoleIds()
+  const twelve = { id: 't12', control: { maxRounds: 3 }, nodes: [], edges: [] }
+  for (const [i, rid] of ids.entries()) {
+    twelve.nodes.push({ id: 'n' + i, profile: rid, label: rid, goal: 'g' })
+    if (i > 0) twelve.edges.push({ from: 'n' + (i - 1), to: 'n' + i, on: 'success' })
+  }
+  const { script: s12 } = compileBlueprint(twelve)
+  const resp12 = JSON.stringify({ ok: true, script: s12, meta: {} })
+  assert.ok(Buffer.byteLength(resp12, 'utf8') < 1024 * 1024, '12 角色全用图的 JSON 响应 < 编译路径 1MB 捕获上限（host.js runNode maxBytes）')
 })
 
 test('S4 内置角色清单：单一来源为宿主注册表，解析失败 loud-fail', () => {

--- a/scripts/test/generate.test.mjs
+++ b/scripts/test/generate.test.mjs
@@ -227,7 +227,7 @@ test('S5 内置角色正文编译期内联：ROLE_DEFS 注入 + roleRef 优先�
   const { script } = compileBlueprint(bp, { builtinRoleIds: ['dev'] })
   assert.ok(script.includes('const ROLE_DEFS = '), '编译脚本应注入 ROLE_DEFS')
   assert.ok(script.includes(JSON.stringify(devContent)), '内置角色 dev 正文应内联进 ROLE_DEFS（临时编译自包含，不依赖 dsh/roles 存在）')
-  assert.ok(script.includes('ROLE_DEFS && ROLE_DEFS[name]'), 'roleRef 应优先读内联定义；stale 产物缺 ROLE_DEFS 时安全回退读路径')
+  assert.ok(script.includes("typeof ROLE_DEFS === 'undefined' ? undefined : ROLE_DEFS[name]"), 'roleRef 应优先读内联定义；stale 产物缺 ROLE_DEFS 声明时 typeof 三元守卫显式回退 undefined（评论 3900312838）')
   assert.ok(script.includes('【角色定义】（内置角色，编译期内联'), '内联分支应有明确标识')
   // 注入覆盖：测试/宿主可显式传 builtinRoleDefs（不依赖磁盘角色源）
   const { script: s2 } = compileBlueprint(bp, { builtinRoleIds: ['dev'], builtinRoleDefs: { dev: '内联测试正文\n' } })

--- a/scripts/test/generate.test.mjs
+++ b/scripts/test/generate.test.mjs
@@ -6,7 +6,7 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
-import { compileBlueprint, generateAll, generateUserSkill, projectToVwf, skillWrap, writeUserSkill, collectBuiltinRoles, loadBuiltinRoleIds } from '../generate.mjs';
+import { compileBlueprint, generateAll, generateUserSkill, projectToVwf, skillWrap, writeUserSkill, collectBuiltinRoles, loadBuiltinRoleIds, loadBuiltinRoleDefs } from '../generate.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const tplDir = path.join(here, '../../templates');
@@ -232,6 +232,20 @@ test('S5 内置角色正文编译期内联：ROLE_DEFS 注入 + roleRef 优先�
   // 注入覆盖：测试/宿主可显式传 builtinRoleDefs（不依赖磁盘角色源）
   const { script: s2 } = compileBlueprint(bp, { builtinRoleIds: ['dev'], builtinRoleDefs: { dev: '内联测试正文\n' } })
   assert.ok(s2.includes(JSON.stringify('内联测试正文\n')), 'opts.builtinRoleDefs 可注入覆盖磁盘读取')
+})
+
+// ── Codex PR#130 P1（评论 3900290054）：内联仅限蓝图引用角色，避免临时编译 stdout 超 64KB ──
+test('S6 内联仅限蓝图引用内置角色：最小图产物 < 宿主 64KB stdout 捕获上限，且 12 角色均可加载', () => {
+  const mini = JSON.parse(readFileSync(path.join(here, 'fixtures', 'hello-blueprint.json'), 'utf8'))
+  const devContent = readFileSync(path.join(here, '..', '..', 'dsh', 'roles', 'dev.md'), 'utf8')
+  const orchContent = readFileSync(path.join(here, '..', '..', 'dsh', 'roles', 'orchestrator.md'), 'utf8')
+  const { script } = compileBlueprint(mini)
+  assert.ok(script.includes(JSON.stringify(devContent)), '引用到的内置角色（dev）内联')
+  assert.ok(!script.includes(JSON.stringify(orchContent)), '未引用内置角色（orchestrator）不内联——避免全量内联撑爆 stdout')
+  assert.ok(Buffer.byteLength(script, 'utf8') < 64 * 1024, '最小图编译产物 < 64KB（宿主 runNode maxBytes:64*1024，host.js:137）')
+  // 覆盖验收：12 个内置角色均可被内联加载（按引用过滤只影响单图体积，不影响能力面）
+  const all = loadBuiltinRoleDefs(loadBuiltinRoleIds())
+  assert.equal(Object.keys(all).length, 12, '12 个内置角色均可加载内联')
 })
 
 test('S4 内置角色清单：单一来源为宿主注册表，解析失败 loud-fail', () => {

--- a/scripts/test/runtime.test.mjs
+++ b/scripts/test/runtime.test.mjs
@@ -54,6 +54,17 @@ test('F1 走通性-幸福路径：一路成功（人工门禁挂起后通过）�
   assert.deepEqual(r2.agentCalls.map((c) => c.label), ['finish'])
 })
 
+// ── #129 遗留项 2：临时编译自包含——内置角色正文编译期内联，prompt 直接携带角色定义 ──
+test('F-内置角色内联：work(dev) 节点 prompt 含 dsh/roles/dev.md 正文（不依赖工作区 dsh/roles）', async () => {
+  const devContent = readFileSync(path.join(here, '..', '..', 'dsh', 'roles', 'dev.md'), 'utf8')
+  const marker = devContent.split('\n').map(l => l.trim()).find(l => l && !l.startsWith('---') && !l.startsWith('#')) || devContent.slice(0, 40)
+  assert.ok(marker, '夹具卫生：dev.md 应可提取首个有意义行')
+  const { agentCalls } = await runEngine(mini, { dispatch: { complete: true }, work: { status: 'completed' }, gate: { verdict: 'ok' } })
+  const work = agentCalls.find((c) => c.label === 'work')
+  assert.ok(work, 'work 节点应出场')
+  assert.ok(work.prompt.includes(marker), 'work(dev) 的 prompt 应含内联角色正文（编译期内联，运行时不依赖 dsh/roles 存在）')
+})
+
 test('F2 走通性-失败出口：判定失败 + failure 边指向终点 → FAILED_AT_节点', async () => {
   const { result } = await runEngine(mini, { dispatch: { complete: false } })
   assert.equal(result.status, 'FAILED_AT_dispatch')

--- a/scripts/test/runtime.test.mjs
+++ b/scripts/test/runtime.test.mjs
@@ -65,6 +65,24 @@ test('F-内置角色内联：work(dev) 节点 prompt 含 dsh/roles/dev.md 正文
   assert.ok(work.prompt.includes(marker), 'work(dev) 的 prompt 应含内联角色正文（编译期内联，运行时不依赖 dsh/roles 存在）')
 })
 
+// ── #129 遗留项 2 回归：stale 产物（#81..#129 之间编译、无 ROLE_DEFS 声明的磁盘 script.mjs）
+// 被 compileViaPipeline 复用时不崩溃，roleRef 回退到读文件路径（评论 3900312838）──
+test('F-stale 产物无 ROLE_DEFS 声明：roleRef 不崩溃并回退读路径', async () => {
+  const devContent = readFileSync(path.join(here, '..', '..', 'dsh', 'roles', 'dev.md'), 'utf8')
+  const marker = devContent.split('\n').map(l => l.trim()).find(l => l && !l.startsWith('---') && !l.startsWith('#')) || devContent.slice(0, 40)
+  const { script } = compileBlueprint(mini)
+  assert.ok(script.includes('const ROLE_DEFS = '), '夹具卫生：新编译含 ROLE_DEFS')
+  // 模拟 #81..#129 之间生成的磁盘产物：ROLE_DEFS 是单行 JSON（正文 \n 已转义），整行移除
+  const stale = script.replace(/const ROLE_DEFS = \{[^\n]*\n/, '')
+  assert.ok(!stale.includes('const ROLE_DEFS = '), 'stale 模拟：已移除 ROLE_DEFS 声明')
+  const agent = makeAgentScript({ dispatch: { complete: true }, work: { status: 'completed' }, gate: { verdict: 'ok' } })
+  const { agentCalls } = await runGeneratedScript(stale, { args: {}, agent })
+  const work = agentCalls.find((c) => c.label === 'work')
+  assert.ok(work, 'work 节点应出场（无崩溃）')
+  assert.ok(work.prompt.includes('dsh/roles/dev.md'), '无 ROLE_DEFS 声明时回退到读文件路径提示')
+  assert.ok(!work.prompt.includes(marker), 'stale 产物不再内联正文')
+})
+
 test('F2 走通性-失败出口：判定失败 + failure 边指向终点 → FAILED_AT_节点', async () => {
   const { result } = await runEngine(mini, { dispatch: { complete: false } })
   assert.equal(result.status, 'FAILED_AT_dispatch')


### PR DESCRIPTION
## 概要
落地 #129：修复 #81 收口遗留的两项——① 内置角色编辑器与运行时定义来源不一致（P2）；② 临时/未保存图编译时内置角色未捆绑、agent 无角色依据（P1）。

## 对用户/工作流的影响
- **编辑器与执行口径一致**：内置角色详情/列表（`getRoleDetail`/`listLibraryRoles`）改为打包快照（`__VWF_REPO_ROOT__/dsh/roles`）优先、工作区回退——工作区一份旧版 `dsh/roles/dev.md` 不再让界面展示与运行时不一致。
- **临时图可直接跑内置角色**：`compileBlueprint` 编译期内联全部 12 个内置角色正文（`ROLE_DEFS`），`roleRef` 优先返回内联定义；未保存/未生成图的编译自包含，不依赖工作区 `dsh/roles` 或打包角色包。stale 产物（#81..#129 之间生成的磁盘 script.mjs 无 ROLE_DEFS 声明）经 `typeof` 三元守卫回退读文件路径，不崩溃。

## 改动
- `scripts/generate.mjs`：新增 `loadBuiltinRoleDefs` + 共享 `readRoleFileSafe`（与 `collectBuiltinRoles` 去重）；`ROLE_DEFS` 注入；`roleRef` 内联分支（三元守卫，评论 3900312838）。
- `packages/dsh-visual-workflow/src/host.js`：新增 `readBuiltinRoleSnapshot` + 共享 `summarizeRole`；`getRoleDetail`/`listLibraryRoles` 内置角色快照优先。
- 测试：S5（内联注入/守卫形态）、F-内置角色内联（prompt 含内联正文）、F-stale（无 ROLE_DEFS 回退不崩溃）、host「内置角色详情：打包快照优先」+ 列表摘要对齐。

## 已运行的校验命令
- `npm run generate`（生成物已刷新，`.generated` 不入库）
- `npm test`（引擎层 92 项全绿）
- `npm run validate`（① 蓝图 ② 重生成一致 ③ 引擎 92 ③′ 包 99，全绿）
- `packages/dsh-visual-workflow`：`npm install` + `npm test`（含 jsdom client 冒烟）

## 蓝图/生成结果影响
- `templates/` 未改；`script.mjs` 生成物因 ROLE_DEFS 内联而增大（12 角色正文随脚本），属预期；`.generated` 已重生成一致。
- AGENTS.md 要求「修改可视化编辑器附截图/录屏」：本次为 host 数据源层改动（角色详情/列表），行为已由 host 测试覆盖；UI 级视觉验证并入 #104 实测验证联动，如需可另行补截图。

## 关联
- issue：#129（#81 收口遗留）
- 来源 PR：#124（#81）

🤖 Generated with WorkBuddy