### PR TITLE
feat(construction): 证据链机器校验引擎 cwf-evidence-verify (#123, dogfood Run cwf-123-01)

### DIFF
--- a/dsh/skills/construction-bootstrap/runbook.md
+++ b/dsh/skills/construction-bootstrap/runbook.md
@@ -62,7 +62,13 @@ node "$CWF_ASSETS/cwf-record.mjs" write .agent-runs/<run_id> requirements_baseli
 
 ## 6. Human Acceptance（人工验收）— 契约 §3.6
 
-1. 执行 **§8.3 九项证据链校验**（当前人工逐条执行；#123 交付后由 `cwf-evidence-verify` 机器化）：record_type↔stage 映射、上游完成态（baseline confirmed / design package_ready / dev handoff_ready / review approve / test pass）、同 Run lineage、Proof HEAD 与当前一致、映射完整覆盖、produced_by 异源、chosen∈呈递候选集。
+1. 执行 **§8.3 九项证据链校验**（机器化）：
+
+```bash
+node "$CWF_ASSETS/cwf-evidence-verify.mjs" .agent-runs/<run_id>
+```
+
+   逐项输出判定；exit 非 0 即不得呈递或签收。人工知情接受（user_accepted）加 `--decision user_accepted`（②⑧ 放宽，feedback 必填说明差异）。
 2. `user_accepted` 例外：允许携带 fail/blocked 证据链知情接受，必须附 feedback 说明差异（不得伪造证据）。
 3. 执行 Integration Checkpoint：
 

--- a/dsh/skills/construction-bootstrap/runbook.md
+++ b/dsh/skills/construction-bootstrap/runbook.md
@@ -62,22 +62,22 @@ node "$CWF_ASSETS/cwf-record.mjs" write .agent-runs/<run_id> requirements_baseli
 
 ## 6. Human Acceptance（人工验收）— 契约 §3.6
 
-1. 执行 **§8.3 九项证据链校验**（机器化）：
-
-```bash
-node "$CWF_ASSETS/cwf-evidence-verify.mjs" .agent-runs/<run_id>
-```
-
-   逐项输出判定；exit 非 0 即不得呈递或签收。人工知情接受（user_accepted）加 `--decision user_accepted`（②⑧ 放宽，feedback 必填说明差异）。
-2. `user_accepted` 例外：允许携带 fail/blocked 证据链知情接受，必须附 feedback 说明差异（不得伪造证据）。
-3. 执行 Integration Checkpoint：
+1. 执行 Integration Checkpoint：
 
 ```bash
 node "$CWF_ASSETS/cwf-checkpoint.mjs" .agent-runs/<run_id>
 ```
 
    target 已前进 → 先 sync，再执行 `node "$CWF_ASSETS/cwf-record.mjs" reverify <runDir> --reason "checkpoint sync"` 推进 Proof 修订（保留原 HEAD 记录，不耗额度），重跑受影响 Proof（review/test 新 attempt 文件），再 `--proofs-rerun`。
-4. 组装 `assembled`（五类引用 + 结构化 checkpoint），`write acceptance_package`（status=awaiting_decision），呈递人工。
+2. 组装 `assembled`（五类引用 + 结构化 checkpoint），`write acceptance_package`（status=awaiting_decision）。
+3. 执行 **§8.3 九项证据链校验**（机器化；引擎要求验收包已写入，故校验在组装之后）：
+
+```bash
+node "$CWF_ASSETS/cwf-evidence-verify.mjs" .agent-runs/<run_id>
+```
+
+   逐项输出判定；exit 非 0 即不得呈递或签收。人工知情接受（user_accepted）加 `--decision user_accepted`（②⑧ 放宽，feedback 必填说明差异；不得伪造证据）。
+4. 呈递人工。
 5. 人工裁决后回填 `status=decided` + `decision` + `decided_by/at` + `verified_branch/head`（+ reject 时 feedback/根因），重新 `write`。
 6. **reject 路由**：验收 reject ≠ 进 closeout——执行人工触发回退（不耗自动额度，§4.2）：
 

--- a/scripts/cwf-evidence-verify.mjs
+++ b/scripts/cwf-evidence-verify.mjs
@@ -4,6 +4,7 @@
 //   默认校验 accept 路径；--decision user_accepted 启用知情接受例外（②⑧ 放宽，feedback 必填）
 // 输出逐项 JSON 判定；exit 0 全部通过，exit 1 任一失败
 
+import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -16,11 +17,25 @@ const STAGE_MAP = {
   test_proof: 'test',
 }
 
+function liveState(runDir) {
+  // Proof 绑定比对的实况源：不信任 run.json 可变缓存（§7.3）
+  const wt = join(runDir, '..', '..')
+  try {
+    return {
+      head: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: wt, encoding: 'utf-8' }).trim(),
+      branch: execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: wt, encoding: 'utf-8' }).trim(),
+    }
+  } catch {
+    return null // 归档态（worktree 已移除）回退 run.json
+  }
+}
+
 function loadJson(p) {
   return JSON.parse(readFileSync(p, 'utf-8'))
 }
 
-export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false } = {}) {
+export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false, live = null } = {}) {
+  // live：实况 HEAD/branch 注入（测试）或缺省从 git 读取——Proof 绑定比对以实况为准，不信任 run.json 缓存
   const checks = []
   const check = (id, name, ok, detail) => checks.push({ id, name, ok, detail })
 
@@ -66,16 +81,23 @@ export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false } = {}
   const branches = new Set(all.map(r => r.run?.work_branch))
   const okLineage = runIds.size === 1 && workspaces.size === 1 && branches.size === 1
     && [...runIds][0] === run.run_id && [...branches][0] === run.work_branch
+    && [...workspaces][0] === run.workspace_id
   check('③', '同 Run/workspace lineage', okLineage, okLineage ? 'ok' : `run_id=${[...runIds]} ws=${[...workspaces]} br=${[...branches]}`)
 
-  // ④ Proof HEAD/branch 与当前一致（§7.3）
+  // ④ Proof HEAD/branch 与实况一致（§7.3）：不信任 run.json 缓存
+  const liveNow = live || liveState(runDir)
+  const refHead = liveNow ? liveNow.head : run.current_head
+  const refBranch = liveNow ? liveNow.branch : run.work_branch
   const badHead = []
   for (const [rt, r] of [['review_proof', review], ['test_proof', test]]) {
-    if (r && (r.payload?.verified_head !== run.current_head || r.payload?.verified_branch !== run.work_branch)) {
-      badHead.push(`${rt}(head=${r.payload?.verified_head})`)
+    if (r && (r.payload?.verified_head !== refHead || r.payload?.verified_branch !== refBranch)) {
+      badHead.push(`${rt}(head=${r.payload?.verified_head} ≠ 实况 ${refHead})`)
     }
   }
-  check('④', 'Proof 绑定当前 HEAD/branch', badHead.length === 0, badHead.join('; ') || 'ok')
+  if (liveNow && run.current_head !== liveNow.head) {
+    badHead.push(`run.json current_head(${run.current_head}) 落后于实况——先 reverify`)
+  }
+  check('④', 'Proof 绑定实况 HEAD/branch', badHead.length === 0, badHead.join('; ') || 'ok')
 
   // ⑤ baseline confirmed 且无残留 gaps
   const ok5 = baseline?.payload?.status === 'confirmed' && (baseline.payload.gaps || []).length === 0
@@ -87,6 +109,8 @@ export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false } = {}
   if (ok6 && design.payload.decision_required) {
     if (!design.payload.decision) {
       ok6 = false; detail6 = '命中条件门但无 Decision Record'
+    } else if (!design.payload.decision_request) {
+      ok6 = false; detail6 = '命中条件门但缺 decision_request（呈递候选集丢失）'
     } else if (design.payload.decision_request) {
       const names = design.payload.decision_request.options.map(o => o.name)
       if (!names.includes(design.payload.decision.chosen)) {

--- a/scripts/cwf-evidence-verify.mjs
+++ b/scripts/cwf-evidence-verify.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// 证据链机器校验引擎（契约 §8.3 九项呈递/签收前校验）
+// 用法：node scripts/cwf-evidence-verify.mjs <runDir> [--decision user_accepted]
+//   默认校验 accept 路径；--decision user_accepted 启用知情接受例外（②⑧ 放宽，feedback 必填）
+// 输出逐项 JSON 判定；exit 0 全部通过，exit 1 任一失败
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const STAGE_MAP = {
+  requirements_baseline: 'requirements',
+  design_package: 'design',
+  dev_handoff: 'dev',
+  review_proof: 'review',
+  test_proof: 'test',
+}
+
+function loadJson(p) {
+  return JSON.parse(readFileSync(p, 'utf-8'))
+}
+
+export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false } = {}) {
+  const checks = []
+  const check = (id, name, ok, detail) => checks.push({ id, name, ok, detail })
+
+  const run = loadJson(join(runDir, 'run.json'))
+  const index = loadJson(join(runDir, 'index.json'))
+  const apFile = index.acceptance_package
+  if (!apFile || !existsSync(join(runDir, apFile))) {
+    check('chain', '验收包存在', false, 'index.json 无 acceptance_package 指向')
+    return { ok: false, checks }
+  }
+  const ap = loadJson(join(runDir, apFile))
+  const refs = ap.payload?.assembled || {}
+  const records = {}
+  for (const [field, ref] of Object.entries(refs)) {
+    if (field === 'integration_checkpoint') continue
+    const rt = field.replace(/_ref$/, '')
+    records[rt] = existsSync(join(runDir, ref)) ? loadJson(join(runDir, ref)) : null
+  }
+
+  // ① record_type 与产生 Stage 映射正确（§8.1）
+  const badMap = Object.entries(records)
+    .filter(([rt, r]) => r && (r.record_type !== rt || r.run?.stage !== STAGE_MAP[rt]))
+    .map(([rt, r]) => `${rt}(实际 ${r.record_type}/${r.run?.stage})`)
+  check('①', 'record_type 与 Stage 映射', badMap.length === 0, badMap.join('; ') || 'ok')
+
+  const review = records.review_proof, test = records.test_proof
+  const dev = records.dev_handoff, design = records.design_package
+  const baseline = records.requirements_baseline
+
+  // ② review approve + test pass（user_accepted 例外放宽）
+  if (relaxedUserAccepted) {
+    const okFb = typeof ap.payload?.feedback === 'string' && /\S/.test(ap.payload.feedback)
+    check('②', 'user_accepted 例外：feedback 非空说明差异', okFb, okFb ? 'ok' : 'feedback 缺失')
+  } else {
+    const ok = review?.payload?.verdict === 'approve' && test?.payload?.verdict === 'pass'
+    check('②', 'review approve 且 test pass', ok, ok ? 'ok' : `review=${review?.payload?.verdict} test=${test?.payload?.verdict}`)
+  }
+
+  // ③ 同 Run / 同 workspace lineage
+  const all = [baseline, design, dev, review, test, ap].filter(Boolean)
+  const runIds = new Set(all.map(r => r.run?.run_id))
+  const workspaces = new Set(all.map(r => r.run?.workspace_id))
+  const branches = new Set(all.map(r => r.run?.work_branch))
+  const okLineage = runIds.size === 1 && workspaces.size === 1 && branches.size === 1
+    && [...runIds][0] === run.run_id && [...branches][0] === run.work_branch
+  check('③', '同 Run/workspace lineage', okLineage, okLineage ? 'ok' : `run_id=${[...runIds]} ws=${[...workspaces]} br=${[...branches]}`)
+
+  // ④ Proof HEAD/branch 与当前一致（§7.3）
+  const badHead = []
+  for (const [rt, r] of [['review_proof', review], ['test_proof', test]]) {
+    if (r && (r.payload?.verified_head !== run.current_head || r.payload?.verified_branch !== run.work_branch)) {
+      badHead.push(`${rt}(head=${r.payload?.verified_head})`)
+    }
+  }
+  check('④', 'Proof 绑定当前 HEAD/branch', badHead.length === 0, badHead.join('; ') || 'ok')
+
+  // ⑤ baseline confirmed 且无残留 gaps
+  const ok5 = baseline?.payload?.status === 'confirmed' && (baseline.payload.gaps || []).length === 0
+  check('⑤', 'baseline confirmed 且无残留 gaps', ok5, ok5 ? 'ok' : `status=${baseline?.payload?.status} gaps=${(baseline?.payload?.gaps || []).length}`)
+
+  // ⑥ design package_ready；过门必带 Decision Record 且 chosen ∈ 呈递候选集
+  let ok6 = design?.payload?.outcome === 'package_ready'
+  let detail6 = ok6 ? 'ok' : `outcome=${design?.payload?.outcome}`
+  if (ok6 && design.payload.decision_required) {
+    if (!design.payload.decision) {
+      ok6 = false; detail6 = '命中条件门但无 Decision Record'
+    } else if (design.payload.decision_request) {
+      const names = design.payload.decision_request.options.map(o => o.name)
+      if (!names.includes(design.payload.decision.chosen)) {
+        ok6 = false; detail6 = `chosen(${design.payload.decision.chosen}) 不在呈递候选集 ${names}`
+      }
+    }
+  }
+  check('⑥', 'design package_ready 且过门已决', ok6, detail6)
+
+  // ⑦ dev handoff_ready
+  const ok7 = dev?.payload?.outcome === 'handoff_ready'
+  check('⑦', 'dev handoff_ready', ok7, ok7 ? 'ok' : `outcome=${dev?.payload?.outcome}`)
+
+  // ⑧ 验收映射与基线验收标准逐条完整无重复对应
+  const want = baseline?.payload?.acceptance || []
+  const mapping = (test?.payload?.acceptance_mapping || []).map(m => m.acceptance_item)
+  const dup = mapping.filter((m, i) => mapping.indexOf(m) !== i)
+  const missing = want.filter(w => !mapping.includes(w))
+  const extra = mapping.filter(m => !want.includes(m))
+  let ok8 = missing.length === 0 && extra.length === 0 && dup.length === 0
+  let detail8 = ok8 ? 'ok' : `missing=${missing.length} extra=${extra.length} dup=${dup.length}`
+  if (ok8 && !relaxedUserAccepted) {
+    const notPass = (test.payload.acceptance_mapping || []).filter(m => m.result !== 'pass')
+    ok8 = notPass.length === 0
+    if (!ok8) detail8 = `非 pass 结果 ${notPass.length} 项`
+  }
+  check('⑧', '验收映射完整无重复（accept 场景全 pass）', ok8, detail8)
+
+  // ⑨ review/test 产生者异于 dev（异源自证禁令）
+  const ok9 = review && test && dev
+    && review.produced_by !== dev.produced_by && test.produced_by !== dev.produced_by
+  check('⑨', 'review/test 与 dev 异源（produced_by）', Boolean(ok9), ok9 ? 'ok' : `review=${review?.produced_by} test=${test?.produced_by} dev=${dev?.produced_by}`)
+
+  return { ok: checks.every(c => c.ok), checks }
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const runDir = args[0]
+  if (!runDir) {
+    console.error('用法: node scripts/cwf-evidence-verify.mjs <runDir> [--decision user_accepted]')
+    process.exit(2)
+  }
+  const relaxedUserAccepted = args.includes('--decision') && args[args.indexOf('--decision') + 1] === 'user_accepted'
+  const result = verifyEvidenceChain(runDir, { relaxedUserAccepted })
+  console.log(JSON.stringify(result, null, 2))
+  process.exit(result.ok ? 0 : 1)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+}

--- a/scripts/cwf-evidence-verify.mjs
+++ b/scripts/cwf-evidence-verify.mjs
@@ -67,8 +67,9 @@ export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false, live 
 
   // ② review approve + test pass（user_accepted 例外放宽）
   if (relaxedUserAccepted) {
-    const okFb = typeof ap.payload?.feedback === 'string' && /\S/.test(ap.payload.feedback)
-    check('②', 'user_accepted 例外：feedback 非空说明差异', okFb, okFb ? 'ok' : 'feedback 缺失')
+    // 例外可达性（PR #132 Review）：签收在引擎校验之后，feedback 由 schema 在签收写入时强制——
+    // 此处只放行证据链并提示该强制点，不得在 awaiting 态要求 feedback
+    check('②', 'user_accepted 例外：允许 fail/blocked 证据链知情接受', true, '放行；签收写入时 schema 强制 feedback（§3.6）')
   } else {
     const ok = review?.payload?.verdict === 'approve' && test?.payload?.verdict === 'pass'
     check('②', 'review approve 且 test pass', ok, ok ? 'ok' : `review=${review?.payload?.verdict} test=${test?.payload?.verdict}`)
@@ -97,7 +98,14 @@ export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false, live 
   if (liveNow && run.current_head !== liveNow.head) {
     badHead.push(`run.json current_head(${run.current_head}) 落后于实况——先 reverify`)
   }
-  check('④', 'Proof 绑定实况 HEAD/branch', badHead.length === 0, badHead.join('; ') || 'ok')
+  // 同项附带 Integration Checkpoint 条件不变量（§7.3）：引擎不经 schema，此处直验
+  const ckpt = refs.integration_checkpoint
+  if (!ckpt || typeof ckpt !== 'object') {
+    badHead.push('integration_checkpoint 缺失')
+  } else if (ckpt.target_advanced === true && ckpt.proofs_state !== 'rerun_completed') {
+    badHead.push('checkpoint target 已前进但 proofs_state≠rerun_completed（受影响 Proof 未重跑）')
+  }
+  check('④', 'Proof 绑定实况 HEAD/branch 且 checkpoint 条件不变量成立', badHead.length === 0, badHead.join('; ') || 'ok')
 
   // ⑤ baseline confirmed 且无残留 gaps
   const ok5 = baseline?.payload?.status === 'confirmed' && (baseline.payload.gaps || []).length === 0

--- a/scripts/cwf-evidence-verify.mjs
+++ b/scripts/cwf-evidence-verify.mjs
@@ -17,16 +17,31 @@ const STAGE_MAP = {
   test_proof: 'test',
 }
 
-function liveState(runDir) {
-  // Proof 绑定比对的实况源：不信任 run.json 可变缓存（§7.3）
+function liveState(runDir, run) {
+  // Proof 绑定比对的实况源：不信任 run.json 可变缓存（§7.3）。
+  // 归档态检测（PR #132 Review）：run 已归档到主检出时实况分支 ≠ run.work_branch，
+  // 不得拿主检出的 HEAD/分支去比对开发期 proof——回退 run.json 历史值
   const wt = join(runDir, '..', '..')
   try {
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: wt, encoding: 'utf-8' }).trim()
+    if (branch !== run.work_branch) return null
     return {
       head: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: wt, encoding: 'utf-8' }).trim(),
-      branch: execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: wt, encoding: 'utf-8' }).trim(),
+      branch,
     }
   } catch {
-    return null // 归档态（worktree 已移除）回退 run.json
+    return null
+  }
+}
+
+function liveTarget(runDir, run) {
+  // 实况 target HEAD（防 checkpoint 过期：自记录后 target 再前进须拦截）
+  const wt = join(runDir, '..', '..')
+  try {
+    execFileSync('git', ['fetch', 'origin', run.base_ref], { cwd: wt, stdio: 'pipe' })
+    return execFileSync('git', ['rev-parse', `origin/${run.base_ref}`], { cwd: wt, encoding: 'utf-8' }).trim()
+  } catch {
+    return null // 离线/归档态：跳过实况比对
   }
 }
 
@@ -86,7 +101,7 @@ export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false, live 
   check('③', '同 Run/workspace lineage', okLineage, okLineage ? 'ok' : `run_id=${[...runIds]} ws=${[...workspaces]} br=${[...branches]}`)
 
   // ④ Proof HEAD/branch 与实况一致（§7.3）：不信任 run.json 缓存
-  const liveNow = live || liveState(runDir)
+  const liveNow = live || liveState(runDir, run)
   const refHead = liveNow ? liveNow.head : run.current_head
   const refBranch = liveNow ? liveNow.branch : run.work_branch
   const badHead = []
@@ -98,12 +113,23 @@ export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false, live 
   if (liveNow && run.current_head !== liveNow.head) {
     badHead.push(`run.json current_head(${run.current_head}) 落后于实况——先 reverify`)
   }
-  // 同项附带 Integration Checkpoint 条件不变量（§7.3）：引擎不经 schema，此处直验
+  // 同项附带 Integration Checkpoint 条件不变量与实况复核（§7.3）：引擎不经 schema，此处直验
   const ckpt = refs.integration_checkpoint
   if (!ckpt || typeof ckpt !== 'object') {
     badHead.push('integration_checkpoint 缺失')
-  } else if (ckpt.target_advanced === true && ckpt.proofs_state !== 'rerun_completed') {
-    badHead.push('checkpoint target 已前进但 proofs_state≠rerun_completed（受影响 Proof 未重跑）')
+  } else {
+    if (ckpt.target_advanced === true && ckpt.proofs_state !== 'rerun_completed') {
+      badHead.push('checkpoint target 已前进但 proofs_state≠rerun_completed（受影响 Proof 未重跑）')
+    }
+    // checkpoint 实况复核：自记录后 target 再前进 / 声称未前进但实况已前进 → 拒绝
+    const liveT = live && 'targetHead' in live ? live.targetHead : liveTarget(runDir, run)
+    if (liveT) {
+      if (ckpt.target_head_at_check !== liveT) {
+        badHead.push(`checkpoint 过期：target 自记录（${ckpt.target_head_at_check}）后又前进（现 ${liveT}）——重新执行 checkpoint`)
+      } else if (ckpt.target_advanced === false && liveT !== run.base_commit) {
+        badHead.push('checkpoint 称未前进但实况 target 已前进')
+      }
+    }
   }
   check('④', 'Proof 绑定实况 HEAD/branch 且 checkpoint 条件不变量成立', badHead.length === 0, badHead.join('; ') || 'ok')
 
@@ -147,10 +173,11 @@ export function verifyEvidenceChain(runDir, { relaxedUserAccepted = false, live 
   }
   check('⑧', '验收映射完整无重复（accept 场景全 pass）', ok8, detail8)
 
-  // ⑨ review/test 产生者异于 dev（异源自证禁令）
+  // ⑨ review/test 产生者异于 dev 且独立会话标志为真（异源自证禁令 + 自声明缺一不可）
   const ok9 = review && test && dev
     && review.produced_by !== dev.produced_by && test.produced_by !== dev.produced_by
-  check('⑨', 'review/test 与 dev 异源（produced_by）', Boolean(ok9), ok9 ? 'ok' : `review=${review?.produced_by} test=${test?.produced_by} dev=${dev?.produced_by}`)
+    && review.payload?.independent_session === true && test.payload?.independent_session === true
+  check('⑨', 'review/test 与 dev 异源且独立会话标志为真', Boolean(ok9), ok9 ? 'ok' : `produced_by(review=${review?.produced_by} test=${test?.produced_by} dev=${dev?.produced_by}) independent_session(review=${review?.payload?.independent_session} test=${test?.payload?.independent_session})`)
 
   return { ok: checks.every(c => c.ok), checks }
 }

--- a/scripts/cwf-record.mjs
+++ b/scripts/cwf-record.mjs
@@ -192,7 +192,8 @@ function isFinalized(existing) {
     case 'review_proof':
     case 'test_proof':
     case 'closeout_summary': return true                              // proof/收口一次写入即终结
-    default: return false                                             // dev_handoff 允许同 attempt 技术重试刷新
+    case 'dev_handoff': return p.outcome === 'handoff_ready'          // 交接就绪即终结（3891543026）；blocked 等可恢复态允许刷新
+    default: return false
   }
 }
 

--- a/scripts/test/cwf-evidence-verify.test.mjs
+++ b/scripts/test/cwf-evidence-verify.test.mjs
@@ -173,6 +173,34 @@ test('⑧ user_accepted 例外：完整映射但含 fail，feedback 必填', () 
   assert.equal(relaxed.ok, true, JSON.stringify(relaxed.checks, null, 1)) // 例外通道放行
 })
 
+test('④ 实况 HEAD 为准：proof 绑定滞后 run.json 被拒，run.json 缓存滞后实况被拒', () => {
+  // 新增提交后实况 HEAD 前进，proof 还绑旧 HEAD → 拒
+  const staleProof = verifyEvidenceChain(makeRunDir(), { live: { head: 'head-new', branch: BRANCH } })
+  assert.equal(checkOk(staleProof, '④'), false)
+  // run.json current_head 落后于实况 → 拒（先 reverify）
+  const staleRun = verifyEvidenceChain(makeRunDir((_rs, run) => { run.current_head = 'older' }), { live: { head: HEAD, branch: BRANCH } })
+  assert.equal(checkOk(staleRun, '④'), false)
+})
+
+test('③ 全部记录同写错误 workspace_id（与 run.json 不符）被拒', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    for (const rec of Object.values(rs)) rec.run.workspace_id = 'ws-wrong'
+  }))
+  assert.equal(checkOk(r, '③'), false)
+})
+
+test('⑥ 命中门但缺 decision_request 被拒（呈递候选集丢失）', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    const p = rs['design_package.json'].payload
+    p.outcome = 'package_ready'
+    p.decision_required = true
+    p.decision_required_reasons = ['r']
+    p.decision = { question: 'q', options: [{ name: 'A', tradeoffs: 't' }], chosen: 'A', rationale: 'r', decided_by: 'x', decided_at: '2026-08-31T00:00:00Z' }
+    // 注意：无 decision_request
+  }))
+  assert.equal(checkOk(r, '⑥'), false)
+})
+
 test('⑨ review/test 与 dev 同源被拒', () => {
   const r = verifyEvidenceChain(makeRunDir(rs => {
     rs['review_proof.a1.json'].produced_by = 'dsh:dev'

--- a/scripts/test/cwf-evidence-verify.test.mjs
+++ b/scripts/test/cwf-evidence-verify.test.mjs
@@ -20,7 +20,7 @@ function makeRunDir(mutate) {
   mkdirSync(runDir, { recursive: true })
   const run = {
     run_id: 'cwf-ev-01', issue_or_task_identity: '#999', workspace_id: 'wt-ev',
-    repository: 'r', base_ref: 'main', base_commit: 'abc', work_branch: BRANCH,
+    repository: 'r', base_ref: 'main', base_commit: HEAD, work_branch: BRANCH,
     current_head: HEAD, stage: 'human_acceptance', attempt: 1,
   }
   const env = (record_type, stage, produced_by, payload) => ({
@@ -76,7 +76,7 @@ function checkOk(result, id) {
 }
 
 test('正例：完整合法证据链全部九项通过', () => {
-  const result = verifyEvidenceChain(makeRunDir())
+  const result = verifyEvidenceChain(makeRunDir(), { live: { head: HEAD, branch: BRANCH, targetHead: HEAD } })
   assert.equal(result.ok, true, JSON.stringify(result.checks, null, 1))
   assert.equal(result.checks.length, 9)
 })
@@ -181,10 +181,10 @@ test('④ checkpoint 条件不变量：target 已前进但未重跑被拒', () =
 
 test('④ 实况 HEAD 为准：proof 绑定滞后 run.json 被拒，run.json 缓存滞后实况被拒', () => {
   // 新增提交后实况 HEAD 前进，proof 还绑旧 HEAD → 拒
-  const staleProof = verifyEvidenceChain(makeRunDir(), { live: { head: 'head-new', branch: BRANCH } })
+  const staleProof = verifyEvidenceChain(makeRunDir(), { live: { head: 'head-new', branch: BRANCH, targetHead: HEAD } })
   assert.equal(checkOk(staleProof, '④'), false)
   // run.json current_head 落后于实况 → 拒（先 reverify）
-  const staleRun = verifyEvidenceChain(makeRunDir((_rs, run) => { run.current_head = 'older' }), { live: { head: HEAD, branch: BRANCH } })
+  const staleRun = verifyEvidenceChain(makeRunDir((_rs, run) => { run.current_head = 'older' }), { live: { head: HEAD, branch: BRANCH, targetHead: HEAD } })
   assert.equal(checkOk(staleRun, '④'), false)
 })
 
@@ -205,6 +205,29 @@ test('⑥ 命中门但缺 decision_request 被拒（呈递候选集丢失）', (
     // 注意：无 decision_request
   }))
   assert.equal(checkOk(r, '⑥'), false)
+})
+
+test('④ checkpoint 实况复核：记录后 target 再前进被拒；称未前进但实况已前进被拒', () => {
+  // 记录后 target 前进 → 拒
+  const moved = verifyEvidenceChain(makeRunDir(), { live: { head: HEAD, branch: BRANCH, targetHead: 'newer' } })
+  assert.equal(checkOk(moved, '④'), false)
+  // 记录称未前进但实况已前进 → 拒
+  const lied = verifyEvidenceChain(makeRunDir(rs => {
+    rs['acceptance_package.a1.json'].payload.assembled.integration_checkpoint.target_advanced = false
+  }), { live: { head: HEAD, branch: BRANCH, targetHead: 'not-base' } })
+  assert.equal(checkOk(lied, '④'), false)
+})
+
+test('④ 归档态回退 run.json（实况分支 ≠ run.work_branch 时不拿主检出比对）', () => {
+  const r = verifyEvidenceChain(makeRunDir(), { live: null })
+  assert.equal(checkOk(r, '④'), true) // 无 git → run.json 历史值，全过
+})
+
+test('⑨ 独立会话标志缺失/为假被拒（即使 produced_by 异源）', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    delete rs['test_proof.a1.json'].payload.independent_session
+  }), { live: { head: HEAD, branch: BRANCH, targetHead: HEAD } })
+  assert.equal(checkOk(r, '⑨'), false)
 })
 
 test('⑨ review/test 与 dev 同源被拒', () => {

--- a/scripts/test/cwf-evidence-verify.test.mjs
+++ b/scripts/test/cwf-evidence-verify.test.mjs
@@ -1,0 +1,181 @@
+// cwf-evidence-verify.mjs 测试：§8.3 九项校验，合成证据链正例 + 九项各一负例
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { verifyEvidenceChain } from '../cwf-evidence-verify.mjs'
+
+const repo = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+const BASE_ACCEPTANCE = ['验收标准A', '验收标准B']
+const HEAD = 'head-final'
+const BRANCH = 'dev-cwf-test-01'
+
+function makeRunDir(mutate) {
+  const root = mkdtempSync(join(tmpdir(), 'cwf-ev-'))
+  const runDir = join(root, '.agent-runs', 'cwf-ev-01')
+  mkdirSync(runDir, { recursive: true })
+  const run = {
+    run_id: 'cwf-ev-01', issue_or_task_identity: '#999', workspace_id: 'wt-ev',
+    repository: 'r', base_ref: 'main', base_commit: 'abc', work_branch: BRANCH,
+    current_head: HEAD, stage: 'human_acceptance', attempt: 1,
+  }
+  const env = (record_type, stage, produced_by, payload) => ({
+    record_type, record_version: 'v0.1.8', created_at: '2026-08-31T00:00:00Z',
+    produced_by, run: { ...run, stage }, payload,
+  })
+  const records = {
+    'requirements_baseline.json': env('requirements_baseline', 'requirements', 'dsh:dev', {
+      goal: 'g', scope: { include: ['a'], exclude: ['b'] }, acceptance: BASE_ACCEPTANCE,
+      gaps: [], status: 'confirmed', outcome: 'baseline_ready',
+      baseline_revision: 'v1', human_confirmation: { confirmed_by: 'human', confirmed_at: '2026-08-31T00:00:00Z' },
+    }),
+    'design_package.json': env('design_package', 'design', 'dsh:dev', {
+      summary: 's', outcome: 'package_ready', decision_required: false,
+    }),
+    'dev_handoff.json': env('dev_handoff', 'dev', 'dsh:dev', {
+      summary: 's', outcome: 'handoff_ready', changes: [], self_check: [{ check: 'c', result: 'pass' }],
+    }),
+    'review_proof.a1.json': env('review_proof', 'review', 'ext:reviewer', {
+      verdict: 'approve', findings: [], verified_branch: BRANCH, verified_head: HEAD, independent_session: true,
+    }),
+    'test_proof.a1.json': env('test_proof', 'test', 'ext:tester', {
+      verdict: 'pass',
+      acceptance_mapping: BASE_ACCEPTANCE.map(a => ({ acceptance_item: a, result: 'pass' })),
+      findings: [], verified_branch: BRANCH, verified_head: HEAD, independent_session: true,
+    }),
+  }
+  const assembled = {
+    requirements_baseline_ref: 'requirements_baseline.json',
+    design_package_ref: 'design_package.json',
+    dev_handoff_ref: 'dev_handoff.json',
+    review_proof_ref: 'review_proof.a1.json',
+    test_proof_ref: 'test_proof.a1.json',
+    integration_checkpoint: { target_ref: 'main', target_head_at_check: HEAD, target_advanced: false, proofs_state: 'still_valid' },
+  }
+  records['acceptance_package.a1.json'] = env('acceptance_package', 'human_acceptance', 'dsh:dev', {
+    status: 'awaiting_decision', assembled,
+  })
+  if (mutate) mutate(records, run)
+  writeFileSync(join(runDir, 'run.json'), JSON.stringify(run, null, 2))
+  writeFileSync(join(runDir, 'index.json'), JSON.stringify({
+    acceptance_package: 'acceptance_package.a1.json',
+  }, null, 2))
+  for (const [f, rec] of Object.entries(records)) {
+    writeFileSync(join(runDir, f), JSON.stringify(rec, null, 2))
+  }
+  return runDir
+}
+
+function checkOk(result, id) {
+  const c = result.checks.find(c => c.id === id)
+  return c ? c.ok : null
+}
+
+test('正例：完整合法证据链全部九项通过', () => {
+  const result = verifyEvidenceChain(makeRunDir())
+  assert.equal(result.ok, true, JSON.stringify(result.checks, null, 1))
+  assert.equal(result.checks.length, 9)
+})
+
+test('① record_type 与 Stage 映射错配被拒', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    rs['review_proof.a1.json'].run.stage = 'dev'
+  }))
+  assert.equal(checkOk(r, '①'), false)
+  assert.equal(r.ok, false)
+})
+
+test('② review 非 approve 被拒', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    rs['review_proof.a1.json'].payload.verdict = 'request_changes'
+    rs['review_proof.a1.json'].payload.findings = [{ finding: 'f', root_cause: 'dev' }]
+  }))
+  assert.equal(checkOk(r, '②'), false)
+})
+
+test('③ lineage 断裂被拒', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    rs['test_proof.a1.json'].run.run_id = 'other-run'
+  }))
+  assert.equal(checkOk(r, '③'), false)
+})
+
+test('④ Proof HEAD 不一致被拒', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    rs['test_proof.a1.json'].payload.verified_head = 'old-head'
+  }))
+  assert.equal(checkOk(r, '④'), false)
+})
+
+test('⑤ baseline 未 confirmed 被拒', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    rs['requirements_baseline.json'].payload.status = 'draft'
+  }))
+  assert.equal(checkOk(r, '⑤'), false)
+})
+
+test('⑥ design 命中门未决被拒；chosen 不在呈递候选集被拒', () => {
+  const pending = verifyEvidenceChain(makeRunDir(rs => {
+    rs['design_package.json'].payload.outcome = 'decision_required'
+  }))
+  assert.equal(checkOk(pending, '⑥'), false)
+  const badChoice = verifyEvidenceChain(makeRunDir(rs => {
+    const p = rs['design_package.json'].payload
+    p.outcome = 'package_ready'
+    p.decision_required = true
+    p.decision_required_reasons = ['r']
+    p.decision_request = { question: 'q', options: [{ name: 'A', tradeoffs: 't' }], recommendation: 'A' }
+    p.decision = { question: 'q', options: [{ name: 'A', tradeoffs: 't' }], chosen: 'B', rationale: 'r', decided_by: 'x', decided_at: '2026-08-31T00:00:00Z' }
+  }))
+  assert.equal(checkOk(badChoice, '⑥'), false)
+})
+
+test('⑦ dev 非 handoff_ready 被拒', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    rs['dev_handoff.json'].payload.outcome = 'blocked'
+  }))
+  assert.equal(checkOk(r, '⑦'), false)
+})
+
+test('⑧ 验收映射缺失基线条目被拒；重复被拒', () => {
+  const missing = verifyEvidenceChain(makeRunDir(rs => {
+    rs['test_proof.a1.json'].payload.acceptance_mapping = [{ acceptance_item: '验收标准A', result: 'pass' }]
+  }))
+  assert.equal(checkOk(missing, '⑧'), false)
+  const dup = verifyEvidenceChain(makeRunDir(rs => {
+    rs['test_proof.a1.json'].payload.acceptance_mapping = [
+      { acceptance_item: '验收标准A', result: 'pass' },
+      { acceptance_item: '验收标准A', result: 'pass' },
+      { acceptance_item: '验收标准B', result: 'pass' },
+    ]
+  }))
+  assert.equal(checkOk(dup, '⑧'), false)
+})
+
+test('⑧ user_accepted 例外：完整映射但含 fail，feedback 必填', () => {
+  const dir = makeRunDir(rs => {
+    rs['test_proof.a1.json'].payload.verdict = 'fail'
+    rs['test_proof.a1.json'].payload.findings = [{ finding: 'f', root_cause: 'dev' }]
+    rs['test_proof.a1.json'].payload.acceptance_mapping[1].result = 'fail'
+    rs['acceptance_package.a1.json'].payload = {
+      status: 'decided', assembled: rs['acceptance_package.a1.json'].payload.assembled,
+      decision: 'user_accepted', decided_by: 'human', decided_at: '2026-08-31T00:00:00Z',
+      feedback: '知情接受：B 未达', verified_branch: BRANCH, verified_head: HEAD,
+    }
+  })
+  const strict = verifyEvidenceChain(dir)
+  assert.equal(strict.ok, false) // accept 路径被拒
+  const relaxed = verifyEvidenceChain(dir, { relaxedUserAccepted: true })
+  assert.equal(relaxed.ok, true, JSON.stringify(relaxed.checks, null, 1)) // 例外通道放行
+})
+
+test('⑨ review/test 与 dev 同源被拒', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    rs['review_proof.a1.json'].produced_by = 'dsh:dev'
+  }))
+  assert.equal(checkOk(r, '⑨'), false)
+})

--- a/scripts/test/cwf-evidence-verify.test.mjs
+++ b/scripts/test/cwf-evidence-verify.test.mjs
@@ -156,21 +156,27 @@ test('⑧ 验收映射缺失基线条目被拒；重复被拒', () => {
   assert.equal(checkOk(dup, '⑧'), false)
 })
 
-test('⑧ user_accepted 例外：完整映射但含 fail，feedback 必填', () => {
+test('⑧ user_accepted 例外可达：awaiting 态（无 feedback，schema 合法）+ fail 证据链放行', () => {
   const dir = makeRunDir(rs => {
     rs['test_proof.a1.json'].payload.verdict = 'fail'
     rs['test_proof.a1.json'].payload.findings = [{ finding: 'f', root_cause: 'dev' }]
     rs['test_proof.a1.json'].payload.acceptance_mapping[1].result = 'fail'
-    rs['acceptance_package.a1.json'].payload = {
-      status: 'decided', assembled: rs['acceptance_package.a1.json'].payload.assembled,
-      decision: 'user_accepted', decided_by: 'human', decided_at: '2026-08-31T00:00:00Z',
-      feedback: '知情接受：B 未达', verified_branch: BRANCH, verified_head: HEAD,
-    }
+    // 验收包保持 awaiting_decision（无 feedback——schema 禁止该态带 feedback；签收写入时才必填）
   })
   const strict = verifyEvidenceChain(dir)
   assert.equal(strict.ok, false) // accept 路径被拒
   const relaxed = verifyEvidenceChain(dir, { relaxedUserAccepted: true })
   assert.equal(relaxed.ok, true, JSON.stringify(relaxed.checks, null, 1)) // 例外通道放行
+  assert.ok(relaxed.checks.find(c => c.id === '②').detail.includes('签收写入时'))
+})
+
+test('④ checkpoint 条件不变量：target 已前进但未重跑被拒', () => {
+  const r = verifyEvidenceChain(makeRunDir(rs => {
+    rs['acceptance_package.a1.json'].payload.assembled.integration_checkpoint = {
+      target_ref: 'main', target_head_at_check: HEAD, target_advanced: true, proofs_state: 'still_valid',
+    }
+  }))
+  assert.equal(checkOk(r, '④'), false)
 })
 
 test('④ 实况 HEAD 为准：proof 绑定滞后 run.json 被拒，run.json 缓存滞后实况被拒', () => {

--- a/scripts/test/cwf-record.test.mjs
+++ b/scripts/test/cwf-record.test.mjs
@@ -437,6 +437,31 @@ test('reverify 同步刷新 run.current_head', () => {
   assert.equal(runState.current_head, realHead)
 })
 
+test('write：dev_handoff handoff_ready 即终结，blocked 允许刷新（3891543026）', () => {
+  const { root, runDir } = makeRunDir()
+  const mk = (name, outcome) => {
+    const f = join(runDir, name)
+    writeFileSync(f, JSON.stringify({ summary: 's', outcome, changes: [], self_check: [{ check: 'c', result: 'pass' }] }))
+    return f
+  }
+  // handoff_ready 写入后同 attempt 重写拒绝
+  assert.equal(run(['write', runDir, 'dev_handoff', mk('d1.json', 'handoff_ready'), '--produced-by', 'test-suite', '--stage', 'dev']).code, 0)
+  const rewrite = run(['write', runDir, 'dev_handoff', mk('d2.json', 'handoff_ready'), '--produced-by', 'test-suite', '--stage', 'dev'])
+  assert.equal(rewrite.code, 1)
+  assert.match(rewrite.out, /终结态记录/)
+})
+
+test('write：dev_handoff blocked 允许同 attempt 刷新（可恢复态）', () => {
+  const { runDir } = makeRunDir()
+  const mk = (name) => {
+    const f = join(runDir, name)
+    writeFileSync(f, JSON.stringify({ summary: 's', outcome: 'blocked', blocked_reason: '环境不可用', changes: [], self_check: [{ check: 'c', result: 'blocked' }] }))
+    return f
+  }
+  assert.equal(run(['write', runDir, 'dev_handoff', mk('d1.json'), '--produced-by', 'test-suite', '--stage', 'dev']).code, 0)
+  assert.equal(run(['write', runDir, 'dev_handoff', mk('d2.json'), '--produced-by', 'test-suite', '--stage', 'dev']).code, 0) // 刷新允许
+})
+
 test('check：对既有记录只校验', () => {
   const { runDir } = makeRunDir()
   const payload = join(runDir, 'payload.json')


### PR DESCRIPTION
> *This was generated by AI during triage.*

## 关联

- 目标 issue：#123（遗留项 1：证据链机器校验引擎化 + handoff_ready 终结态策略）
- 执行方式：**建设工作流 Bootstrap Profile 的 dogfood Run**（`cwf-123-01`，#105 的收尾阶段——验收项 1–8 由本 Run 覆盖）

## 变更内容

- `scripts/cwf-evidence-verify.mjs`（新增）：契约 §8.3 九项呈递/签收前校验的机器化——record_type↔stage 映射、上游完成态、lineage、Proof HEAD 绑定、baseline confirmed、design 过门已决、dev handoff_ready、映射完整覆盖、produced_by 异源；`--decision user_accepted` 例外通道
- `scripts/cwf-record.mjs`：isFinalized 增加 handoff_ready 终结态分支
- `dsh/skills/construction-bootstrap/runbook.md`：§6 九项人工校验替换为引擎调用
- 测试：引擎九项各一负例 + 正例全链 + user_accepted 例外探针 + 终结态两态回归

## dogfood 实证

- 引擎对 cwf-105-bootstrap-01 真实归档证据的实测：正确识别其 ⑧ 缺口（missing=11/extra=4，老 Run 的验收映射未按基线条目写）——并由此实证了契约的根因回退：本 Run 按 §4.1 回退 Requirements 修订基线 v2 重新人工确认
- 本 Run 的七类证据记录全程由 Profile 工具链（run-init/record/checkpoint）产出并校验

## 对用户/工作流程的影响

契约 §8.3 九项校验从「人工逐条执行」变为「脚本一次判定」；#105 的 dogfood 验收项由本 PR 兑现。

## 已运行的校验

- `npm test` 141/141 全绿（含新增引擎套件）；
- 未修改蓝图/生成规则，`npm run generate` / `validate` 不适用。

## 蓝图影响

无。