### PR TITLE
feat: 最小 Codex PR Review Controller (#134)

### DIFF
--- a/.github/workflows/codex-pr-review-controller.yml
+++ b/.github/workflows/codex-pr-review-controller.yml
@@ -1,0 +1,28 @@
+name: codex-pr-review-controller
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  controller:
+    if: ${{ github.event.issue.pull_request != null && startsWith(github.event.comment.body, '/codex-review') }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: codex-pr-review-${{ github.event.repository.full_name }}-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: 处理 Codex Review 轮次请求
+        run: node scripts/codex-review-controller.mjs "$GITHUB_EVENT_PATH"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/scripts/codex-review-controller.mjs
+++ b/scripts/codex-review-controller.mjs
@@ -1,0 +1,257 @@
+import fs from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_MAX_ROUNDS = 3;
+const STATE_MARKER = 'codex-review-controller-state';
+const ALLOWED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+export function parseCommand(body) {
+  const text = String(body ?? '').trim();
+  if (!text.toLowerCase().startsWith('/codex-review')) return null;
+  if (/^\/codex-review\s+next\s*$/i.test(text)) return { type: 'next' };
+  if (/^\/codex-review\s+retry\s*$/i.test(text)) return { type: 'retry' };
+  const extend = text.match(/^\/codex-review\s+extend\s+1(?:\s+([\s\S]+))?$/i);
+  if (extend) return { type: 'extend', amount: 1, reason: sanitizeText(extend[1] ?? '') };
+  return { type: 'invalid' };
+}
+
+export function initialState() {
+  return {
+    version: 1,
+    round: 0,
+    maxRounds: DEFAULT_MAX_ROUNDS,
+    lastHead: null,
+    status: 'READY',
+    extensions: [],
+    retries: 0,
+    updatedAt: null,
+  };
+}
+
+export function nextDecision(state, head) {
+  if (state.round >= state.maxRounds) return { ok: false, reason: 'EXHAUSTED' };
+  if (state.round > 0 && state.lastHead === head) return { ok: false, reason: 'DUPLICATE_HEAD' };
+  return { ok: true, round: state.round + 1 };
+}
+
+export function retryDecision(state, head) {
+  if (state.round < 1) return { ok: false, reason: 'NO_ROUND' };
+  if (state.lastHead !== head) return { ok: false, reason: 'HEAD_CHANGED' };
+  return { ok: true, round: state.round };
+}
+
+export function extendDecision(state, amount = 1) {
+  if (amount !== 1) return { ok: false, reason: 'ONLY_ONE' };
+  if (state.round < state.maxRounds) return { ok: false, reason: 'NOT_EXHAUSTED' };
+  return { ok: true, maxRounds: state.maxRounds + 1 };
+}
+
+export function buildReviewPrompt(round, maxRounds, extensionReason = '') {
+  if (round === 1) {
+    return `@codex review 第 1/${maxRounds} 轮完整审查：围绕当前 Issue/PR 的验收条件检查需求符合性、正确性、回归风险、证据与必要边界条件。请区分必须在本 PR 修复的阻塞问题与可作为 follow-up 的非阻塞建议。`;
+  }
+  if (round === 2) {
+    return `@codex review 第 2/${maxRounds} 轮收敛审查：重点验证上一轮阻塞问题是否正确解决，以及本轮修改是否引入新的当前范围阻塞问题。新的非阻塞优化建议请明确标记为 follow-up，不要扩大当前 PR 的验收范围。`;
+  }
+  if (round === 3 && maxRounds === DEFAULT_MAX_ROUNDS) {
+    return '@codex review 第 3/3 轮最终收敛审查：只报告会导致当前 Issue 验收失败、当前修改引入的明显回归或必须在合并前解决的阻塞问题。其他改进建议请标记为 follow-up，不得作为继续自动循环的理由。';
+  }
+  const reason = extensionReason ? ` 人工追加原因：${extensionReason}` : '';
+  return `@codex review 人工追加的第 ${round}/${maxRounds} 轮收敛审查：仅核查当前 PR 尚未解决的明确阻塞项及相关修复是否引入回归；新的非阻塞建议统一作为 follow-up，不扩大当前 PR 范围。${reason}`;
+}
+
+export function parseStateComment(body) {
+  const match = String(body ?? '').match(new RegExp(`<!-- ${STATE_MARKER}\\s*\\n([\\s\\S]*?)\\n-->`));
+  if (!match) return null;
+  try {
+    return { ...initialState(), ...JSON.parse(match[1]) };
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeText(value) {
+  return String(value ?? '').replace(/-->/g, '—>').replace(/\s+/g, ' ').trim().slice(0, 300);
+}
+
+function renderState(state) {
+  const remaining = Math.max(0, state.maxRounds - state.round);
+  const added = state.extensions.reduce((sum, item) => sum + item.amount, 0);
+  const statusText = {
+    READY: '可申请下一轮',
+    REVIEW_REQUESTED: '已发起审查',
+    RETRY_REQUESTED: '当前轮已重试',
+    EXHAUSTED: '自动额度耗尽，等待人工决策',
+    EXTENDED: '人工已追加有限额度',
+  }[state.status] ?? state.status;
+  const json = JSON.stringify(state);
+  return `### Codex PR Review Controller\n\n- 当前轮次：**${state.round} / ${state.maxRounds}**\n- 状态：**${statusText}**\n- 最近审查版本：${state.lastHead ? `\`${state.lastHead.slice(0, 12)}\`` : '—'}\n- 剩余可申请轮次：**${remaining}**\n- 人工追加：**${added}**\n\n命令：\`/codex-review next\` · 服务故障重试：\`/codex-review retry\` · 额度耗尽后人工追加：\`/codex-review extend 1 <原因>\`\n\n<!-- ${STATE_MARKER}\n${json}\n-->`;
+}
+
+function isAuthorized(event) {
+  return ALLOWED_ASSOCIATIONS.has(event.comment?.author_association);
+}
+
+async function githubRequest(token, path, options = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...options,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'workflow-manager-codex-review-controller',
+      ...(options.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub API ${response.status}: ${text}`);
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+async function listAllComments(token, repo, number) {
+  const comments = [];
+  for (let page = 1; ; page += 1) {
+    const batch = await githubRequest(token, `/repos/${repo}/issues/${number}/comments?per_page=100&page=${page}`);
+    comments.push(...batch);
+    if (batch.length < 100) return comments;
+  }
+}
+
+function findStateComment(comments) {
+  return [...comments].reverse().find((comment) =>
+    comment.user?.login === 'github-actions[bot]' && String(comment.body ?? '').includes(`<!-- ${STATE_MARKER}`));
+}
+
+async function postComment(token, repo, number, body) {
+  return githubRequest(token, `/repos/${repo}/issues/${number}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body }),
+  });
+}
+
+async function saveState(token, repo, number, stateComment, state) {
+  const body = renderState(state);
+  if (stateComment) {
+    return githubRequest(token, `/repos/${repo}/issues/comments/${stateComment.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body }),
+    });
+  }
+  return postComment(token, repo, number, body);
+}
+
+async function handleNext({ token, repo, number, actor, stateComment, state, head }) {
+  const decision = nextDecision(state, head);
+  if (!decision.ok) {
+    if (decision.reason === 'EXHAUSTED') {
+      state.status = 'EXHAUSTED';
+      state.updatedAt = new Date().toISOString();
+      await saveState(token, repo, number, stateComment, state);
+      await postComment(token, repo, number, `⛔ Codex 自动 Review 已达到 ${state.round}/${state.maxRounds}。Controller 不会触发下一轮。请人工选择收口、拆分 follow-up，或使用 \`/codex-review extend 1 <原因>\` 追加 1 轮有限额度。`);
+      return;
+    }
+    await postComment(token, repo, number, `ℹ️ 当前版本 \`${head.slice(0, 12)}\` 已经发起过 Round ${state.round}，不会重复占用下一轮。若上一轮是 Codex 服务错误，请使用 \`/codex-review retry\`；若已完成修改，请先提交新的 PR 版本再申请 \`next\`。`);
+    return;
+  }
+
+  state.round = decision.round;
+  state.lastHead = head;
+  state.status = 'REVIEW_REQUESTED';
+  state.updatedAt = new Date().toISOString();
+  state.lastRequestedBy = actor;
+  await saveState(token, repo, number, stateComment, state);
+  const extensionReason = state.extensions.at(-1)?.reason ?? '';
+  await postComment(token, repo, number, `${buildReviewPrompt(state.round, state.maxRounds, extensionReason)}\n\n<!-- codex-review-controller-trigger round:${state.round} head:${head} -->`);
+}
+
+async function handleRetry({ token, repo, number, actor, stateComment, state, head }) {
+  const decision = retryDecision(state, head);
+  if (!decision.ok) {
+    const message = decision.reason === 'NO_ROUND'
+      ? '当前还没有已发起的 Review，请先使用 `/codex-review next`。'
+      : 'PR 版本已经变化，不能把新版本当作上一轮服务重试；请使用 `/codex-review next`。';
+    await postComment(token, repo, number, `ℹ️ ${message}`);
+    return;
+  }
+  state.status = 'RETRY_REQUESTED';
+  state.retries = (state.retries ?? 0) + 1;
+  state.updatedAt = new Date().toISOString();
+  state.lastRequestedBy = actor;
+  await saveState(token, repo, number, stateComment, state);
+  const extensionReason = state.extensions.at(-1)?.reason ?? '';
+  await postComment(token, repo, number, `${buildReviewPrompt(state.round, state.maxRounds, extensionReason)}\n\n> Controller：这是 Round ${state.round} 的服务/工具故障重试，不增加业务轮次。\n\n<!-- codex-review-controller-retry round:${state.round} head:${head} -->`);
+}
+
+async function handleExtend({ token, repo, number, actor, stateComment, state, command }) {
+  if (!command.reason) {
+    await postComment(token, repo, number, '⛔ 人工追加额度必须记录原因。用法：`/codex-review extend 1 <原因>`。');
+    return;
+  }
+  const decision = extendDecision(state, command.amount);
+  if (!decision.ok) {
+    const message = decision.reason === 'NOT_EXHAUSTED'
+      ? `当前仍有自动额度（${state.round}/${state.maxRounds}），无需提前追加。`
+      : 'MVP 每次只允许追加 1 轮。';
+    await postComment(token, repo, number, `⛔ ${message}`);
+    return;
+  }
+  state.maxRounds = decision.maxRounds;
+  state.status = 'EXTENDED';
+  state.extensions.push({
+    amount: 1,
+    by: actor,
+    reason: command.reason,
+    at: new Date().toISOString(),
+  });
+  state.updatedAt = new Date().toISOString();
+  await saveState(token, repo, number, stateComment, state);
+  await postComment(token, repo, number, `✅ @${actor} 已人工追加 **1 轮** Codex Review，最大轮次变为 **${state.maxRounds}**。原因：${command.reason}\n\n追加额度不会自动触发审查；完成针对阻塞项的修改并提交新版本后，再使用 \`/codex-review next\`。`);
+}
+
+export async function runController(event, { token, repo }) {
+  if (!event.issue?.pull_request) return { handled: false, reason: 'NOT_PR' };
+  const command = parseCommand(event.comment?.body);
+  if (!command) return { handled: false, reason: 'NOT_COMMAND' };
+  const number = event.issue.number;
+
+  if (!isAuthorized(event)) {
+    await postComment(token, repo, number, '⛔ 只有仓库 Owner / Member / Collaborator 可以操作 Codex Review Controller。');
+    return { handled: true, reason: 'UNAUTHORIZED' };
+  }
+  if (command.type === 'invalid') {
+    await postComment(token, repo, number, '用法：`/codex-review next`、`/codex-review retry`、`/codex-review extend 1 <原因>`。');
+    return { handled: true, reason: 'INVALID' };
+  }
+
+  const comments = await listAllComments(token, repo, number);
+  const stateComment = findStateComment(comments);
+  const state = stateComment ? parseStateComment(stateComment.body) ?? initialState() : initialState();
+  const pr = await githubRequest(token, `/repos/${repo}/pulls/${number}`);
+  const head = pr.head.sha;
+  const actor = event.comment.user.login;
+  const context = { token, repo, number, actor, stateComment, state, head, command };
+
+  if (command.type === 'next') await handleNext(context);
+  if (command.type === 'retry') await handleRetry(context);
+  if (command.type === 'extend') await handleExtend(context);
+  return { handled: true, reason: command.type.toUpperCase() };
+}
+
+async function main() {
+  const eventPath = process.argv[2] ?? process.env.GITHUB_EVENT_PATH;
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!eventPath || !token || !repo) throw new Error('缺少 GITHUB_EVENT_PATH / GITHUB_TOKEN / GITHUB_REPOSITORY');
+  const event = JSON.parse(await fs.readFile(eventPath, 'utf8'));
+  await runController(event, { token, repo });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/test/codex-review-controller.test.mjs
+++ b/scripts/test/codex-review-controller.test.mjs
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildReviewPrompt,
+  extendDecision,
+  initialState,
+  nextDecision,
+  parseCommand,
+  parseStateComment,
+  retryDecision,
+} from '../codex-review-controller.mjs';
+
+test('解析 next / retry / extend 命令', () => {
+  assert.deepEqual(parseCommand('/codex-review next'), { type: 'next' });
+  assert.deepEqual(parseCommand('/codex-review retry'), { type: 'retry' });
+  assert.deepEqual(parseCommand('/codex-review extend 1 仍有 P1 阻塞'), {
+    type: 'extend',
+    amount: 1,
+    reason: '仍有 P1 阻塞',
+  });
+  assert.deepEqual(parseCommand('/codex-review extend 2'), { type: 'invalid' });
+  assert.equal(parseCommand('普通评论'), null);
+});
+
+test('默认最多三轮，第四次被拒绝', () => {
+  const state = initialState();
+
+  let decision = nextDecision(state, 'head-1');
+  assert.deepEqual(decision, { ok: true, round: 1 });
+  state.round = decision.round;
+  state.lastHead = 'head-1';
+
+  decision = nextDecision(state, 'head-2');
+  assert.deepEqual(decision, { ok: true, round: 2 });
+  state.round = decision.round;
+  state.lastHead = 'head-2';
+
+  decision = nextDecision(state, 'head-3');
+  assert.deepEqual(decision, { ok: true, round: 3 });
+  state.round = decision.round;
+  state.lastHead = 'head-3';
+
+  assert.deepEqual(nextDecision(state, 'head-4'), { ok: false, reason: 'EXHAUSTED' });
+});
+
+test('同一 PR 版本重复 next 不占用下一轮', () => {
+  const state = { ...initialState(), round: 1, lastHead: 'same-head' };
+  assert.deepEqual(nextDecision(state, 'same-head'), { ok: false, reason: 'DUPLICATE_HEAD' });
+});
+
+test('retry 只允许重试当前轮同一版本且不增加轮次', () => {
+  const state = { ...initialState(), round: 2, lastHead: 'head-2' };
+  assert.deepEqual(retryDecision(state, 'head-2'), { ok: true, round: 2 });
+  assert.deepEqual(retryDecision(state, 'head-3'), { ok: false, reason: 'HEAD_CHANGED' });
+  assert.deepEqual(retryDecision(initialState(), 'head-1'), { ok: false, reason: 'NO_ROUND' });
+});
+
+test('只有额度耗尽后才允许一次追加一轮', () => {
+  assert.deepEqual(extendDecision({ ...initialState(), round: 2 }), { ok: false, reason: 'NOT_EXHAUSTED' });
+  assert.deepEqual(extendDecision({ ...initialState(), round: 3 }), { ok: true, maxRounds: 4 });
+  assert.deepEqual(extendDecision({ ...initialState(), round: 3 }, 2), { ok: false, reason: 'ONLY_ONE' });
+});
+
+test('第 2/3 轮提示词明确收敛范围', () => {
+  assert.match(buildReviewPrompt(1, 3), /完整审查/);
+  assert.match(buildReviewPrompt(2, 3), /收敛审查/);
+  assert.match(buildReviewPrompt(3, 3), /最终收敛审查/);
+  assert.match(buildReviewPrompt(4, 4, '仍有 P1'), /人工追加原因：仍有 P1/);
+});
+
+test('可以从 Controller 状态评论恢复状态', () => {
+  const body = `状态\n<!-- codex-review-controller-state\n${JSON.stringify({ round: 2, maxRounds: 4, lastHead: 'abc' })}\n-->`;
+  const state = parseStateComment(body);
+  assert.equal(state.round, 2);
+  assert.equal(state.maxRounds, 4);
+  assert.equal(state.lastHead, 'abc');
+  assert.deepEqual(state.extensions, []);
+});


### PR DESCRIPTION
Closes #134

## 目标

为 GitHub PR 层增加一个独立的最小 Codex Review Controller，阻止 Agent 通过重复 `@codex review` 形成无上限循环。该机制不进入本地工作流、Run 或业务节点体系。

## 用户使用方式

在 PR 评论：

- `/codex-review next`：申请下一轮 Review；
- `/codex-review retry`：Codex 服务/工具故障时重发当前轮，不增加业务轮次；
- `/codex-review extend 1 <原因>`：3 轮额度耗尽后，由有仓库权限的人显式追加 1 轮。

## 行为

- 默认最大 3 轮：完整审查 → 收敛审查 → 最终收敛审查；
- Controller 自己发布对应的 `@codex review ...` 指令；
- 同一 PR HEAD 只能 `next` 一次，重复/并发请求不会把同一版本重复计轮；
- Round 3 后自动 `next` 被拒绝，进入人工决策；
- 追加额度只能在耗尽后发生，而且每次只能 +1，必须记录操作者和原因；
- Controller 状态保存在 PR 的单一状态评论中，同时 Review 触发/追加仍以独立评论留痕；
- 只有 Owner / Member / Collaborator 可以操作；普通 Issue 不响应。

## 改动

- `.github/workflows/codex-pr-review-controller.yml`：PR 评论入口与按 PR 串行处理；
- `scripts/codex-review-controller.mjs`：轮次、重复请求、重试、追加、状态记录与 Codex 指令；
- `scripts/test/codex-review-controller.test.mjs`：MVP 规则测试。

## 边界 / 实测要求

OpenAI 官方明确支持在 PR 评论中用 `@codex review` 触发托管 Review，但公开文档没有明确承诺 `github-actions[bot]` 发布的 mention 一定会被托管 Codex 接受。因此本 PR 先实现 Controller 与触发评论；合并后需要用一个真实 PR 做一次 Round 1 联调。如果托管 Codex 忽略 GitHub Actions Bot 评论，再把“触发身份”独立替换为受控 GitHub App/专用身份，不改变本 Controller 的轮次与状态模型。

另一个前提：如果 Codex 仓库设置为“每次 push 自动 Review”，该外部自动行为不受本 Controller 控制；要让 Controller 成为后续轮次唯一入口，应关闭 every-push 自动审查，只保留首轮自动审查或统一改用 Controller。

## 验证

PR CI 使用仓库现有 `validate` 全量门禁；新增测试会被现有 `npm test` 自动纳入。
