### PR TITLE
fix: 修正 Codex PR Review Controller 评论权限 (#134)

### DIFF
--- a/.github/workflows/codex-pr-review-controller.yml
+++ b/.github/workflows/codex-pr-review-controller.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   controller:


### PR DESCRIPTION
## 问题

#134 合并后的真实 Round 1 联调中，Controller 成功响应 `/codex-review next`，但在写入 PR 状态评论时收到 GitHub 403。运行日志显示当前权限为 Issues: write、PullRequests: read；PR 对话写入需要 PR 写权限。

## 修改

仅将 Controller 的 PR 权限从 read 调整为 write；不修改轮次、状态、命令或 Codex Review 策略。

## 验证

- 原 PR #135 全量 validate 已通过；
- 本 PR 继续走现有 validate；
- 合并后在 PR #133 重跑 `/codex-review next` 做真实联调。

关联 #134。