### PR TITLE
docs(construction): Codex/Cursor External Profile runbook 与薄工具差异层 (#104)

### DIFF
--- a/docs/runbooks/acceptance-construction-epic.md
+++ b/docs/runbooks/acceptance-construction-epic.md
@@ -1,0 +1,120 @@
+# Epic #102 建设工作流 · 可执行验收手册
+
+> 适用范围：验收建设工作流 Portable Contract（v0.1.8）、DSH Bootstrap Profile、证据链引擎、External Profile（PR #139 合并后）与两个真实 dogfood Run 的证据链。
+> 执行环境：macOS / zsh、bash、git、gh、Node.js。本手册命令不含行内注释，可直接整行复制到 zsh 执行。
+
+## 0. 环境引导（必须先做）
+
+不要 checkout main（可能被其他 worktree 占用）。为验收单独建 worktree：
+
+```bash
+cd /Users/chris/workspace/workflow-manager
+git fetch origin main
+git worktree add .scratch/worktrees/accept-main --detach origin/main
+cd .scratch/worktrees/accept-main
+```
+
+清理（全部验收完成后执行）：
+
+```bash
+cd /Users/chris/workspace/workflow-manager
+git worktree remove --force .scratch/worktrees/accept-main
+git branch -D dev-cwf-accept-demo-01
+```
+
+下文所有相对路径命令均在 `accept-main` 目录内执行；E 层证据用主检出的绝对路径。
+
+## A. 静态资产完整性
+
+```bash
+git ls-tree -r HEAD --name-only | grep -E "construction|cwf-"
+grep "版本" docs/design/construction-workflow-portable-contract.md | head -1
+ls docs/runbooks/
+```
+
+预期：20+ 个交付物（契约、schema、7 示例、skill 三件套、4 个 cwf 脚本、5 个测试套件）；版本行含 v0.1.8；`docs/runbooks/` 含 `construction-external/`（PR #139 合并后）。
+
+## B. 契约语义审读（人工）
+
+读 `docs/design/construction-workflow-portable-contract.md`，逐条认可或不认可：
+
+| 判定点 | 位置 | 预期 |
+|---|---|---|
+| 主链七阶段顺序固定 | §2 | requirements→design→dev→review→test→acceptance→closeout |
+| 回退一次一条边、按根因、优先级上游 | §4.1 | 有根因路由表与优先级 |
+| 额度耗尽行为 | §4.3 | WAITING_HUMAN + MAX_ROUNDS_REACHED，不篡改原结果 |
+| Decision ≠ Acceptance | §5.1 | 对照表成立（方向取舍 vs 成果签收） |
+| AI 不代签 | §5.4 | 禁止事项明确 |
+| #105 可消费性 | §9.5 | 11 项逐项有小节映射 |
+
+预期：六条全部认可。不认可处即 finding。
+
+## C. 机械校验强度
+
+```bash
+node scripts/cwf-validate.mjs docs/design/construction-workflow/handoff.schema.json docs/design/construction-workflow/examples/*.json
+node scripts/cwf-validate.mjs docs/design/construction-workflow/handoff.schema.json /Users/chris/workspace/workflow-manager/.agent-runs/cwf-123-01/requirements_baseline.json /Users/chris/workspace/workflow-manager/.agent-runs/cwf-123-01/design_package.json /Users/chris/workspace/workflow-manager/.agent-runs/cwf-123-01/dev_handoff.a2.json /Users/chris/workspace/workflow-manager/.agent-runs/cwf-123-01/review_proof.a7.json /Users/chris/workspace/workflow-manager/.agent-runs/cwf-123-01/test_proof.a7.json /Users/chris/workspace/workflow-manager/.agent-runs/cwf-123-01/acceptance_package.a7.json /Users/chris/workspace/workflow-manager/.agent-runs/cwf-123-01/closeout_summary.a7.json
+```
+
+预期：示例 7 个全部 valid；cwf-123-01 六类记录全部 valid。
+反例自测：把任一记录的 `verified_head` 置空再跑应 invalid，证明校验器在拦。
+
+## D. 工具链端到端演练（只读外的轻量写操作）
+
+```bash
+cd /Users/chris/workspace/workflow-manager
+node .scratch/worktrees/accept-main/scripts/cwf-run-init.mjs 999 cwf-accept-demo-01
+node .scratch/worktrees/accept-main/scripts/cwf-run-init.mjs 999 cwf-accept-demo-01
+```
+
+预期：worktree + run.json 生成；幂等重跑（同 run_id 同参数）输出 reused=true。
+
+```bash
+cd .scratch/worktrees/dev-cwf-accept-demo-01
+node ../../../../../accept-main/scripts/cwf-record.mjs rollback .agent-runs/cwf-accept-demo-01 dev
+```
+
+说明：rollback 需要真实 git 分支环境，演练 Run 的 worktree 满足；预期额度 1/3 入账。
+
+## E. 真实 Run 证据审计
+
+```bash
+ls /Users/chris/workspace/workflow-manager/.agent-runs/cwf-105-bootstrap-01/
+ls /Users/chris/workspace/workflow-manager/.agent-runs/cwf-123-01/
+cat /Users/chris/workspace/workflow-manager/.agent-runs/cwf-105-bootstrap-01/run.json
+```
+
+预期：两目录各含七类记录 + run.json + index.json；cwf-105 的 run.json 含 rollback_history（含 rejected 标记）与 budget_adjustments；cwf-123 的 rollback_history 含 requirements 根因回退（基线 v1→v2）。
+
+## F. 流程纪律实证（人工核对 PR 历史）
+
+- PR #115 / #125 / #132 / #139 的 review 讨论：每轮意见有逐条回复、无代签、收口评论在案；
+- 人工门：#105/#123/#104 的基线确认与验收均由 crystepj-max 完成（human_confirmation / decided_by 字段）。
+
+预期：全部属实。
+
+## G. External Profile 就绪检查（PR #139 合并后）
+
+```bash
+ls docs/runbooks/construction-external/
+grep -c "^### " docs/runbooks/construction-external/runbook.md
+node scripts/cwf-run-init.mjs --help
+```
+
+预期：两文件存在；小节数 10；脚本报用法提示。
+
+---
+
+## 验收记录表（执行者填写）
+
+| 层 | 结果（通过/差异） | 证据/备注 |
+|---|---|---|
+| A 静态资产 | | |
+| B 契约语义 | | |
+| C 机械校验 | | |
+| D 工具链演练 | | |
+| E 证据审计 | | |
+| F 流程纪律 | | |
+| G External Profile | | |
+
+验收人：__________　日期：__________　结论：通过 / 不通过（附差异说明）

--- a/docs/runbooks/construction-external/runbook.md
+++ b/docs/runbooks/construction-external/runbook.md
@@ -1,0 +1,85 @@
+# 建设 · 完整功能开发 · External Profile Runbook（Codex / Cursor 共用）
+
+> **语义纪律**：业务语义的唯一来源是建设工作流 Portable Contract（本仓库 `docs/design/construction-workflow-portable-contract.md`，版本以其文档头为准）。本 runbook 只做工具映射与驱动纪律，**不复制契约正文语义**（契约 §9.2）。下文 `§x.y` 锚点均指契约文档。
+>
+> **适用**：不运行在 DSH 内的 Coding Agent（Codex CLI / Cursor Agent 等）。环境需求：bash、git、gh（已认证）、Node.js。
+
+## 工具链（复用仓库脚本，零额外依赖）
+
+| 命令 | 用途 |
+|---|---|
+| `node scripts/cwf-run-init.mjs <issue编号> <run_id>` | Run 引导：分支 + worktree + portable run identity + schema 提供 |
+| `node scripts/cwf-record.mjs write/check/rollback/reverify/budget/archive` | 证据记录、校验、额度、归档 |
+| `node scripts/cwf-checkpoint.mjs <runDir>` | Integration Checkpoint（实况计算） |
+| `node scripts/cwf-evidence-verify.mjs <runDir>` | §8.3 九项证据链机器校验 |
+| `node scripts/cwf-validate.mjs <schema> <record...>` | 单记录 schema 校验 |
+
+> 本仓库克隆后即可用；所有脚本零外部依赖（纯 Node 标准库）。run 产物落在 worktree 的 `.agent-runs/<run_id>/`，由 run-init 自动写入 git 本地排除（不入 PR diff）。
+
+## 十节适配点
+
+### 1. Run 引导（issue → run_id / branch / worktree）
+
+```bash
+node scripts/cwf-run-init.mjs <issue编号> <run_id>   # run_id 建议 cwf-<issue>-<序号>，小写连字符
+```
+
+产出：分支 `dev-<run_id>` + worktree `.scratch/worktrees/dev-<run_id>/` + `run.json`（portable run identity，契约 §7.1）。**此后全部工作在 worktree 内进行**。
+
+### 2. 上下文加载
+
+进入 Run 前阅读（按序）：本仓库 `AGENTS.md` → 契约文档（版本头为准）→ 目标 issue 全文与评论。契约是业务语义唯一权威；本 runbook 与工具差异说明只是执行层。
+
+### 3. Requirements（需求基线落盘）— §3.1
+
+按契约三要素产出 baseline payload（goal/scope/acceptance/gaps），写入并呈递用户确认：
+
+```bash
+node scripts/cwf-record.mjs write .agent-runs/<run_id> requirements_baseline payload.json \
+  --produced-by <你的会话标识> --stage requirements
+```
+
+固定人工门：呈递三要素摘要，等用户确认；确认后 payload 置 `status=confirmed` + `baseline_revision` + `human_confirmation{confirmed_by, confirmed_at}` 重新写入（同 attempt 成熟刷新）。缺口必须显式（gaps 非空 + outcome=awaiting_human_input 挂起），不编造。
+
+### 4. Design — §3.2
+
+产出 design package（outcome 必填）；命中契约 §5.2 条件门判据 → `outcome=decision_required` + 非空 reasons + `decision_request`（question/options≥1/recommendation）呈递用户；裁决后补 `decision`（chosen 必须属于呈递候选集）并翻转 `package_ready`。未命中即自动推进。
+
+### 5. Dev（Run Workspace 施工）— §3.3
+
+在 worktree 内开发；完成写 dev handoff（`outcome=handoff_ready` 要求自验非空且无 fail/blocked）。`blocked`（可恢复外部条件）必须附 `blocked_reason`，恢复后重入（不耗额度）。写完即提交代码，handoff 记录自动绑定真实 HEAD。
+
+### 6. Review / Test（同一 verified HEAD 上独立复验）— §3.4/§3.5
+
+- **独立证明者（§2 不变量 2）**：审核与测试必须开**新的独立上下文**（见 tool-notes 的会话隔离方法）；`--produced-by` 必须与 dev 不同且 `independent_session=true`；
+- review：`verdict` + findings（逐条带根因分类）；`request_changes` → 单边回退（见 §8）；
+- test：映射基线验收标准逐条 `acceptance_mapping`（完整无重复）；`fail` 必须带 findings。
+- 两者的 `verified_branch`/`verified_head` 必须等于 worktree 实况（脚本写入时自动强校验）。
+
+### 7. Human Acceptance（呈递用户）— §3.6
+
+```bash
+node scripts/cwf-checkpoint.mjs .agent-runs/<run_id>          # 集成检查点
+node scripts/cwf-record.mjs write .agent-runs/<run_id> acceptance_package assembled.json --stage human_acceptance
+node scripts/cwf-evidence-verify.mjs .agent-runs/<run_id>     # §8.3 九项机器校验，非 0 不得呈递
+```
+
+呈递用户裁决：accept / reject（feedback + 根因）/ user_accepted（知情接受差异，feedback 必填）。**AI 不代签**。裁决后回填 decided 字段重新写入（成熟刷新；assembled 不得改写）。
+
+### 8. Rollback（根因路由回退）— §4.1/§4.2
+
+```bash
+node scripts/cwf-record.mjs rollback .agent-runs/<run_id> <dev|design|requirements>            # 自动回退（耗额度）
+node scripts/cwf-record.mjs rollback .agent-runs/<run_id> <根因> --by human --decided-by <人>   # 人工触发（不耗额度）
+node scripts/cwf-record.mjs budget .agent-runs/<run_id> <n> --decided-by <人> --reason "..."    # 人工调额（显式入账）
+```
+
+一次回退一条边、按根因选目标（requirements > design > dev 优先上游）；自动额度默认 3，耗尽挂起 `WAITING_HUMAN`（§4.3）呈递决策包。
+
+### 9. 多 Run 并行隔离
+
+run_id 唯一 ⇒ 分支/worktree 唯一（run-init 保证，§7.2）；不同 Run 不在共享 main cwd 开发。重入同一 Run 用同一 run_id 幂等复用（身份不符即拒绝）。
+
+### 10. run 产物不入库
+
+run-init 自动向主仓与 worktree 的 git `info/exclude` 写入 `.scratch/` 与 `.agent-runs/`（本地排除，不改 .gitignore）。收口归档（`cwf-record.mjs archive`）把证据复制到主检出 `.agent-runs/`——worktree 可安全删除，PR diff 始终干净。

--- a/docs/runbooks/construction-external/runbook.md
+++ b/docs/runbooks/construction-external/runbook.md
@@ -60,11 +60,20 @@ node scripts/cwf-record.mjs write .agent-runs/<run_id> requirements_baseline pay
 
 ```bash
 node scripts/cwf-checkpoint.mjs .agent-runs/<run_id>          # 集成检查点
-node scripts/cwf-record.mjs write .agent-runs/<run_id> acceptance_package assembled.json --stage human_acceptance
+node scripts/cwf-record.mjs write .agent-runs/<run_id> acceptance_package assembled.json --produced-by <你的会话标识> --stage human_acceptance
 node scripts/cwf-evidence-verify.mjs .agent-runs/<run_id>     # §8.3 九项机器校验，非 0 不得呈递
+# 人工知情接受（user_accepted）场景改用例外通道：
+node scripts/cwf-evidence-verify.mjs .agent-runs/<run_id> --decision user_accepted
 ```
 
 呈递用户裁决：accept / reject（feedback + 根因）/ user_accepted（知情接受差异，feedback 必填）。**AI 不代签**。裁决后回填 decided 字段重新写入（成熟刷新；assembled 不得改写）。
+
+**收口序列（契约 §3.7，accept 之后）**：PR 按仓库规则创建/合并 → 写 closeout_summary（交付清单 + 集成结果 + acceptance 引用 + `records_retained=true`）→ 归档：
+
+```bash
+node scripts/cwf-record.mjs write .agent-runs/<run_id> closeout_summary closeout.json --produced-by <你的会话标识> --stage closeout
+node scripts/cwf-record.mjs archive .agent-runs/<run_id>   # 证据归档到主检出后，worktree 才可移除
+```
 
 ### 8. Rollback（根因路由回退）— §4.1/§4.2
 

--- a/docs/runbooks/construction-external/runbook.md
+++ b/docs/runbooks/construction-external/runbook.md
@@ -66,7 +66,7 @@ node scripts/cwf-evidence-verify.mjs .agent-runs/<run_id>     # §8.3 九项机�
 node scripts/cwf-evidence-verify.mjs .agent-runs/<run_id> --decision user_accepted
 ```
 
-呈递用户裁决：accept / reject（feedback + 根因）/ user_accepted（知情接受差异，feedback 必填）。**AI 不代签**。裁决后回填 decided 字段重新写入（成熟刷新；assembled 不得改写）。
+呈递用户裁决：accept / reject（feedback + 根因）/ user_accepted（知情接受差异，feedback 必填）。**AI 不代签**。裁决后回填 decided 字段重新写入（成熟刷新；assembled 不得改写）。**裁决回填前必须重跑实况校验**（人工等待期间 target 可能已前进，契约 §7.3）：`node scripts/cwf-checkpoint.mjs .agent-runs/<run_id>` 与 `node scripts/cwf-evidence-verify.mjs .agent-runs/<run_id>` 任一失败即不得签收——先重跑受影响 Proof 并更新 checkpoint。
 
 **收口序列（契约 §3.7，accept 之后）**：PR 按仓库规则创建/合并 → 写 closeout_summary（交付清单 + 集成结果 + acceptance 引用 + `records_retained=true`）→ 归档：
 

--- a/docs/runbooks/construction-external/tool-notes.md
+++ b/docs/runbooks/construction-external/tool-notes.md
@@ -1,0 +1,30 @@
+# External Profile 工具差异说明（薄适配层）
+
+> 本文件只描述「同一 runbook 在不同工具环境下怎么操作」的机械差异，**不含任何业务语义**。语义一律以契约为准（见 runbook.md 头部纪律）。
+
+## Codex CLI
+
+| 环节 | 做法 |
+|---|---|
+| 上下文加载 | 仓库根 `AGENTS.md` 自动生效；契约与 runbook 路径写入 AGENTS.md 引用或开工指令 |
+| 命令执行 | 内建 shell；cwf-* 脚本直接用 `node scripts/...` |
+| GitHub | `gh` CLI（`gh auth login` 预置） |
+| 独立证明者 | 新开 Codex 会话（新对话窗口/`codex` 新会话）执行 review/test；produced_by 用新会话标识 |
+| 人工门 | 呈现文本摘要等待用户在终端回复；裁决由用户在下一条消息给出 |
+
+## Cursor
+
+| 环节 | 做法 |
+|---|---|
+| 上下文加载 | `.cursor/rules/` 或 @-references 指向契约与 runbook；或在 Agent 开工消息中粘贴路径 |
+| 命令执行 | Agent 的 Terminal 能力；cwf-* 脚本同样 `node scripts/...` |
+| GitHub | `gh` CLI 同上 |
+| 独立证明者 | 新开一个 Chat/Agent 会话执行 review/test（不同 produced_by）；可选不同模型路线 |
+| 人工门 | Agent 会话内呈递；用户在下一条消息裁决 |
+
+## 共同纪律（工具无关）
+
+- 每个 Run 独立 worktree/branch（runbook §1）；
+- review/test 禁止与 dev 同会话同 produced_by（契约 §2 不变量 2）；
+- 人工门一律挂起等待，AI 不代签（§5.4）；
+- run 产物经本地 exclude 不入库（runbook §10）。

--- a/scripts/cwf-record.mjs
+++ b/scripts/cwf-record.mjs
@@ -148,6 +148,31 @@ function cmdWrite(runDir, recordType, payloadPath, flags) {
     }
   }
 
+  // closeout 收口双重校验（契约 §8.3）：所引验收包必须已 decided、非 reject、
+  // 且 decision 与 acceptance_outcome 一致——不得归档无效或错配的完结
+  if (recordType === 'closeout_summary') {
+    const ref = record.payload.acceptance_package_ref
+    const apPath = join(runDir, ref)
+    if (!existsSync(apPath)) {
+      console.error(`closeout 引用的验收包不存在: ${ref}`)
+      process.exit(1)
+    }
+    const ap = JSON.parse(readFileSync(apPath, 'utf-8'))
+    const problems = []
+    if (ap.record_type !== 'acceptance_package') problems.push(`引用类型错误: ${ap.record_type}`)
+    if (ap.payload?.status !== 'decided') problems.push(`验收包未决: status=${ap.payload?.status}`)
+    if (ap.payload?.decision === 'reject') problems.push('验收包为 reject——不得收口')
+    if (ap.payload?.decision && ap.payload.decision !== record.payload.acceptance_outcome) {
+      problems.push(`acceptance_outcome(${record.payload.acceptance_outcome}) ≠ 引用包 decision(${ap.payload.decision})`)
+    }
+    if (ap.run?.run_id !== run.run_id) problems.push(`引用包不属于本 Run（${ap.run?.run_id}）`)
+    if (problems.length > 0) {
+      console.error('closeout 引用校验失败（契约 §8.3）：')
+      for (const p2 of problems) console.error(`  ${p2}`)
+      process.exit(1)
+    }
+  }
+
   // attempt 戳文件名 + index 索引：回退重跑的旧记录不得被覆盖（契约 §8.5）
   const fileName = `${recordType}.a${run.attempt}.json`
   const out = join(runDir, fileName)

--- a/scripts/test/cwf-record.test.mjs
+++ b/scripts/test/cwf-record.test.mjs
@@ -462,6 +462,62 @@ test('write：dev_handoff blocked 允许同 attempt 刷新（可恢复态）', (
   assert.equal(run(['write', runDir, 'dev_handoff', mk('d2.json'), '--produced-by', 'test-suite', '--stage', 'dev']).code, 0) // 刷新允许
 })
 
+test('closeout：引用验收包交叉校验（未决/reject/错配/跨 Run 全拒，一致放行）', () => {
+  const { root, runDir } = makeRunDir()
+  const realHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf-8' }).trim()
+  const realBranch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: root, encoding: 'utf-8' }).trim()
+  const mk = (name, status, extra = {}) => {
+    const f = join(runDir, name)
+    writeFileSync(f, JSON.stringify({
+      status,
+      assembled: {
+        requirements_baseline_ref: 'r', design_package_ref: 'd', dev_handoff_ref: 'v',
+        review_proof_ref: 'rp', test_proof_ref: 'tp',
+        integration_checkpoint: { target_ref: 'main', target_head_at_check: realHead, target_advanced: false, proofs_state: 'still_valid' },
+      },
+      ...extra,
+    }))
+    return f
+  }
+  const writeCloseout = (outcome) => {
+    const f = join(runDir, 'co.json')
+    writeFileSync(f, JSON.stringify({
+      deliverables: ['x'], integration: { pr: '#1', checkpoint: 'c' },
+      acceptance_package_ref: 'acceptance_package.a1.json', acceptance_outcome: outcome, records_retained: true,
+    }))
+    return run(['write', runDir, 'closeout_summary', f, '--produced-by', 'test-suite', '--stage', 'closeout'])
+  }
+  // 未决 → 拒
+  run(['write', runDir, 'acceptance_package', mk('a-await.json', 'awaiting_decision'), '--produced-by', 'test-suite', '--stage', 'human_acceptance'])
+  assert.equal(writeCloseout('accept').code, 1)
+  // reject → 拒
+  run(['write', runDir, 'acceptance_package', mk('a-reject.json', 'decided', { decision: 'reject', decided_by: 'x', decided_at: '2026-08-31T00:00:00Z', feedback: 'f', rejection_root_cause: 'dev', verified_branch: realBranch, verified_head: realHead }), '--produced-by', 'test-suite', '--stage', 'human_acceptance'])
+  // 注意：同 attempt 同文件成熟——改用新文件名引用拒绝态
+  const badRef = writeCloseout('accept')
+  // 上面的 writeCloseout 引用 acceptance_package.a1.json，但该文件从未被写过（mk 只写 payload 文件）——先补真实引用目标
+  const ap = join(runDir, 'acceptance_package.a1.json')
+  writeFileSync(ap, JSON.stringify({
+    record_type: 'acceptance_package', record_version: 'v0.1.8', created_at: '2026-08-31T00:00:00Z',
+    produced_by: 'x', run: { run_id: 'cwf-test-01', issue_or_task_identity: '#999', workspace_id: 'wt-test', repository: 'crystepj-max/workflow-manager', base_ref: 'main', base_commit: 'abc', work_branch: realBranch, current_head: realHead, stage: 'human_acceptance', attempt: 1 },
+    payload: { status: 'decided', assembled: {}, decision: 'reject', decided_by: 'x', decided_at: '2026-08-31T00:00:00Z', feedback: 'f', rejection_root_cause: 'dev', verified_branch: realBranch, verified_head: realHead },
+  }))
+  const rReject = writeCloseout('accept')
+  assert.equal(rReject.code, 1)
+  assert.match(rReject.out, /reject/)
+  // outcome 与 decision 错配 → 拒
+  writeFileSync(ap, JSON.stringify({
+    record_type: 'acceptance_package', record_version: 'v0.1.8', created_at: '2026-08-31T00:00:00Z',
+    produced_by: 'x', run: { run_id: 'cwf-test-01', issue_or_task_identity: '#999', workspace_id: 'wt-test', repository: 'crystepj-max/workflow-manager', base_ref: 'main', base_commit: 'abc', work_branch: realBranch, current_head: realHead, stage: 'human_acceptance', attempt: 1 },
+    payload: { status: 'decided', assembled: {}, decision: 'user_accepted', decided_by: 'x', decided_at: '2026-08-31T00:00:00Z', feedback: 'f', verified_branch: realBranch, verified_head: realHead },
+  }))
+  const rMismatch = writeCloseout('accept')
+  assert.equal(rMismatch.code, 1)
+  assert.match(rMismatch.out, /acceptance_outcome/)
+  // 一致 → 放行
+  const rOk = run(['write', runDir, 'closeout_summary', (() => { const f = join(runDir, 'co-ok.json'); writeFileSync(f, JSON.stringify({ deliverables: ['x'], integration: { pr: '#1', checkpoint: 'c' }, acceptance_package_ref: 'acceptance_package.a1.json', acceptance_outcome: 'user_accepted', records_retained: true })); return f })(), '--produced-by', 'test-suite', '--stage', 'closeout'])
+  assert.equal(rOk.code, 0, rOk.out)
+})
+
 test('check：对既有记录只校验', () => {
   const { runDir } = makeRunDir()
   const payload = join(runDir, 'payload.json')


### PR DESCRIPTION
> *This was generated by AI during triage.*

## 关联

- 目标 issue：#104（Blocked by #103 已解除——契约 v0.1.8 在 main）
- 语义来源：建设工作流 Portable Contract（全部锚点引用，零语义复制）

## 变更内容

- `docs/runbooks/construction-external/runbook.md`：Codex/Cursor 共用共享 runbook，覆盖 #104 十项适配点（Run 引导/上下文加载/需求设计落盘/Dev 施工/独立复验/人工验收/收口/根因回退/并行隔离/run 产物不入库），命令全部走已合入的 cwf-* 工具链
- `docs/runbooks/construction-external/tool-notes.md`：薄工具差异层（无业务语义）

## 已运行的校验

- 十节覆盖核验（10/10）；16 个契约锚点全部存在于契约文档（脚本核验）；
- `npm test` 160/160 全绿；纯文档变更，generate/validate 不适用。

## 蓝图影响

无。

## 备注

External Dogfood（Cursor/Codex 各跑 1 个真实 issue）由对应 Agent 按本 runbook 后续执行（#104 原文允许届时确认）。