### PR TITLE
feat: 落地 Formal Record 不可覆盖 Revision 与依赖式证明失效 (#78)

### DIFF
--- a/docs/design/formal-records.md
+++ b/docs/design/formal-records.md
@@ -62,7 +62,7 @@ Node Result 可以产生 **0..n** 条 Formal Record（验收要求「可产生�
 ## 5. Decision 与 Guidance
 
 - **Decision Record**：`kind=proof_decision`，`body.value.decision` 含 question / options / chosen / rationale / decided_by / decided_at。追加式；不得改写已存在 Revision。
-- **Guidance**：`kind=input_baseline` 的输入记录，依赖当时 Baseline。`changes_baseline=false` 时不产生新 Baseline Revision；`true` 时必须同时追加新的 Baseline Revision，且新 Baseline 的 `dependencies` 含旧 Baseline 与该 Guidance。
+- **Guidance**：`kind=input_baseline` 的输入记录，依赖当时 Baseline。`changes_baseline=false` 时不产生新 Baseline Revision；`true` 时必须同时追加新的 Baseline Revision，且新 Baseline 的 `dependencies` 含旧 Baseline 与该 Guidance。失败路径不得留下「声称改 Baseline 却没有新 Revision」的 Guidance。
 
 ## 6. Portable 映射
 

--- a/docs/design/formal-records.md
+++ b/docs/design/formal-records.md
@@ -1,0 +1,91 @@
+# Formal Records / Revision / Provenance
+
+> 状态：#78 实现契约  
+> 权威实现：`scripts/formal-records.mjs`  
+> Schema：`docs/design/formal-records/schema.json`  
+> 产品语义：`workflow-manager-v0.1-final-product-spec.md` §2.7 / §7；原则 R3–R5
+
+本文件定义跨四套正式工作流的 **Formal Record** 内核。框架只承载 record / revision / dependency / provenance，**不硬编码** Requirement、Review 等业务名。建设工作流 Portable 七类交接包（`docs/design/construction-workflow-portable-contract.md` §8）是本模型的兼容前身；本内核落地后，Revision / 依赖链 / 证明失效以本契约为权威，七类记录经 `mapPortableHandoff` 映射，不丢历史。
+
+本票不实现 Logical Run / Snapshot Runtime（#79）、Human Decision 挂起（#72）、多格式 Artifact（#69）、模板消费（#82）或 Bootstrap shim 退役（#105）。
+
+## 1. 三类语义（kind）
+
+| kind | 对应原则中的分类 | 例子（业务名不属于内核） |
+|---|---|---|
+| `input_baseline` | 输入 / 基准 | 需求基线、评价契约、诊断结论、Guidance 输入 |
+| `result` | 成果 | 方案、实现交接、综合分析、修复产物 |
+| `proof_decision` | 证明 / 决策 | 审核、测试、评估、Human Decision、人工验收 |
+
+## 2. 记录形状
+
+每条记录在诞生时冻结，之后只可读。同一 `record_id` 的新内容产生新的 `record_revision`（从 1 起的正整数），旧 Revision 内容不变。
+
+```text
+record_id + record_revision
+kind
+body.media_type ∈ { application/json, text/markdown, text/plain }
+body.value            ← 不透明载体；覆盖判定不得读取
+dependencies[]        ← { record_id, record_revision }；覆盖判定的唯一依据
+based_on?             ← 主前驱，若出现则必须是 dependencies 中的一项
+provenance            ← 诞生时拷贝，含 snapshot_revision / provider / model /
+                        node / attempt / node_business_outcome 等
+created_at
+```
+
+`based_on` 是主前驱标注；**机器失效与覆盖判定只读 `dependencies`。** 禁止把 Markdown / 自由文本解析成依赖。
+
+Node Business Outcome 与 Formal Record 分离：Outcome 留在 Node Result 上；写入 Record 时只把当时的 Outcome **拷贝**进 `provenance.node_business_outcome`。Runtime 控制状态（含 `WAITING_HUMAN + MAX_ROUNDS_REACHED`）不得回写已形成的 Outcome 或 Record。
+
+## 3. 覆盖判定
+
+给定 Proof `P` 与目标 `record_id`（其当前 Revision 为 `T`）：
+
+| 结果 | 条件 |
+|---|---|
+| `covering` | `P.dependencies` 含 `{ record_id, record_revision: T }` |
+| `not_covering_current` | `P.dependencies` 含同一 `record_id` 但 Revision ≠ `T`（旧 Proof 保留，标记 stale） |
+| `unrelated` | `P.dependencies` 不含该 `record_id` |
+
+只认**直接**依赖，不走传递闭包，避免 Fan-out 兄弟被机械失效。
+
+`dependsOnStaleInputs(record)`：任一项依赖的当前 Revision 已前进，则该记录的输入集合不再覆盖当前世界（用于 Synthesis / Evaluation 等成果，不只是 Proof）。
+
+典型链：`R1 → D1 → I1 → RV1 → T1`。产生 `I2` 后，RV1/T1 仍是 I1 的历史证明，对 I2 为 `not_covering_current`。
+
+Fan-out：专家 A1、B1 保留；仅依赖 `{A1,B1}` 的 Synthesis / Evaluation 在 A→A2 后 `dependsOnStaleInputs=true`；未依赖 A 的兄弟不失效。
+
+## 4. Node Result
+
+Node Result 可以产生 **0..n** 条 Formal Record（验收要求「可产生一个或多个」，能力存在即可）。每条 Record 拷贝同一份诞生时 Outcome。节点业务 Output Schema 继续活在 Node Result / `body.value` 里，不迁入信封。
+
+## 5. Decision 与 Guidance
+
+- **Decision Record**：`kind=proof_decision`，`body.value.decision` 含 question / options / chosen / rationale / decided_by / decided_at。追加式；不得改写已存在 Revision。
+- **Guidance**：`kind=input_baseline` 的输入记录，依赖当时 Baseline。`changes_baseline=false` 时不产生新 Baseline Revision；`true` 时必须同时追加新的 Baseline Revision，且新 Baseline 的 `dependencies` 含旧 Baseline 与该 Guidance。
+
+## 6. Portable 映射
+
+`portable:{run_id}:{record_type}` 作为稳定 `record_id`。同 Run 再次映射同一 `record_type`（含 draft→confirmed 刷新）追加新 Revision，并把上一 Revision 列入 `dependencies`。
+
+| Portable `record_type` | kind | 直接前驱 |
+|---|---|---|
+| `requirements_baseline` | `input_baseline` | （无；刷新时含自身上一 Revision） |
+| `design_package` | `result` | `requirements_baseline` |
+| `dev_handoff` | `result` | `design_package` |
+| `review_proof` | `proof_decision` | `dev_handoff` |
+| `test_proof` | `proof_decision` | `dev_handoff` |
+| `acceptance_package` | `proof_decision` | 上述五类 |
+| `closeout_summary` | `result` | `acceptance_package` |
+
+映射后 `provenance.portable` 保留源 `record_type` / `record_version` / `run_id` / `attempt` / `created_at`，历史 Dogfood Run 可追溯。不删除 construction-bootstrap shim。
+
+## 7. 模块边界
+
+| 路径 | 职责 |
+|---|---|
+| `scripts/formal-records.mjs` | 追加式 Store、覆盖判定、Node Result 展开、Decision/Guidance 助手、Portable 映射、schema 校验 |
+| `scripts/test/formal-records.test.mjs` | #78 验收的可执行证据 |
+| 本文件 + schema.json | 对外契约（供 #69 / #79 / #82 消费） |
+
+不接入 `scripts/generate.mjs`、`packages/dsh-visual-workflow`、建设 Portable Contract 正文。Store 默认内存；Runtime 落盘归 #79。

--- a/docs/design/formal-records/schema.json
+++ b/docs/design/formal-records/schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "docs/design/formal-records/schema.json",
+  "title": "Formal Record / Revision / Provenance",
+  "description": "跨四套工作流通用的 Formal Record 信封（#78）。body 不透明；覆盖判定只读 dependencies。",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "record_id",
+    "record_revision",
+    "kind",
+    "body",
+    "dependencies",
+    "provenance",
+    "created_at"
+  ],
+  "properties": {
+    "record_id": { "$ref": "#/definitions/nonEmptyText" },
+    "record_revision": { "type": "integer", "minimum": 1 },
+    "kind": {
+      "enum": ["input_baseline", "result", "proof_decision"]
+    },
+    "body": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["media_type", "value"],
+      "properties": {
+        "media_type": {
+          "enum": ["application/json", "text/markdown", "text/plain"]
+        },
+        "value": true
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/recordRef" }
+    },
+    "based_on": { "$ref": "#/definitions/recordRef" },
+    "provenance": { "$ref": "#/definitions/provenance" },
+    "created_at": { "$ref": "#/definitions/isoDateTime" }
+  },
+  "definitions": {
+    "nonEmptyText": {
+      "type": "string",
+      "pattern": "\\S"
+    },
+    "isoDateTime": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$"
+    },
+    "recordRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "record_revision"],
+      "properties": {
+        "record_id": { "$ref": "#/definitions/nonEmptyText" },
+        "record_revision": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "logical_run_id",
+        "node",
+        "attempt",
+        "snapshot_revision",
+        "provider",
+        "model",
+        "produced_by",
+        "node_business_outcome"
+      ],
+      "properties": {
+        "logical_run_id": { "$ref": "#/definitions/nonEmptyText" },
+        "node": { "$ref": "#/definitions/nonEmptyText" },
+        "attempt": { "type": "integer", "minimum": 1 },
+        "snapshot_revision": { "$ref": "#/definitions/nonEmptyText" },
+        "provider": { "$ref": "#/definitions/nonEmptyText" },
+        "model": { "$ref": "#/definitions/nonEmptyText" },
+        "produced_by": { "$ref": "#/definitions/nonEmptyText" },
+        "node_business_outcome": true,
+        "lifecycle_event": { "$ref": "#/definitions/nonEmptyText" },
+        "related_decision": { "$ref": "#/definitions/recordRef" },
+        "related_guidance": { "$ref": "#/definitions/recordRef" },
+        "portable": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["record_type", "record_version", "run_id", "attempt", "created_at"],
+          "properties": {
+            "record_type": { "$ref": "#/definitions/nonEmptyText" },
+            "record_version": { "$ref": "#/definitions/nonEmptyText" },
+            "run_id": { "$ref": "#/definitions/nonEmptyText" },
+            "attempt": { "type": "integer", "minimum": 1 },
+            "created_at": { "$ref": "#/definitions/isoDateTime" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/formal-records.mjs
+++ b/scripts/formal-records.mjs
@@ -1,0 +1,417 @@
+// Formal Record / Revision / Provenance 内核（#78）
+// 追加式 Store：无 update；覆盖判定只读 dependencies。
+// 用法：import { createStore, appendRecord, coverageStatus, mapPortableHandoff } from './formal-records.mjs'
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { validateRecord } from './cwf-validate.mjs'
+
+export const KIND = {
+  INPUT_BASELINE: 'input_baseline',
+  RESULT: 'result',
+  PROOF_DECISION: 'proof_decision',
+}
+
+export const MEDIA = {
+  JSON: 'application/json',
+  MARKDOWN: 'text/markdown',
+  TEXT: 'text/plain',
+}
+
+export const COVERING = 'covering'
+export const NOT_COVERING_CURRENT = 'not_covering_current'
+export const UNRELATED = 'unrelated'
+
+export const PORTABLE_KIND = {
+  requirements_baseline: KIND.INPUT_BASELINE,
+  design_package: KIND.RESULT,
+  dev_handoff: KIND.RESULT,
+  review_proof: KIND.PROOF_DECISION,
+  test_proof: KIND.PROOF_DECISION,
+  acceptance_package: KIND.PROOF_DECISION,
+  closeout_summary: KIND.RESULT,
+}
+
+export const PORTABLE_PREDECESSORS = {
+  requirements_baseline: [],
+  design_package: ['requirements_baseline'],
+  dev_handoff: ['design_package'],
+  review_proof: ['dev_handoff'],
+  test_proof: ['dev_handoff'],
+  acceptance_package: [
+    'requirements_baseline',
+    'design_package',
+    'dev_handoff',
+    'review_proof',
+    'test_proof',
+  ],
+  closeout_summary: ['acceptance_package'],
+}
+
+const KINDS = new Set(Object.values(KIND))
+const MEDIAS = new Set(Object.values(MEDIA))
+const SCHEMA_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs', 'design', 'formal-records', 'schema.json')
+
+let cachedSchema
+
+export function loadFormalRecordSchema() {
+  if (!cachedSchema) {
+    cachedSchema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf-8'))
+  }
+  return cachedSchema
+}
+
+export function validateFormalRecord(record) {
+  return validateRecord(loadFormalRecordSchema(), record)
+}
+
+export function createStore() {
+  return { byId: new Map(), order: [], control_log: [] }
+}
+
+export function toRef(record) {
+  return { record_id: record.record_id, record_revision: record.record_revision }
+}
+
+export function currentRevision(store, recordId) {
+  const revs = store.byId.get(recordId)
+  if (!revs || revs.size === 0) return undefined
+  return Math.max(...revs.keys())
+}
+
+export function getRecord(store, recordId, revision) {
+  const revs = store.byId.get(recordId)
+  if (!revs) return undefined
+  const rev = revision === undefined ? currentRevision(store, recordId) : revision
+  return revs.get(rev)
+}
+
+export function listRevisions(store, recordId) {
+  const revs = store.byId.get(recordId)
+  if (!revs) return []
+  return [...revs.keys()].sort((a, b) => a - b).map(r => revs.get(r))
+}
+
+export function allRecords(store) {
+  return store.order.map(ref => getRecord(store, ref.record_id, ref.record_revision))
+}
+
+export function appendRecord(store, input) {
+  if (!input || typeof input !== 'object') throw new Error('appendRecord 需要记录对象')
+  if (input.record_revision !== undefined) {
+    throw new Error('禁止指定 record_revision：由 Store 追加分配')
+  }
+  const recordId = requireText(input.record_id, 'record_id')
+  if (!KINDS.has(input.kind)) throw new Error(`非法 kind: ${input.kind}`)
+  const body = normalizeBody(input.body)
+  const dependencies = normalizeDeps(input.dependencies)
+  for (const dep of dependencies) {
+    if (!getRecord(store, dep.record_id, dep.record_revision)) {
+      throw new Error(`依赖不存在: ${dep.record_id}@${dep.record_revision}`)
+    }
+  }
+  let basedOn
+  if (input.based_on !== undefined && input.based_on !== null) {
+    basedOn = normalizeRef(input.based_on, 'based_on')
+    if (!dependencies.some(d => refsEqual(d, basedOn))) {
+      throw new Error('based_on 必须是 dependencies 中的一项')
+    }
+  }
+  const provenance = normalizeProvenance(input.provenance)
+  const nextRev = (currentRevision(store, recordId) || 0) + 1
+  const record = {
+    record_id: recordId,
+    record_revision: nextRev,
+    kind: input.kind,
+    body,
+    dependencies,
+    provenance,
+    created_at: input.created_at || new Date().toISOString(),
+  }
+  if (basedOn) record.based_on = basedOn
+
+  const errors = validateFormalRecord(record)
+  if (errors.length > 0) {
+    throw new Error(`Formal Record 校验失败：${errors.join('；')}`)
+  }
+
+  const frozen = deepFreeze(structuredClone(record))
+  if (!store.byId.has(recordId)) store.byId.set(recordId, new Map())
+  store.byId.get(recordId).set(nextRev, frozen)
+  store.order.push(toRef(frozen))
+  return frozen
+}
+
+export function recordsFromNodeResult(store, { outcome, productions, provenance }) {
+  if (!Array.isArray(productions)) throw new Error('productions 必须是数组')
+  const produced_records = productions.map(p => appendRecord(store, {
+    ...p,
+    provenance: {
+      ...provenance,
+      node_business_outcome: structuredClone(outcome),
+    },
+  }))
+  return { outcome, produced_records }
+}
+
+export function appendDecisionRecord(store, input) {
+  const d = input.decision || input
+  for (const k of ['question', 'options', 'chosen', 'rationale', 'decided_by', 'decided_at']) {
+    if (d[k] === undefined || d[k] === null || d[k] === '') {
+      throw new Error(`Decision Record 缺少 ${k}`)
+    }
+  }
+  if (!Array.isArray(d.options) || d.options.length < 1) {
+    throw new Error('Decision Record options 至少一项')
+  }
+  return appendRecord(store, {
+    record_id: requireText(input.record_id, 'record_id'),
+    kind: KIND.PROOF_DECISION,
+    body: {
+      media_type: MEDIA.JSON,
+      value: {
+        decision: {
+          question: d.question,
+          options: d.options,
+          chosen: d.chosen,
+          rationale: d.rationale,
+          decided_by: d.decided_by,
+          decided_at: d.decided_at,
+        },
+      },
+    },
+    dependencies: input.dependencies,
+    based_on: input.based_on,
+    provenance: input.provenance,
+  })
+}
+
+export function appendGuidance(store, input) {
+  const baseline = normalizeRef(input.baseline, 'baseline')
+  if (!getRecord(store, baseline.record_id, baseline.record_revision)) {
+    throw new Error(`Guidance 所依赖的 Baseline 不存在: ${baseline.record_id}@${baseline.record_revision}`)
+  }
+  const changes = input.changes_baseline === true
+  const guidance = appendRecord(store, {
+    record_id: requireText(input.record_id, 'record_id'),
+    kind: KIND.INPUT_BASELINE,
+    body: {
+      media_type: MEDIA.JSON,
+      value: { text: input.text || '', changes_baseline: changes },
+    },
+    dependencies: [baseline],
+    based_on: baseline,
+    provenance: input.provenance,
+  })
+  if (!changes) {
+    return { guidance, baseline: getRecord(store, baseline.record_id, baseline.record_revision) }
+  }
+  if (!input.new_baseline || !input.new_baseline.body) {
+    throw new Error('changes_baseline 必须关联新的 Baseline Revision（提供 new_baseline.body）')
+  }
+  const nextId = input.new_baseline.record_id || baseline.record_id
+  const next = appendRecord(store, {
+    record_id: nextId,
+    kind: KIND.INPUT_BASELINE,
+    body: normalizeBody(input.new_baseline.body),
+    dependencies: [baseline, toRef(guidance)],
+    based_on: baseline,
+    provenance: {
+      ...input.provenance,
+      related_guidance: toRef(guidance),
+    },
+  })
+  return { guidance, baseline: next }
+}
+
+export function applyRuntimeControl(store, event) {
+  if (!event || typeof event !== 'object') throw new Error('控制事件必须是对象')
+  const type = requireText(event.type, 'type')
+  const entry = deepFreeze(structuredClone({
+    at: event.at || new Date().toISOString(),
+    type,
+    ...(event.reason !== undefined ? { reason: event.reason } : {}),
+  }))
+  store.control_log.push(entry)
+  return entry
+}
+
+export function coverageStatus(store, proofRef, targetRecordId) {
+  const proof = resolve(store, proofRef, 'proof')
+  const current = currentRevision(store, targetRecordId)
+  const target = current === undefined ? undefined : { record_id: targetRecordId, record_revision: current }
+  const hits = (proof.dependencies || []).filter(d => d.record_id === targetRecordId)
+  if (hits.length === 0) {
+    return { status: UNRELATED, stale: false, proof, target }
+  }
+  if (current !== undefined && hits.some(d => d.record_revision === current)) {
+    return { status: COVERING, stale: false, proof, target }
+  }
+  return { status: NOT_COVERING_CURRENT, stale: true, proof, target }
+}
+
+export function coversRevision(store, proofRef, targetRef) {
+  const proof = resolve(store, proofRef, 'proof')
+  const target = normalizeRef(targetRef, 'target')
+  return proof.dependencies.some(d => refsEqual(d, target))
+}
+
+export function dependsOnStaleInputs(store, recordRef) {
+  const rec = resolve(store, recordRef, 'record')
+  return rec.dependencies.some(d => currentRevision(store, d.record_id) !== d.record_revision)
+}
+
+export function staleProofsFor(store, recordId) {
+  return allRecords(store).filter(r =>
+    r.kind === KIND.PROOF_DECISION
+    && coverageStatus(store, r, recordId).status === NOT_COVERING_CURRENT,
+  )
+}
+
+export function portableRecordId(runId, recordType) {
+  return `portable:${runId}:${recordType}`
+}
+
+export function mapPortableHandoff(store, portable, extraProvenance = {}) {
+  const type = portable && portable.record_type
+  if (!PORTABLE_KIND[type]) throw new Error(`未知 portable record_type: ${type}`)
+  const runId = portable.run && portable.run.run_id
+  if (!runId) throw new Error('portable 缺少 run.run_id')
+  const selfId = portableRecordId(runId, type)
+  const dependencies = []
+  for (const pred of PORTABLE_PREDECESSORS[type]) {
+    const id = portableRecordId(runId, pred)
+    const rev = currentRevision(store, id)
+    if (rev !== undefined) dependencies.push({ record_id: id, record_revision: rev })
+  }
+  const prev = currentRevision(store, selfId)
+  if (prev !== undefined) {
+    const selfRef = { record_id: selfId, record_revision: prev }
+    if (!dependencies.some(d => refsEqual(d, selfRef))) dependencies.push(selfRef)
+  }
+  const basedOn = prev !== undefined
+    ? { record_id: selfId, record_revision: prev }
+    : (dependencies[0] || undefined)
+  const createdAt = portable.created_at && /^\d{4}-\d{2}-\d{2}T/.test(portable.created_at)
+    ? portable.created_at
+    : new Date().toISOString()
+  const outcome = portable.payload && (
+    portable.payload.outcome
+    ?? portable.payload.verdict
+    ?? portable.payload.decision
+    ?? portable.payload.status
+    ?? null
+  )
+  return appendRecord(store, {
+    record_id: selfId,
+    kind: PORTABLE_KIND[type],
+    body: { media_type: MEDIA.JSON, value: portable.payload === undefined ? null : portable.payload },
+    dependencies,
+    based_on: basedOn,
+    created_at: createdAt,
+    provenance: {
+      logical_run_id: extraProvenance.logical_run_id || runId,
+      node: extraProvenance.node || portable.run.stage || type,
+      attempt: extraProvenance.attempt || portable.run.attempt || 1,
+      snapshot_revision: extraProvenance.snapshot_revision
+        || portable.run.current_head
+        || portable.run.base_commit
+        || 'unspecified',
+      provider: extraProvenance.provider || 'unknown',
+      model: extraProvenance.model || 'unknown',
+      produced_by: portable.produced_by || extraProvenance.produced_by || 'unknown',
+      node_business_outcome: outcome,
+      portable: {
+        record_type: type,
+        record_version: portable.record_version || 'unknown',
+        run_id: runId,
+        attempt: portable.run.attempt || 1,
+        created_at: createdAt,
+      },
+    },
+  })
+}
+
+function resolve(store, refOrRecord, label) {
+  if (refOrRecord && refOrRecord.dependencies && refOrRecord.record_id) return refOrRecord
+  const ref = normalizeRef(refOrRecord, label)
+  const rec = getRecord(store, ref.record_id, ref.record_revision)
+  if (!rec) throw new Error(`${label} 不存在: ${ref.record_id}@${ref.record_revision}`)
+  return rec
+}
+
+function normalizeBody(body) {
+  if (!body || typeof body !== 'object') throw new Error('body 必须是对象')
+  if (!MEDIAS.has(body.media_type)) throw new Error(`非法 media_type: ${body.media_type}`)
+  return { media_type: body.media_type, value: structuredClone(body.value) }
+}
+
+function normalizeDeps(deps) {
+  if (deps === undefined || deps === null) return []
+  if (!Array.isArray(deps)) throw new Error('dependencies 必须是数组')
+  return deps.map((d, i) => normalizeRef(d, `dependencies[${i}]`))
+}
+
+function normalizeRef(ref, label) {
+  if (!ref || typeof ref !== 'object') throw new Error(`${label} 必须是 { record_id, record_revision }`)
+  const record_id = requireText(ref.record_id, `${label}.record_id`)
+  const record_revision = ref.record_revision
+  if (!Number.isInteger(record_revision) || record_revision < 1) {
+    throw new Error(`${label}.record_revision 必须是正整数`)
+  }
+  return { record_id, record_revision }
+}
+
+function normalizeProvenance(p) {
+  if (!p || typeof p !== 'object') throw new Error('provenance 必填')
+  const out = {
+    logical_run_id: requireText(p.logical_run_id, 'provenance.logical_run_id'),
+    node: requireText(p.node, 'provenance.node'),
+    attempt: p.attempt,
+    snapshot_revision: requireText(p.snapshot_revision, 'provenance.snapshot_revision'),
+    provider: requireText(p.provider, 'provenance.provider'),
+    model: requireText(p.model, 'provenance.model'),
+    produced_by: requireText(p.produced_by, 'provenance.produced_by'),
+    node_business_outcome: structuredClone(p.node_business_outcome),
+  }
+  if (!Number.isInteger(out.attempt) || out.attempt < 1) {
+    throw new Error('provenance.attempt 必须是正整数')
+  }
+  if (p.lifecycle_event) out.lifecycle_event = requireText(p.lifecycle_event, 'provenance.lifecycle_event')
+  if (p.related_decision) out.related_decision = normalizeRef(p.related_decision, 'related_decision')
+  if (p.related_guidance) out.related_guidance = normalizeRef(p.related_guidance, 'related_guidance')
+  if (p.portable) {
+    out.portable = {
+      record_type: requireText(p.portable.record_type, 'portable.record_type'),
+      record_version: requireText(p.portable.record_version, 'portable.record_version'),
+      run_id: requireText(p.portable.run_id, 'portable.run_id'),
+      attempt: p.portable.attempt,
+      created_at: requireText(p.portable.created_at, 'portable.created_at'),
+    }
+    if (!Number.isInteger(out.portable.attempt) || out.portable.attempt < 1) {
+      throw new Error('portable.attempt 必须是正整数')
+    }
+  }
+  return out
+}
+
+function requireText(v, label) {
+  if (typeof v !== 'string' || !/\S/.test(v)) throw new Error(`${label} 必须是非空字符串`)
+  return v
+}
+
+function refsEqual(a, b) {
+  return a.record_id === b.record_id && a.record_revision === b.record_revision
+}
+
+function deepFreeze(value) {
+  if (value === null || typeof value !== 'object') return value
+  Object.freeze(value)
+  if (Array.isArray(value)) {
+    for (const item of value) deepFreeze(item)
+  } else {
+    for (const v of Object.values(value)) deepFreeze(v)
+  }
+  return value
+}

--- a/scripts/formal-records.mjs
+++ b/scripts/formal-records.mjs
@@ -98,6 +98,17 @@ export function allRecords(store) {
 }
 
 export function appendRecord(store, input) {
+  const frozen = buildRecord(store, input)
+  return commitRecord(store, frozen)
+}
+
+function forkStore(store) {
+  const byId = new Map()
+  for (const [id, revs] of store.byId) byId.set(id, new Map(revs))
+  return { byId, order: store.order.slice(), control_log: store.control_log }
+}
+
+function buildRecord(store, input) {
   if (!input || typeof input !== 'object') throw new Error('appendRecord 需要记录对象')
   if (input.record_revision !== undefined) {
     throw new Error('禁止指定 record_revision：由 Store 追加分配')
@@ -135,10 +146,13 @@ export function appendRecord(store, input) {
   if (errors.length > 0) {
     throw new Error(`Formal Record 校验失败：${errors.join('；')}`)
   }
+  return deepFreeze(structuredClone(record))
+}
 
-  const frozen = deepFreeze(structuredClone(record))
+function commitRecord(store, frozen) {
+  const recordId = frozen.record_id
   if (!store.byId.has(recordId)) store.byId.set(recordId, new Map())
-  store.byId.get(recordId).set(nextRev, frozen)
+  store.byId.get(recordId).set(frozen.record_revision, frozen)
   store.order.push(toRef(frozen))
   return frozen
 }
@@ -193,7 +207,10 @@ export function appendGuidance(store, input) {
     throw new Error(`Guidance 所依赖的 Baseline 不存在: ${baseline.record_id}@${baseline.record_revision}`)
   }
   const changes = input.changes_baseline === true
-  const guidance = appendRecord(store, {
+  if (changes && (!input.new_baseline || !input.new_baseline.body)) {
+    throw new Error('changes_baseline 必须关联新的 Baseline Revision（提供 new_baseline.body）')
+  }
+  const guidanceBuilt = buildRecord(store, {
     record_id: requireText(input.record_id, 'record_id'),
     kind: KIND.INPUT_BASELINE,
     body: {
@@ -205,23 +222,25 @@ export function appendGuidance(store, input) {
     provenance: input.provenance,
   })
   if (!changes) {
+    const guidance = commitRecord(store, guidanceBuilt)
     return { guidance, baseline: getRecord(store, baseline.record_id, baseline.record_revision) }
   }
-  if (!input.new_baseline || !input.new_baseline.body) {
-    throw new Error('changes_baseline 必须关联新的 Baseline Revision（提供 new_baseline.body）')
-  }
   const nextId = input.new_baseline.record_id || baseline.record_id
-  const next = appendRecord(store, {
+  const tmp = forkStore(store)
+  commitRecord(tmp, guidanceBuilt)
+  const nextBuilt = buildRecord(tmp, {
     record_id: nextId,
     kind: KIND.INPUT_BASELINE,
-    body: normalizeBody(input.new_baseline.body),
-    dependencies: [baseline, toRef(guidance)],
+    body: input.new_baseline.body,
+    dependencies: [baseline, toRef(guidanceBuilt)],
     based_on: baseline,
     provenance: {
       ...input.provenance,
-      related_guidance: toRef(guidance),
+      related_guidance: toRef(guidanceBuilt),
     },
   })
+  const guidance = commitRecord(store, guidanceBuilt)
+  const next = commitRecord(store, nextBuilt)
   return { guidance, baseline: next }
 }
 

--- a/scripts/test/formal-records.test.mjs
+++ b/scripts/test/formal-records.test.mjs
@@ -1,0 +1,409 @@
+// #78 Formal Records 验收：不可覆盖 Revision、依赖覆盖、Fan-out、Decision/Guidance、Portable 映射
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  KIND, MEDIA, COVERING, NOT_COVERING_CURRENT, UNRELATED,
+  createStore, appendRecord, getRecord, listRevisions, currentRevision, allRecords, toRef,
+  recordsFromNodeResult, appendDecisionRecord, appendGuidance, applyRuntimeControl,
+  coverageStatus, coversRevision, dependsOnStaleInputs, staleProofsFor,
+  mapPortableHandoff, portableRecordId, validateFormalRecord, loadFormalRecordSchema,
+} from '../formal-records.mjs'
+
+const repo = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+function prov(extra = {}) {
+  return {
+    logical_run_id: 'run-1',
+    node: 'n1',
+    attempt: 1,
+    snapshot_revision: 'snap-1',
+    provider: 'test-provider',
+    model: 'test-model',
+    produced_by: 'test:dev',
+    node_business_outcome: { verdict: 'ok' },
+    ...extra,
+  }
+}
+
+function jsonBody(value) {
+  return { media_type: MEDIA.JSON, value }
+}
+
+function append(store, rec) {
+  return appendRecord(store, { provenance: prov(), body: jsonBody({}), kind: KIND.RESULT, ...rec })
+}
+
+test('A1 不可覆盖 Revision：同 id 新写入产生新 revision，旧版内容不变', () => {
+  const store = createStore()
+  const r1 = append(store, { record_id: 'impl', body: jsonBody({ sha: 'a' }) })
+  assert.equal(r1.record_revision, 1)
+  const r2 = append(store, { record_id: 'impl', body: jsonBody({ sha: 'b' }) })
+  assert.equal(r2.record_revision, 2)
+  const old = getRecord(store, 'impl', 1)
+  assert.deepEqual(old.body.value, { sha: 'a' })
+  assert.equal(getRecord(store, 'impl', 2).body.value.sha, 'b')
+  assert.equal(currentRevision(store, 'impl'), 2)
+  assert.equal(listRevisions(store, 'impl').length, 2)
+  assert.throws(() => { old.body.value.sha = 'mutated' }, TypeError)
+  assert.equal(getRecord(store, 'impl', 1).body.value.sha, 'a')
+  assert.throws(() => appendRecord(store, {
+    record_id: 'impl', record_revision: 3, kind: KIND.RESULT, body: jsonBody({}), provenance: prov(),
+  }), /禁止指定 record_revision/)
+})
+
+test('A2 Node Result 可产生一条或多条 Record，Outcome 不迁入信封', () => {
+  const store = createStore()
+  const outcome = { status: 'completed', notes: 'custom-schema-field' }
+  const one = recordsFromNodeResult(store, {
+    outcome,
+    provenance: prov({ node: 'writer' }),
+    productions: [{ record_id: 'doc', kind: KIND.RESULT, body: jsonBody({ md: 'hello' }) }],
+  })
+  assert.equal(one.produced_records.length, 1)
+  assert.equal(one.outcome.status, 'completed')
+  assert.equal(one.produced_records[0].body.value.md, 'hello')
+  assert.deepEqual(one.produced_records[0].provenance.node_business_outcome, outcome)
+  assert.equal('status' in one.produced_records[0], false)
+
+  const two = recordsFromNodeResult(store, {
+    outcome: { pass: true },
+    provenance: prov({ node: 'split' }),
+    productions: [
+      { record_id: 'art-a', kind: KIND.RESULT, body: jsonBody({ n: 1 }) },
+      { record_id: 'art-b', kind: KIND.RESULT, body: jsonBody({ n: 2 }) },
+    ],
+  })
+  assert.equal(two.produced_records.length, 2)
+  assert.equal(two.outcome.pass, true)
+  assert.deepEqual(two.produced_records[0].provenance.node_business_outcome, { pass: true })
+})
+
+test('A3 依赖指向 record_id + revision，禁止悬挂引用', () => {
+  const store = createStore()
+  const r = append(store, { record_id: 'req', kind: KIND.INPUT_BASELINE })
+  const d = append(store, {
+    record_id: 'design',
+    dependencies: [toRef(r)],
+    based_on: toRef(r),
+  })
+  assert.deepEqual(d.dependencies, [{ record_id: 'req', record_revision: 1 }])
+  assert.deepEqual(d.based_on, { record_id: 'req', record_revision: 1 })
+  assert.throws(() => append(store, {
+    record_id: 'ghost',
+    dependencies: [{ record_id: 'req', record_revision: 99 }],
+  }), /依赖不存在/)
+  assert.throws(() => append(store, {
+    record_id: 'bad-based',
+    dependencies: [toRef(r)],
+    based_on: { record_id: 'impl', record_revision: 1 },
+  }), /based_on 必须是 dependencies 中的一项/)
+})
+
+test('A4/A5 Proof 覆盖当前目标；上游新 Revision 后旧 Proof 保留且 stale', () => {
+  const store = createStore()
+  const req = append(store, { record_id: 'R', kind: KIND.INPUT_BASELINE })
+  const design = append(store, { record_id: 'D', dependencies: [toRef(req)], based_on: toRef(req) })
+  const impl = append(store, { record_id: 'I', dependencies: [toRef(design)], based_on: toRef(design) })
+  const review = append(store, {
+    record_id: 'RV', kind: KIND.PROOF_DECISION,
+    dependencies: [toRef(impl)], based_on: toRef(impl),
+    body: jsonBody({ verdict: 'approve' }),
+  })
+  const testP = append(store, {
+    record_id: 'T', kind: KIND.PROOF_DECISION,
+    dependencies: [toRef(impl)], based_on: toRef(impl),
+    body: jsonBody({ verdict: 'pass' }),
+  })
+  assert.equal(coverageStatus(store, review, 'I').status, COVERING)
+  assert.equal(coversRevision(store, testP, toRef(impl)), true)
+
+  const impl2 = append(store, { record_id: 'I', dependencies: [toRef(design)], based_on: toRef(design) })
+  assert.equal(impl2.record_revision, 2)
+  assert.equal(getRecord(store, 'RV', 1).body.value.verdict, 'approve')
+  assert.equal(coverageStatus(store, review, 'I').status, NOT_COVERING_CURRENT)
+  assert.equal(coverageStatus(store, review, 'I').stale, true)
+  assert.equal(coversRevision(store, review, toRef(impl)), true)
+  assert.equal(coversRevision(store, review, toRef(impl2)), false)
+  const stale = staleProofsFor(store, 'I').map(r => r.record_id).sort()
+  assert.deepEqual(stale, ['RV', 'T'])
+})
+
+test('A6 Fan-out 多依赖：只让依赖变化子集的下游 stale，兄弟不机械失效', () => {
+  const store = createStore()
+  const a1 = append(store, { record_id: 'expert-a' })
+  const b1 = append(store, { record_id: 'expert-b' })
+  const synth = append(store, {
+    record_id: 'synth',
+    dependencies: [toRef(a1), toRef(b1)],
+  })
+  const evalP = append(store, {
+    record_id: 'eval', kind: KIND.PROOF_DECISION,
+    dependencies: [toRef(a1), toRef(b1)],
+  })
+  assert.equal(dependsOnStaleInputs(store, synth), false)
+  assert.equal(coverageStatus(store, evalP, 'expert-a').status, COVERING)
+  assert.equal(coverageStatus(store, evalP, 'expert-b').status, COVERING)
+
+  append(store, { record_id: 'expert-a', body: jsonBody({ extra: true }) })
+  assert.equal(dependsOnStaleInputs(store, synth), true)
+  assert.equal(coverageStatus(store, evalP, 'expert-a').status, NOT_COVERING_CURRENT)
+  assert.equal(coverageStatus(store, evalP, 'expert-b').status, COVERING)
+  assert.equal(getRecord(store, 'expert-b', 1).record_revision, 1)
+  assert.equal(coverageStatus(store, evalP, 'expert-b').stale, false)
+  assert.deepEqual(staleProofsFor(store, 'expert-a').map(r => r.record_id), ['eval'])
+  assert.deepEqual(staleProofsFor(store, 'expert-b'), [])
+  // 传递闭包不得把未列入 dependencies 的记录算作覆盖
+  assert.equal(coverageStatus(store, evalP, 'synth').status, UNRELATED)
+})
+
+test('A7 Decision Record 不可覆盖；后续流转不得改写', () => {
+  const store = createStore()
+  const baseline = append(store, { record_id: 'bl', kind: KIND.INPUT_BASELINE })
+  const dec = appendDecisionRecord(store, {
+    record_id: 'decision-1',
+    question: '选哪条路径',
+    options: [{ name: 'A', tradeoffs: '快' }, { name: 'B', tradeoffs: '稳' }],
+    chosen: 'A',
+    rationale: '先交货',
+    decided_by: 'crystepj-max',
+    decided_at: '2026-09-01T05:00:00Z',
+    dependencies: [toRef(baseline)],
+    based_on: toRef(baseline),
+    provenance: prov({ node: 'human-decision' }),
+  })
+  assert.equal(dec.kind, KIND.PROOF_DECISION)
+  assert.equal(dec.body.value.decision.chosen, 'A')
+  const snapshot = structuredClone(dec)
+  applyRuntimeControl(store, { type: 'WAITING_HUMAN', reason: 'MAX_ROUNDS_REACHED' })
+  appendDecisionRecord(store, {
+    record_id: 'decision-1',
+    question: '选哪条路径',
+    options: [{ name: 'A', tradeoffs: '快' }, { name: 'B', tradeoffs: '稳' }],
+    chosen: 'B',
+    rationale: '改选',
+    decided_by: 'crystepj-max',
+    decided_at: '2026-09-01T06:00:00Z',
+    dependencies: [toRef(baseline)],
+    based_on: toRef(baseline),
+    provenance: prov({ node: 'human-decision', attempt: 2 }),
+  })
+  assert.deepEqual(getRecord(store, 'decision-1', 1).body.value.decision, snapshot.body.value.decision)
+  assert.equal(getRecord(store, 'decision-1', 2).body.value.decision.chosen, 'B')
+})
+
+test('A8 Guidance 与 Baseline：普通 Guidance 不改版本；改范围必须关联新 Baseline', () => {
+  const store = createStore()
+  const bl1 = append(store, { record_id: 'baseline', kind: KIND.INPUT_BASELINE, body: jsonBody({ goal: 'v1' }) })
+  const keep = appendGuidance(store, {
+    record_id: 'guide-note',
+    text: '先按原范围做',
+    changes_baseline: false,
+    baseline: toRef(bl1),
+    provenance: prov({ node: 'guidance' }),
+  })
+  assert.equal(keep.baseline.record_revision, 1)
+  assert.equal(currentRevision(store, 'baseline'), 1)
+  assert.deepEqual(keep.guidance.based_on, toRef(bl1))
+
+  assert.throws(() => appendGuidance(store, {
+    record_id: 'guide-bad',
+    text: '扩大范围',
+    changes_baseline: true,
+    baseline: toRef(bl1),
+    provenance: prov({ node: 'guidance' }),
+  }), /必须关联新的 Baseline Revision/)
+
+  const changed = appendGuidance(store, {
+    record_id: 'guide-scope',
+    text: '扩大范围',
+    changes_baseline: true,
+    baseline: toRef(bl1),
+    new_baseline: { body: jsonBody({ goal: 'v2' }) },
+    provenance: prov({ node: 'guidance' }),
+  })
+  assert.equal(changed.baseline.record_id, 'baseline')
+  assert.equal(changed.baseline.record_revision, 2)
+  assert.equal(changed.baseline.body.value.goal, 'v2')
+  assert.deepEqual(changed.baseline.provenance.related_guidance, toRef(changed.guidance))
+  assert.ok(changed.baseline.dependencies.some(d => d.record_id === 'guide-scope'))
+  assert.ok(changed.baseline.dependencies.some(d => d.record_id === 'baseline' && d.record_revision === 1))
+})
+
+test('A9 每条 Record 可追溯 snapshot / provider+model / node+attempt / Outcome', () => {
+  const store = createStore()
+  const rec = appendRecord(store, {
+    record_id: 'traced',
+    kind: KIND.RESULT,
+    body: jsonBody({ ok: true }),
+    provenance: prov({
+      logical_run_id: 'lr-9',
+      node: 'implement',
+      attempt: 3,
+      snapshot_revision: 'snap-xyz',
+      provider: 'openai',
+      model: 'gpt-test',
+      node_business_outcome: { outcome: 'handoff_ready' },
+    }),
+  })
+  const p = rec.provenance
+  assert.equal(p.snapshot_revision, 'snap-xyz')
+  assert.equal(p.provider, 'openai')
+  assert.equal(p.model, 'gpt-test')
+  assert.equal(p.node, 'implement')
+  assert.equal(p.attempt, 3)
+  assert.deepEqual(p.node_business_outcome, { outcome: 'handoff_ready' })
+  assert.equal(p.logical_run_id, 'lr-9')
+  assert.equal(validateFormalRecord(rec).length, 0)
+})
+
+test('A10 Runtime 控制状态不得回写 Outcome 或 Record', () => {
+  const store = createStore()
+  const rec = append(store, {
+    record_id: 'eval-out',
+    kind: KIND.PROOF_DECISION,
+    body: jsonBody({ outcome: 'NEEDS_RESEARCH' }),
+    provenance: prov({ node_business_outcome: 'NEEDS_RESEARCH' }),
+  })
+  const before = JSON.stringify(allRecords(store))
+  const outcomeBefore = rec.provenance.node_business_outcome
+  applyRuntimeControl(store, { type: 'WAITING_HUMAN', reason: 'MAX_ROUNDS_REACHED' })
+  applyRuntimeControl(store, { type: 'RUNNING' })
+  assert.equal(JSON.stringify(allRecords(store)), before)
+  assert.equal(getRecord(store, 'eval-out', 1).provenance.node_business_outcome, outcomeBefore)
+  assert.equal(getRecord(store, 'eval-out', 1).body.value.outcome, 'NEEDS_RESEARCH')
+  assert.equal(store.control_log.length, 2)
+  assert.equal(store.control_log[0].reason, 'MAX_ROUNDS_REACHED')
+})
+
+test('A11 覆盖判定只读结构化依赖，不解析 Markdown/自由文本', () => {
+  const store = createStore()
+  const impl1 = append(store, { record_id: 'code', body: jsonBody({ n: 1 }) })
+  append(store, { record_id: 'code', body: jsonBody({ n: 2 }) })
+  const proof = append(store, {
+    record_id: 'review',
+    kind: KIND.PROOF_DECISION,
+    dependencies: [toRef(impl1)],
+    based_on: toRef(impl1),
+    body: {
+      media_type: MEDIA.MARKDOWN,
+      value: '本审核覆盖 code@2（最新实现）。depends on record_id=code revision=2',
+    },
+  })
+  assert.equal(coverageStatus(store, proof, 'code').status, NOT_COVERING_CURRENT)
+  assert.equal(coversRevision(store, proof, { record_id: 'code', record_revision: 2 }), false)
+  assert.equal(coversRevision(store, proof, toRef(impl1)), true)
+})
+
+test('A12 Markdown / Text / JSON 载体可保存与读取', () => {
+  const store = createStore()
+  const md = appendRecord(store, {
+    record_id: 'md', kind: KIND.RESULT,
+    body: { media_type: MEDIA.MARKDOWN, value: '# 标题\n\n正文' },
+    provenance: prov(),
+  })
+  const txt = appendRecord(store, {
+    record_id: 'txt', kind: KIND.RESULT,
+    body: { media_type: MEDIA.TEXT, value: 'plain text' },
+    provenance: prov(),
+  })
+  const js = appendRecord(store, {
+    record_id: 'js', kind: KIND.RESULT,
+    body: { media_type: MEDIA.JSON, value: { a: 1, nested: { b: true } } },
+    provenance: prov(),
+  })
+  assert.equal(getRecord(store, 'md', 1).body.media_type, MEDIA.MARKDOWN)
+  assert.equal(getRecord(store, 'md', 1).body.value, '# 标题\n\n正文')
+  assert.equal(getRecord(store, 'txt', 1).body.value, 'plain text')
+  assert.deepEqual(getRecord(store, 'js', 1).body.value, { a: 1, nested: { b: true } })
+  for (const r of [md, txt, js]) assert.equal(validateFormalRecord(r).length, 0)
+})
+
+test('A13 Portable 七类可映射；刷新产生新 Revision；历史标识可追溯', () => {
+  const store = createStore()
+  const types = [
+    'requirements_baseline', 'design_package', 'dev_handoff',
+    'review_proof', 'test_proof', 'acceptance_package', 'closeout_summary',
+  ]
+  const payloads = {
+    requirements_baseline: { outcome: 'baseline_ready', status: 'draft', goal: 'g' },
+    design_package: { outcome: 'package_ready' },
+    dev_handoff: { outcome: 'handoff_ready' },
+    review_proof: { verdict: 'approve' },
+    test_proof: { verdict: 'pass' },
+    acceptance_package: { decision: 'accept', status: 'decided' },
+    closeout_summary: { outcome: 'delivered' },
+  }
+  const mapped = {}
+  for (const type of types) {
+    mapped[type] = mapPortableHandoff(store, {
+      record_type: type,
+      record_version: 'v0.1.8',
+      created_at: '2026-09-01T05:00:00Z',
+      produced_by: 'cwf:example',
+      run: {
+        run_id: 'cwf-78-map',
+        stage: type === 'acceptance_package' ? 'human_acceptance' : type.replace(/_.*/, ''),
+        attempt: 1,
+        current_head: 'abc',
+      },
+      payload: payloads[type],
+    })
+    assert.equal(mapped[type].record_id, portableRecordId('cwf-78-map', type))
+    assert.equal(mapped[type].record_revision, 1)
+    assert.equal(mapped[type].provenance.portable.record_type, type)
+    assert.equal(mapped[type].provenance.portable.run_id, 'cwf-78-map')
+    assert.equal(validateFormalRecord(mapped[type]).length, 0)
+    if (type !== 'requirements_baseline') {
+      assert.ok(mapped[type].dependencies.length >= 1, `${type} 应有前驱`)
+    }
+  }
+  assert.equal(mapped.review_proof.kind, KIND.PROOF_DECISION)
+  assert.ok(mapped.review_proof.dependencies.some(d => d.record_id === portableRecordId('cwf-78-map', 'dev_handoff')))
+  assert.equal(coverageStatus(store, mapped.review_proof, portableRecordId('cwf-78-map', 'dev_handoff')).status, COVERING)
+
+  const confirmed = mapPortableHandoff(store, {
+    record_type: 'requirements_baseline',
+    record_version: 'v0.1.8',
+    created_at: '2026-09-01T05:10:00Z',
+    produced_by: 'cwf:example',
+    run: { run_id: 'cwf-78-map', stage: 'requirements', attempt: 1, current_head: 'abc' },
+    payload: { outcome: 'baseline_ready', status: 'confirmed', goal: 'g' },
+  })
+  assert.equal(confirmed.record_revision, 2)
+  assert.equal(getRecord(store, portableRecordId('cwf-78-map', 'requirements_baseline'), 1).body.value.status, 'draft')
+  assert.equal(confirmed.body.value.status, 'confirmed')
+  assert.ok(confirmed.dependencies.some(d => d.record_id === confirmed.record_id && d.record_revision === 1))
+  assert.equal(
+    coverageStatus(store, mapped.design_package, portableRecordId('cwf-78-map', 'requirements_baseline')).status,
+    NOT_COVERING_CURRENT,
+  )
+})
+
+test('schema 可加载；夹具拒绝未知 kind 与额外信封字段', () => {
+  const schema = loadFormalRecordSchema()
+  assert.equal(schema.title.includes('Formal Record'), true)
+  const store = createStore()
+  const rec = appendRecord(store, {
+    record_id: 'ok', kind: KIND.RESULT, body: jsonBody({}), provenance: prov(),
+  })
+  const extra = { ...JSON.parse(JSON.stringify(rec)), extra_field: true }
+  assert.ok(validateFormalRecord(extra).some(e => e.includes('额外属性')))
+  assert.throws(() => appendRecord(store, {
+    record_id: 'bad-kind', kind: 'review', body: jsonBody({}), provenance: prov(),
+  }), /非法 kind/)
+})
+
+test('仓库内 Portable 示例外壳可映射（不要求本测试解析 payload 文本）', () => {
+  const example = JSON.parse(readFileSync(
+    join(repo, 'docs/design/construction-workflow/examples/01-requirements-baseline.json'),
+    'utf-8',
+  ))
+  const store = createStore()
+  const rec = mapPortableHandoff(store, example)
+  assert.equal(rec.kind, KIND.INPUT_BASELINE)
+  assert.equal(rec.provenance.portable.record_type, 'requirements_baseline')
+  assert.equal(rec.body.value.status, 'confirmed')
+})

--- a/scripts/test/formal-records.test.mjs
+++ b/scripts/test/formal-records.test.mjs
@@ -208,6 +208,7 @@ test('A8 Guidance 与 Baseline：普通 Guidance 不改版本；改范围必须�
   assert.equal(currentRevision(store, 'baseline'), 1)
   assert.deepEqual(keep.guidance.based_on, toRef(bl1))
 
+  const beforeFail = allRecords(store).length
   assert.throws(() => appendGuidance(store, {
     record_id: 'guide-bad',
     text: '扩大范围',
@@ -215,6 +216,19 @@ test('A8 Guidance 与 Baseline：普通 Guidance 不改版本；改范围必须�
     baseline: toRef(bl1),
     provenance: prov({ node: 'guidance' }),
   }), /必须关联新的 Baseline Revision/)
+  assert.equal(allRecords(store).length, beforeFail)
+  assert.equal(getRecord(store, 'guide-bad'), undefined)
+
+  assert.throws(() => appendGuidance(store, {
+    record_id: 'guide-bad-body',
+    text: '扩大范围',
+    changes_baseline: true,
+    baseline: toRef(bl1),
+    new_baseline: { body: { media_type: 'nope', value: { goal: 'x' } } },
+    provenance: prov({ node: 'guidance' }),
+  }), /非法 media_type/)
+  assert.equal(allRecords(store).length, beforeFail)
+  assert.equal(getRecord(store, 'guide-bad-body'), undefined)
 
   const changed = appendGuidance(store, {
     record_id: 'guide-scope',


### PR DESCRIPTION
## Summary
- 落地跨四套工作流通用的 Formal Record / Revision / Provenance 内核（不可覆盖 Revision、结构化依赖、Proof 覆盖判定、Decision/Guidance、Portable 七类可重放映射）。
- 纯逻辑模块 + Node 测试；不接线 DSH Runtime、不改模板 / generate / host、不删除 construction-bootstrap shim。
- 建设工作流 Run `cwf-78-01` 已人工验收 **accept**（确认人 crystepj-max）。

## Test plan
- [ ] `node --test scripts/test/formal-records.test.mjs`（14 pass）
- [ ] 同 `record_id` 两次写入产生 revision 1/2，旧版可读且 frozen
- [ ] `I@2` 后依赖 `I@1` 的 Proof 为 `not_covering_current`，记录仍在
- [ ] Fan-out：只 stale 真实依赖的下游
- [ ] `appendGuidance({ changes_baseline: true })` 缺 `new_baseline` 时 Store 不变
- [ ] Portable 七类映射后 `provenance.portable` 可追溯；draft→confirmed 为新 Revision

Closes #78


Made with [Cursor](https://cursor.com)