### PR TITLE
fix(workflow): 去掉不批准固定回开发的手册硬编码 (#117)

### DIFF
--- a/dsh/README.md
+++ b/dsh/README.md
@@ -84,12 +84,13 @@ gh issue view <N> --json title,body,comments
 {
   "taskId": "issue-12",                 // 必填，任务标识
   "runDir": ".agent-runs/issue-12",     // 必填，run 产物目录（相对目标仓库根）
-  "entry": "dispatch",                  // 首次 = 蓝图入口；续跑 = 门禁节点 id（accept）或打回起点（dev）
+  "entry": "dispatch",                  // 首次 = 蓝图入口；残留门禁续跑 = 被暂停的门禁节点 id（如 accept）
   "issueRef": "#12", "issueTitle": "...", "issueBody": "...", "issueComments": "...",
   // 或 "requirement": "...(直接需求文本)",
   "roleDir": "dsh/roles",               // 可选，角色提示词目录（相对工作区根）
   // —— 续跑专用（AWAITING_HUMAN_<节点id> 后回传返回值）——
-  "approved": true, "startRound": 3, "feedback": "人工验收不通过意见 / 打回原因",
+  // 仅人工「通过」时 approved=true；不通过不要设 true，仍以同一门禁节点续跑
+  "approved": true, "startRound": 3, "feedback": "",
   "history": [ { "round": 1, "stage": "review", "verdict": "REQUEST_CHANGES", "reason": "..." } ]
 }
 ```

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -26,8 +26,8 @@ workflow 编排脚本（.generated/dev-workflow-2-0/script.mjs——单一编译
    │
    ▼
 主会话呈 acceptance-summary.md → ask_user_question 人工裁决（AI 不代签）
-   ├─ 通过 → workflow(entry=closeout) → 收口 agent（一致性收口 + 推送/合并 PR + 关闭 issue）→ DONE
-   └─ 不通过 → workflow(entry=dev, feedback=人工意见, startRound+1) → 继续开发循环
+   ├─ 通过 → 以门禁节点为 entry + approved=true 续跑（只走 success；下游是否收口由蓝图决定）
+   └─ 不通过 → 仍以同一门禁节点续跑并带意见；引擎对非 true（含 false）再挂起，不走 failure
 ```
 
 - **人机职责边界**：人工只做两个决策——确认需求（issue 三要素）与验收裁决；
@@ -101,7 +101,7 @@ gh issue view <N> --json title,body,comments
 
 | 返回 status | 含义 | 主会话动作 |
 |---|---|---|
-| `AWAITING_HUMAN_<节点id>`（如 `AWAITING_HUMAN_accept`） | 门禁节点产出后挂起 | 呈报告 + 人工确认卡：通过 → `entry=<节点id>` + `approved=true` 续跑；不通过 → `entry=dev` + `feedback` + `startRound+1` 续跑（返回体含 `resume` 载荷） |
+| `AWAITING_HUMAN_<节点id>`（如 `AWAITING_HUMAN_accept`） | 门禁节点产出后挂起 | 呈报告 + 人工确认卡：通过 → 以该门禁节点为 entry 且 `approved=true` 续跑（只走 success）；非 true（含 false）→ 仍以同一门禁节点续跑，引擎再挂起，不走 failure（返回体含 `resume` 载荷）。不要手写跳到开发或收口节点。 |
 | `FAILED_AT_<节点id>`（如 `FAILED_AT_dispatch`） | 节点未通过且走 failure 边至终点（含三要素缺失、dev 受阻） | 呈节点结果（dispatch 场景含 `missing`/`reason` 三要素判定；dev 受阻 = `status: "blocked"`），人工补齐后重跑对应 `entry` |
 | `FAILED_MAX_ROUNDS` | 超限（auto-reschedule 时含归因 `reschedule`） | 呈 reschedule（归因/拆分建议/人工介入建议）→ 人工决策拆分 |
 | `ENDED_NO_SUCCESS_EDGE` / `ENDED_NO_FAILURE_EDGE` | 图缺陷（走通性违约的运行时兜底） | 检查蓝图（创作期由校验器「successCondition 必须有 failure 边」规则拦截） |
@@ -334,7 +334,7 @@ P0 试跑（issue #1，2026-08-16）发现的问题：
 | `issueRef` | 可选 | issue 引用（如 `#7`）；无 issue 时用 `requirement` |
 | `issueTitle` / `issueBody` / `issueComments` | 可选 | issue 标题 / 正文 / 评论 |
 | `requirement` | 可选 | 原始需求文本（无 issue 时） |
-| `entry` | 可选 | 起点/续跑点，缺省 `dispatch`；续跑时指向被暂停的门禁节点（如 `accept`）或打回起点 `dev` |
+| `entry` | 可选 | 起点/续跑点，缺省 `dispatch`；残留门禁续跑时指向被暂停的门禁节点本身（如 `accept`），不要手写跳到开发或收口节点 |
 | `approved` | 续跑 | 人工裁决结果：`true` 表「通过」，放行门禁节点走 success 出边 |
 | `feedback` | 续跑 | 打回/续跑意见（验收不通过或审核打回时回传） |
 | `startRound` | 续跑 | 续跑起始轮次，回传上次返回值以保持 9 轮计数连续 |
@@ -350,9 +350,9 @@ P0 试跑（issue #1，2026-08-16）发现的问题：
 `history` / `feedback`），主会话据此呈 `acceptance-summary.md` + 发人工确认卡（AI 不代签）：
 
 - **通过**：以 `entry=<节点id>` + `approved=true` 续跑（并回传 `startRound` / `history` /
-  `feedback`），门禁节点走 success 出边进入收口，最终 `DONE`；
-- **不通过**：以 `entry=dev` + `feedback=人工意见` + `startRound=上次+1` + `history` 续跑，
-  回到开发循环继续（9 轮上限计数连续）。
+  `feedback`）；引擎只走该节点 success 出边，下游是否收口由蓝图决定，手册不得指定下一跳；
+- **不通过**：仍以同一门禁节点续跑并带上意见；引擎对非 true（含 false）会再挂起，**不走
+  failure 边**。不要手写跳到开发或收口节点。
 
 ```jsonc
 // 首次运行：选内置模板，entry=dispatch 起（issue 字段为透传输入，与 workflow 工具同源）
@@ -364,7 +364,7 @@ P0 试跑（issue #1，2026-08-16）发现的问题：
 { "templateId": "dev-workflow-2-0", "taskId": "req-1",
   "requirement": "把登录流程改为无密码邮箱验证码" }
 
-// 收到 AWAITING_HUMAN_accept 后，人工裁决「通过」→ 放行进入收口
+// 收到 AWAITING_HUMAN_accept 后，人工裁决「通过」→ 以门禁节点续跑（approved=true，只走 success）
 { "templateId": "dev-workflow-2-0", "taskId": "issue-7",
   "entry": "accept", "approved": true,
   "startRound": 1, "history": [], "feedback": "" }

--- a/scripts/test/generate.test.mjs
+++ b/scripts/test/generate.test.mjs
@@ -162,6 +162,8 @@ test('#117 主会话 README 不再写死不通过去开发或不经门禁去收�
   const readme = readFileSync(path.join(here, '../../dsh/README.md'), 'utf8');
   assert.equal(readme.includes('entry=closeout'), false, 'README 不得写死通过 → entry=closeout');
   assert.equal(readme.includes('entry=dev'), false, 'README 不得写死不通过 → entry=dev');
+  assert.equal(/打回起点\s*[（(]dev[）)]/.test(readme), false, '不得用自然语言写打回起点（dev）');
+  assert.equal(/approved:\s*true[\s\S]{0,80}不通过/.test(readme), false, '不得把 approved:true 与不通过意见写进同一续跑示例');
 });
 
 // ── 候选四 T-IMP-14 · 原子写盘（失败零残留） ──

--- a/scripts/test/generate.test.mjs
+++ b/scripts/test/generate.test.mjs
@@ -160,10 +160,17 @@ test('#117 手写主会话手册同样不再写死这两跳', () => {
 
 test('#117 主会话 README 不再写死不通过去开发或不经门禁去收口', () => {
   const readme = readFileSync(path.join(here, '../../dsh/README.md'), 'utf8');
+  // 允许 JSONC `"approved":` 与裸 `approved:`；80 字符窗口覆盖同一续跑示例行
+  const staleApprovedWithReject = /approved"?\s*:\s*true[\s\S]{0,80}不通过/;
+  assert.equal(
+    staleApprovedWithReject.test('"approved": true, "startRound": 3, "feedback": "人工验收不通过意见"'),
+    true,
+    '断言须能抓到带引号的 JSONC 键名',
+  );
   assert.equal(readme.includes('entry=closeout'), false, 'README 不得写死通过 → entry=closeout');
   assert.equal(readme.includes('entry=dev'), false, 'README 不得写死不通过 → entry=dev');
   assert.equal(/打回起点\s*[（(]dev[）)]/.test(readme), false, '不得用自然语言写打回起点（dev）');
-  assert.equal(/approved:\s*true[\s\S]{0,80}不通过/.test(readme), false, '不得把 approved:true 与不通过意见写进同一续跑示例');
+  assert.equal(staleApprovedWithReject.test(readme), false, '不得把 approved:true 与不通过意见写进同一续跑示例');
 });
 
 // ── 候选四 T-IMP-14 · 原子写盘（失败零残留） ──

--- a/scripts/test/generate.test.mjs
+++ b/scripts/test/generate.test.mjs
@@ -158,6 +158,12 @@ test('#117 手写主会话手册同样不再写死这两跳', () => {
   assert.equal(handbook.includes('entry=dev'), false, '手册不得写死不通过 → entry=dev');
 });
 
+test('#117 主会话 README 不再写死不通过去开发或不经门禁去收口', () => {
+  const readme = readFileSync(path.join(here, '../../dsh/README.md'), 'utf8');
+  assert.equal(readme.includes('entry=closeout'), false, 'README 不得写死通过 → entry=closeout');
+  assert.equal(readme.includes('entry=dev'), false, 'README 不得写死不通过 → entry=dev');
+});
+
 // ── 候选四 T-IMP-14 · 原子写盘（失败零残留） ──
 const makeTmp = () => mkdtempSync(path.join(tmpdir(), 'vwf-skill-'))
 const rmTmp = (dir) => { try { execFileSync('/bin/rm', ['-rf', dir]) } catch (e) {} }


### PR DESCRIPTION
## Summary
- 对齐主会话 `dsh/README.md` 与残留 `manualCheck` 1A：通过只走 success，非 true（含 false）再挂起、不走 failure；不再写死 `entry=dev` / `entry=closeout`。
- 增加 README 回归测试，钉死这两跳不得回潮。`skillWrap`、手写 `dsh/skill/SKILL.md`、契约 §6.2 与引擎 1A 已在 main，本 PR 不重做。
- 建设工作流 Run `cwf-117-01` 人工验收 **accept**（chris，2026-09-02）。

## Test plan
- [ ] `node --test --test-name-pattern '#117|F5 人工门禁' scripts/test/generate.test.mjs scripts/test/runtime.test.mjs` 全绿
- [ ] `rg 'entry=dev|entry=closeout' scripts/generate.mjs dsh/skill/SKILL.md dsh/README.md` 无匹配
- [ ] `docs/design/blueprint-schema.md` §6.2 人工确认行仍写明非 true 再挂起、不走 failure
- [ ] 本 PR 不影响蓝图 / `.generated/`（未改 `templates/`）

Closes #117

Made with [Cursor](https://cursor.com)