### PR TITLE
fix(dev): 复用未登记的开发 DSH，并隔离启动器测试

### DIFF
--- a/scripts/dev-plugin.mjs
+++ b/scripts/dev-plugin.mjs
@@ -10,7 +10,7 @@ import {
 } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
@@ -20,6 +20,8 @@ const defaultProductHome = join(homedir(), '.dsh')
 const devHome = resolve(process.env.VWF_DEV_DSH_HOME || defaultDevHome)
 const configuredHome = process.env.DSH_HOME ? resolve(process.env.DSH_HOME) : null
 const productHome = resolve(process.env.VWF_PRODUCT_DSH_HOME || defaultProductHome)
+const dshBin = process.env.VWF_DEV_DSH_BIN || 'dsh'
+const lsofBin = process.env.VWF_DEV_LSOF_BIN || (existsSync('/usr/sbin/lsof') ? '/usr/sbin/lsof' : 'lsof')
 const webProfile = join(devHome, 'profiles', 'web')
 const profilePackage = join(webProfile, 'package.json')
 const pidFile = join(devHome, '.vwf-dev-dsh.pid')
@@ -77,9 +79,78 @@ function isRunning(pid) {
   try {
     process.kill(pid, 0)
     return true
-  } catch {
-    return false
+  } catch (error) {
+    return error.code === 'EPERM'
   }
+}
+
+function inspect(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    maxBuffer: 8 * 1024 * 1024,
+  })
+  if (result.error || result.status !== 0) return null
+  return result.stdout
+}
+
+function processNames(pid) {
+  const output = inspect(lsofBin, ['-nP', '-p', String(pid), '-Fn'])
+  if (output === null) return null
+  return output
+    .split('\n')
+    .filter((line) => line.startsWith('n'))
+    .map((line) => line.slice(1))
+}
+
+function listeningProcesses() {
+  const output = inspect(lsofBin, ['-nP', '-iTCP', '-sTCP:LISTEN', '-Fpcn'])
+  if (output === null) return null
+  const processes = []
+  let current = null
+  for (const line of output.split('\n')) {
+    if (line.startsWith('p')) {
+      current = { pid: Number(line.slice(1)), command: '', names: [] }
+      processes.push(current)
+    } else if (current && line.startsWith('c')) {
+      current.command = line.slice(1)
+    } else if (current && line.startsWith('n')) {
+      current.names.push(line.slice(1))
+    }
+  }
+  return processes
+}
+
+function loopbackUrls(names) {
+  return names.flatMap((name) => {
+    const match = name.match(/^(?:127\.0\.0\.1|localhost|\[::1\]):(\d+)$/)
+    return match ? [`http://127.0.0.1:${match[1]}/`] : []
+  })
+}
+
+function discoverDevDsh() {
+  const candidates = listeningProcesses()
+  if (candidates === null) return { available: false, matches: [] }
+  const home = comparisonPath(devHome)
+  const profileMarkers = [
+    join(home, 'profiles', 'web', 'cordis.yml'),
+    join(home, 'profiles', 'web', 'package.json'),
+  ]
+  const matches = []
+  for (const candidate of candidates) {
+    if (candidate.command !== 'node' || !isRunning(candidate.pid)) continue
+    const names = processNames(candidate.pid)
+    if (names === null) {
+      return { available: false, matches: [] }
+    }
+    const belongsToHome = profileMarkers.every((marker) =>
+      names.some((name) => name === marker || name.startsWith(`${marker} `)),
+    )
+    const urls = loopbackUrls(candidate.names)
+    if (belongsToHome && urls.length > 0) {
+      matches.push({ pid: candidate.pid, urls })
+    }
+  }
+  return { available: true, matches }
 }
 
 function sourceVersion() {
@@ -96,15 +167,33 @@ function sourceVersion() {
 
 const profile = readJson(profilePackage)
 const formalBundleInstalled = hasFormalBundle(profile)
-const pid = readPid()
-const running = isRunning(pid)
+const recordedPid = readPid()
+const discovery = discoverDevDsh()
+if (recordedPid && isRunning(recordedPid) && !discovery.available) {
+  fail(`无法核验 PID ${recordedPid} 是否属于开发 DSH；已停止，避免复用错误进程。`)
+}
+if (discovery.matches.length > 1) {
+  fail(
+    `检测到多个使用开发 Home 的 DSH：${discovery.matches
+      .map((item) => `${item.pid} (${item.urls.join(', ')})`)
+      .join('、')}。请先人工确认，不会继续启动。`,
+  )
+}
+const active = discovery.matches[0] || null
+const pid = active?.pid || null
+const running = Boolean(active)
+const discovered = running && recordedPid !== pid
 const version = sourceVersion()
 
 console.log('VWF 开发模式（动态插件，不是发布证据）')
 console.log(`- 开发 DSH Home：${devHome}`)
 console.log(`- web Profile：${profile ? '已初始化' : '未初始化（首次 start 时由 DSH 默认模板创建）'}`)
 console.log(`- 正式 VWF 组合包：${formalBundleInstalled ? '已安装（冲突）' : '未安装'}`)
-console.log(`- 开发 DSH：${running ? `运行中（PID ${pid}）` : '未运行'}`)
+console.log(
+  `- 开发 DSH：${
+    running ? `运行中（PID ${pid}，${active.urls.join(', ')}）` : '未运行'
+  }`,
+)
 console.log(`- 当前联合版本：${version}（host + client）`)
 
 if (formalBundleInstalled) {
@@ -141,13 +230,19 @@ if (command === 'status') {
 }
 
 if (running) {
-  console.log('✅ 开发 DSH 已在运行，无需重复启动。')
+  if (discovered) {
+    mkdirSync(devHome, { recursive: true })
+    writeFileSync(pidFile, `${pid}\n`)
+    console.log('✅ 已发现并登记现有开发 DSH，无需重复启动。')
+  } else {
+    console.log('✅ 开发 DSH 已在运行，无需重复启动。')
+  }
   printSyncGuide()
   process.exit(0)
 }
 
 mkdirSync(devHome, { recursive: true })
-const child = spawn('dsh', ['web', '--port', '0'], {
+const child = spawn(dshBin, ['web', '--port', '0'], {
   cwd: repoRoot,
   env: { ...process.env, DSH_HOME: devHome },
   stdio: 'inherit',
@@ -156,7 +251,16 @@ const child = spawn('dsh', ['web', '--port', '0'], {
 if (!Number.isSafeInteger(child.pid)) {
   fail('开发 DSH 进程未能创建。')
 }
-writeFileSync(pidFile, `${child.pid}\n`)
+try {
+  writeFileSync(pidFile, `${child.pid}\n`)
+} catch (error) {
+  try {
+    process.kill(-child.pid, 'SIGTERM')
+  } catch {
+    child.kill('SIGTERM')
+  }
+  fail(`无法记录开发 DSH PID：${error.message}；已终止本次启动。`)
+}
 console.log(`已使用隔离 Home 启动开发 DSH（DSH PID ${child.pid}）。`)
 
 let shuttingDown = false

--- a/scripts/test/dev-plugin.test.mjs
+++ b/scripts/test/dev-plugin.test.mjs
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -16,6 +17,169 @@ import { spawn, spawnSync } from 'node:child_process'
 import test from 'node:test'
 
 const scriptPath = fileURLToPath(new URL('../dev-plugin.mjs', import.meta.url))
+
+test('开发启动可显式使用 DSH 测试替身，不依赖 PATH', () => {
+  const root = mkdtempSync(join(tmpdir(), 'vwf-dev-plugin-command-'))
+  try {
+    const bin = join(root, 'bin')
+    const markerPath = join(root, 'spawned')
+    const devHome = join(root, 'dev-home')
+    const productHome = join(root, 'product-home')
+    const dshPath = join(root, 'fake-dsh')
+    mkdirSync(bin)
+    writeFileSync(dshPath, `#!/bin/sh
+: > '${markerPath}'
+exit 0
+`)
+    chmodSync(dshPath, 0o755)
+
+    const result = spawnSync(process.execPath, [scriptPath, 'start'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: bin,
+        VWF_DEV_DSH_BIN: dshPath,
+        VWF_DEV_DSH_HOME: devHome,
+        VWF_PRODUCT_DSH_HOME: productHome,
+        DSH_HOME: undefined,
+      },
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(existsSync(markerPath), true)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('PID 文件缺失时发现并接管同一开发 Home 的现有 DSH', () => {
+  const root = mkdtempSync(join(tmpdir(), 'vwf-dev-plugin-discovery-'))
+  try {
+    const bin = join(root, 'bin')
+    const markerPath = join(root, 'spawned')
+    const devHome = join(root, 'dev-home')
+    const productHome = join(root, 'product-home')
+    const dshPath = join(root, 'fake-dsh')
+    const lsofPath = join(root, 'fake-lsof')
+    mkdirSync(bin)
+    writeFileSync(dshPath, `#!/bin/sh
+: > '${markerPath}'
+exit 0
+`)
+    writeFileSync(lsofPath, `#!/bin/sh
+case "$*" in
+  *-iTCP*) printf 'p${process.pid}\\ncnode\\nf19\\nn127.0.0.1:53202\\n' ;;
+  *) printf 'p${process.pid}\\ncnode\\nf20\\nn${devHome}/settings.yaml\\nf21\\nn${devHome}/profiles/web/cordis.yml\\nf22\\nn${devHome}/profiles/web/package.json\\n' ;;
+esac
+`)
+    chmodSync(dshPath, 0o755)
+    chmodSync(lsofPath, 0o755)
+
+    const result = spawnSync(process.execPath, [scriptPath, 'start'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: bin,
+        VWF_DEV_DSH_BIN: dshPath,
+        VWF_DEV_LSOF_BIN: lsofPath,
+        VWF_DEV_DSH_HOME: devHome,
+        VWF_PRODUCT_DSH_HOME: productHome,
+        DSH_HOME: undefined,
+      },
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /已发现.*无需重复启动/)
+    assert.equal(existsSync(markerPath), false)
+    assert.equal(
+      Number(readFileSync(join(devHome, '.vwf-dev-dsh.pid'), 'utf8').trim()),
+      process.pid,
+    )
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('发现多个同一开发 Home 的 DSH 时停止启动', () => {
+  const root = mkdtempSync(join(tmpdir(), 'vwf-dev-plugin-multiple-'))
+  try {
+    const markerPath = join(root, 'spawned')
+    const devHome = join(root, 'dev-home')
+    const productHome = join(root, 'product-home')
+    const dshPath = join(root, 'fake-dsh')
+    const lsofPath = join(root, 'fake-lsof')
+    writeFileSync(dshPath, `#!/bin/sh
+: > '${markerPath}'
+exit 0
+`)
+    writeFileSync(lsofPath, `#!/bin/sh
+case "$*" in
+  *-iTCP*) printf 'p${process.pid}\\ncnode\\nf19\\nn127.0.0.1:53202\\np${process.ppid}\\ncnode\\nf19\\nn127.0.0.1:57160\\n' ;;
+  *) printf 'n${devHome}/profiles/web/cordis.yml\\nn${devHome}/profiles/web/package.json\\n' ;;
+esac
+`)
+    chmodSync(dshPath, 0o755)
+    chmodSync(lsofPath, 0o755)
+
+    const result = spawnSync(process.execPath, [scriptPath, 'start'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        VWF_DEV_DSH_BIN: dshPath,
+        VWF_DEV_LSOF_BIN: lsofPath,
+        VWF_DEV_DSH_HOME: devHome,
+        VWF_PRODUCT_DSH_HOME: productHome,
+        DSH_HOME: undefined,
+      },
+    })
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /检测到多个使用开发 Home 的 DSH/)
+    assert.equal(existsSync(markerPath), false)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('PID 文件指向非开发 DSH 进程时不复用', () => {
+  const root = mkdtempSync(join(tmpdir(), 'vwf-dev-plugin-stale-pid-'))
+  try {
+    const markerPath = join(root, 'spawned')
+    const devHome = join(root, 'dev-home')
+    const productHome = join(root, 'product-home')
+    const dshPath = join(root, 'fake-dsh')
+    const lsofPath = join(root, 'fake-lsof')
+    mkdirSync(devHome)
+    writeFileSync(join(devHome, '.vwf-dev-dsh.pid'), `${process.pid}\n`)
+    writeFileSync(dshPath, `#!/bin/sh
+: > '${markerPath}'
+exit 0
+`)
+    writeFileSync(lsofPath, `#!/bin/sh
+exit 0
+`)
+    chmodSync(dshPath, 0o755)
+    chmodSync(lsofPath, 0o755)
+
+    const result = spawnSync(process.execPath, [scriptPath, 'start'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        VWF_DEV_DSH_BIN: dshPath,
+        VWF_DEV_LSOF_BIN: lsofPath,
+        VWF_DEV_DSH_HOME: devHome,
+        VWF_PRODUCT_DSH_HOME: productHome,
+        DSH_HOME: undefined,
+      },
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /已使用隔离 Home 启动开发 DSH/)
+    assert.equal(existsSync(markerPath), true)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
 
 test('开发 Home 为产品 Home 的符号链接时拒绝启动', () => {
   const root = mkdtempSync(join(tmpdir(), 'vwf-dev-plugin-symlink-'))
@@ -38,7 +202,7 @@ exit 0
       encoding: 'utf8',
       env: {
         ...process.env,
-        PATH: `${bin}:${process.env.PATH ?? ''}`,
+        VWF_DEV_DSH_BIN: dshPath,
         VWF_DEV_DSH_HOME: devHome,
         VWF_PRODUCT_DSH_HOME: productHome,
       },
@@ -71,7 +235,7 @@ exit 0
       encoding: 'utf8',
       env: {
         ...process.env,
-        PATH: `${bin}:${process.env.PATH ?? ''}`,
+        VWF_DEV_DSH_BIN: dshPath,
         VWF_DEV_DSH_HOME: devHome,
         VWF_PRODUCT_DSH_HOME: productHome,
         DSH_HOME: undefined,
@@ -99,9 +263,13 @@ test('PID 文件记录分离的 DSH 子进程，启动器结束后仍能识别�
     const devHome = join(root, 'dev-home')
     const productHome = join(root, 'product-home')
     const dshPath = join(bin, 'dsh')
+    const lsofPath = join(root, 'fake-lsof')
+    mkdirSync(devHome)
+    const canonicalDevHome = realpathSync(devHome)
     const env = {
       ...process.env,
-      PATH: `${bin}:${process.env.PATH ?? ''}`,
+      VWF_DEV_DSH_BIN: dshPath,
+      VWF_DEV_LSOF_BIN: lsofPath,
       VWF_DEV_DSH_HOME: devHome,
       VWF_PRODUCT_DSH_HOME: productHome,
       DSH_HOME: undefined,
@@ -109,9 +277,19 @@ test('PID 文件记录分离的 DSH 子进程，启动器结束后仍能识别�
     mkdirSync(bin)
     writeFileSync(dshPath, `#!/bin/sh
 echo $$ > '${fakePidPath}'
-sleep 30
+/bin/sleep 30
+`)
+    writeFileSync(lsofPath, `#!/bin/sh
+if [ -f '${fakePidPath}' ]; then
+  pid=$(/bin/cat '${fakePidPath}')
+  case "$*" in
+    *-iTCP*) printf 'p%s\\ncnode\\nf19\\nn127.0.0.1:54321\\n' "$pid" ;;
+    *) printf 'p%s\\ncnode\\nf20\\nn${canonicalDevHome}/profiles/web/cordis.yml\\nf21\\nn${canonicalDevHome}/profiles/web/package.json\\n' "$pid" ;;
+  esac
+fi
 `)
     chmodSync(dshPath, 0o755)
+    chmodSync(lsofPath, 0o755)
 
     const launcher = spawn(process.execPath, [scriptPath, 'start'], {
       cwd: root,


### PR DESCRIPTION
## 变更说明

Closes #151

启动器现在会在启动前发现使用同一开发 Home 的既有 DSH：无 PID 记录时登记并复用；发现多个候选时安全停止，避免猜测并产生新端口。测试改为显式注入 DSH 测试替身，避免 Cursor 环境中的 PATH 隔离失效而拉起真实 DSH。

## 验证

- `node --test scripts/test/dev-plugin.test.mjs`：7 项通过
- `npm test`：268 项通过
- `npm run generate`：通过
- `npm run validate`：通过
- 完整测试前后监听实例无新增
- 未修改产品 DSH 配置，未执行停止命令

## 验收边界

当前机器上的真实开发 DSH 在最终复查时已不运行；真实“无 PID 记录时复用单个开发 DSH”的行为已由隔离测试覆盖，需在可写的开发环境中进行一次人工现场确认。