### PR TITLE
fix(visual-workflow): vwf.models 懒取 llm 修复模型面板返回空

### DIFF
--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -50,7 +50,6 @@ return {
   apply(ctx) {
     const engine = ctx.get('workflowEngine')
     const agents = ctx.get('agents')
-    const llm = ctx.get('llm')
     let fs = ctx.get('fs')
     const sp = ctx.get('sandboxPolicy')
     let subprocess = ctx.get('subprocess')
@@ -1269,10 +1268,13 @@ return {
       return { runs: out }
     })
     registerRpc('vwf.models', async () => {
-      if (llm === undefined) return { providers: [] }
+      // llm 每次现取而非 apply 时捕获：llm 服务就绪可能晚于插件 apply，
+      // 启动时一次性捕获会永久拿到 undefined 导致面板「未配置可用模型」
+      const llm = ctx.get('llm')
+      if (llm === undefined) { console.log('[vwf] vwf.models：llm 服务不可用（未就绪或未注入），返回空 provider 列表'); return { providers: [] } }
       const out = []
       let providers = []
-      try { providers = await Promise.resolve(llm.listProviders()) } catch (e) { return { providers: [] } }
+      try { providers = await Promise.resolve(llm.listProviders()) } catch (e) { console.log('[vwf] vwf.models：listProviders 失败：' + String((e && e.message) || e)); return { providers: [] } }
       for (const p of providers || []) {
         const id = String(p && (p.id || p.provider || p.name) || '')
         if (!id) continue
@@ -1280,7 +1282,7 @@ return {
         try {
           const ms = await llm.listModels(id)
           models = (ms || []).map(m => String(m && (m.id || m.model || m.name) || '')).filter(Boolean)
-        } catch (e) {}
+        } catch (e) { console.log('[vwf] vwf.models：listModels(' + id + ') 失败：' + String((e && e.message) || e)) }
         out.push({ id: id, models: models })
       }
       return { providers: out }


### PR DESCRIPTION
## 用户/流程影响
修复 VWF（可视化工作流）模型选择面板在插件加载早期误显示「未配置可用模型」的问题。打开面板现在能正常列出已配置的模型提供方与模型，不再因加载时序问题而显示空白。

## 改动摘要
- 将 `llm` 由插件 `apply` 时一次性捕获，改为 RPC 调用（`vwf.models`）时现取，避免 llm 服务就绪晚于插件加载导致拿到 `undefined`。
- 在各失败分支补充 `console` 日志，便于线上排查 listProviders / listModels 异常。

## 已运行校验
- 仅改动 `packages/dsh-visual-workflow/src/host.js`（1 file，+6 −4）。
- 不涉及 `templates/` 蓝图与生成结果，无需重新 `npm run generate`。
- 工作树已提交并干净（commit `0ff3789`）。

## 关联
无明确关联 issue（host.js 运行时修复，非 issue 驱动）。
