### PR TITLE
feat(llm-account-auth): OpenAI/Anthropic 账户鉴权 LLM 适配器

### DIFF
--- a/.workbuddy/memory/2026-09-03.md
+++ b/.workbuddy/memory/2026-09-03.md
@@ -1,0 +1,161 @@
+# 2026-09-03
+
+## 澄清 workflow-manager 的 provider/model 机制（两条轴）
+
+结论：蓝图 `bindings.models.<nodeId> = {provider, model}` 只控制 **LLM 后端**（推理用哪家模型），
+**不控制执行体/权限模式**。用户常说的「codex + GPT-5.6」「cursor + Sonnet」其实是两条轴：
+
+1. LLM 后端轴 = `bindings.models`（蓝图能配，已支持）
+2. 执行体 + 权限模式轴（codex CLI 的 `agent-full-access`、cursor 的 `agent`、claude 的 `bypassPermissions`、
+   kimi 的 `yolo`）→ **当前 schema 无 per-node executor/permissionMode 字段**，
+   `dsh/README.md:165` 明写 permission_mode「不需要」（DSH 沙箱统一 workspace-write）。
+   `docs/开发工作流优化设计.md:137-151` 的那张 Agent+权限模式表是**设计提案，未进 schema**。
+   → 用户确认：诉求 A（账户鉴权 LLM 推理）现在做；诉求 B（执行体）走 ACP 协议远期实现。
+
+## 关键契约（dsh-llm，实测自 node_modules/@deepseek-ai/dsh-llm）
+
+- provider 路由运行时由 `llm.listProviders()` 动态发现；vwf 编辑器下拉项（`client.js:1301-1303`）即此，非硬编码。
+- 本机已注册路由仅两条：`kimi-coding`（pi-ai 适配器，`KIMI_CODING_API_KEY`）、
+  `deepseek-official`（官方直连，`DEEPSEEK_API_KEY`）。见 `dsh/README.md:170-194`。
+- **账户鉴权的理论依据**：`lib/types/api-key.js` 注释——
+  「a profile naming no credential authenticates through the provider's own ambient discovery or OAuth」。
+  即设置 profile 不写凭据，由 CLI 本地登录态鉴权。
+- `LlmAdapter`：只有 `stream(options)` 是抽象方法；可选覆写 `providerInfo / providerRetryPolicy /
+  listModels / resolveModel / prepareCall`。内部可 throw，LlmRuntime 归一为终态 error/aborted finish。
+- 每个 provider HTTP 请求必须带 `attributionHeaders()`。
+- `LlmError` 的可序列化事实在 `error.failure`（status/requestId/providerRetryAfterMs），
+  **不在 error 的直接属性上**（写断言时踩过一次）。
+
+## 落地：新增 packages/dsh-llm-account-auth（骨架）
+
+账户鉴权适配器骨架，注册 `openai` / `anthropic` 两条路由。8 项离线测试全绿（桩 fetch）。
+
+- 覆盖范围：anthropic API Key + **账户 OAuth 均可用**（Bearer + `anthropic-beta: oauth-2025-04-20`）；
+  openai API Key 可用；**openai 账户模式未实现**（codex 后端走 Responses 协议，与 Chat Completions
+  不同），命中抛 `UNSUPPORTED_ACCOUNT_MODE`，不做静默降级。
+- 凭据解析优先级：账户 token env → CLI 凭据库（~/.codex/auth.json、~/.claude/.credentials.json）→ API Key env。
+- 测试注入点：adapter 构造参数 `fetch / env / resolveCredential`，避免测试依赖真实凭据文件。
+- 待本机核验（README 有清单）：凭据文件真实键名、macOS Keychain 场景、
+  anthropic-beta 当前值、模型 id 与上下文窗口（骨架故意不填 context，不臆造能力数字）。
+
+## 环境备注（Windows，既有失败，非本次引入）
+
+`npm run validate` 有 2 项失败，均为 Windows 环境既有问题，与本次改动无关：
+- 引擎层 3 个测试失败：symlink 语义、端口绑定、硬编码 `/bin/rm`（generate H6 集成测试）。
+- `.generated/` 与重生成不一致（14 文件）。
+本次改动为纯新增（未跟踪 `packages/dsh-llm-account-auth/`），未触碰 templates/ 与 .generated/。
+
+## OpenAI Responses 线格式落地 + 上机核验（下午续）
+
+**OpenAI 账户（ChatGPT / codex 后端）模式已实现**，12 项离线测试全绿。
+
+- `wire-openai-responses.js` 收敛为单一实现（导出 `responsesRequest/responsesChunks`，
+  对齐 `wire-openai.js` 工厂引用，4 参签名含 env）。融合：严格 codex 头
+  （originator/openai-beta/session_id UUID v4/chatgpt-account-id）+ item 键控 builder +
+  `output_item.done` 权威值覆盖（donePatch 防截断）+ 采样参数默认剔除
+  （codex 后端拒收，`DSH_OPENAI_ACCOUNT_ALLOW_SAMPLING=1` 放行）+ UA 三档开关
+  （omit 默认/codex/dsh，opencode 与 hermes-agent 记录矛盾，留给上机定档）。
+- `openai-jwt.js`：JWT 载荷解析取 `chatgpt_account_id`，失败返回 undefined 不抛错。
+- `credentials.js`：`withAccountId` 三级来源（env `DSH_OPENAI_CHATGPT_ACCOUNT_ID` >
+  文档直存键 `tokens.account_id` > JWT claim）；`readFileToken` 顺带返回 doc。
+- usage 修正：dsh-llm 契约 counts 互斥——`input_tokens` 扣掉 cached 单报
+  `cacheReadTokens`；`reasoning_tokens` 为输出子集明细。**发现并修正旧测试期望**
+  （API Key 模式期望 11 实为 8，chatChunks 互斥扣减是对的、测试过期）。
+- **上机核验（Windows 侧，只读脱敏，脚本 .scratch/verify-account-auth.mjs）**：
+  - `~/.codex/auth.json` 结构与预期一致：`tokens.access_token`（JWT 1972c）命中、
+    `tokens.account_id` 直存键存在（36c）、JWT claim 可提取，端到端
+    `mode=account + accountId 可提取` ✅。
+  - **真 bug 修复**：`claudeAiOauth.accessToken` 是 `sk-ant-oat01-…`（sk-ant- 前缀），
+    被 apiKeyPrefix 误判为 api-key。加凭据库条目 `forceMode: 'account'` 修复，
+    端到端复验 `anthropic: mode=account` ✅。
+  - codex CLI 不在 Windows PATH；claude CLI 在 /d/dev/node-v25.5.0-win-x64/claude。
+- Mac 侧待办（README 清单已标注）：Keychain 场景、anthropic-beta 现值抓包、
+  OpenAI 账户模式真实请求定 UA/头部档位、模型 id 与上下文窗口（不臆造）。
+
+## fetch failed 根因修复 + 模型目录（晚续）
+
+用户实测 DSH web（127.0.0.1:3080）报 `fetch failed`（登录前后都报）。
+
+**根因**：Node 全局 fetch（undici）默认不读 `HTTPS_PROXY`，企业内网直连 `chatgpt.com`
+超时（`UND_ERR_CONNECT_TIMEOUT`）。与令牌是否过期无关——所以登录前后现象一致。
+沙箱自带代理 `127.0.0.1:52596` 对 OpenAI 返回 502（不放行）；本机 Clash HTTP 代理
+`127.0.0.1:7890` 可出网（curl -x 7890 对 chatgpt.com 返 403、api.openai.com 返 401）。
+
+**修复**：
+- `adapter.js` 加 undici `ProxyAgent`：构造时读 `DSH_ACCOUNT_AUTH_PROXY` > `HTTPS_PROXY` >
+  `HTTP_PROXY`，存在则 `new ProxyAgent(url)`，`stream()` 的 fetch 注入 `dispatcher`
+  （只代理账户鉴权请求，不动 DSH 其他流量）。NETWORK 错误补代理提示。
+- 装 `undici@^6.28.0` 到包（workspace 提升怪癖：须 `npm install undici --workspaces=false`
+  --no-save 落地到包本地 node_modules；已补进 package.json dependencies）。
+- 模型目录：`profiles.js` openai `models` 由 `['gpt-5.6']` 扩为
+  `['gpt-5.6-sol','gpt-5.6-terra','gpt-5.6-luna','gpt-5.5','gpt-5.4']`（用户 2026-09-03 核实
+  5.6 拆三档 + 5.5/5.4）。
+- 重启 DSH：`HTTPS_PROXY=http://127.0.0.1:7890 HTTP_PROXY=... dsh web`（task jupJ14）。
+- **端到端验证**（.scratch/probe-proxy-e2e.mjs，对假过期令牌）：
+  经 7890 代理到达 codex 后端 → 真实 401 `Could not parse your authentication token` →
+  归一成 `LlmError code=AUTH`，不崩、不泄露令牌、859ms。证明网络通 + 线格式结构正确
+  （格式错会是 400 而非 401-auth）。12 项测试仍全绿。
+- **结论**：登录前（令牌过期）= 干净 AUTH 错误；已 `codex login` 刷新令牌 = 应正常流式。
+  Windows `~/.codex/auth.json` 令牌 6 月已过期，需用户重跑 `npx @openai/codex login` 刷新。
+- README 新增「网络代理（企业内网必读）」小节 + 代理环境变量 + 模型 id 核验项勾选。
+
+## 环境速查（本机代理 / DSH）
+
+- Clash HTTP CONNECT 代理：`127.0.0.1:7890`（可达 OpenAI/Anthropic）。SOCKS5 也在 7890。
+- 沙箱代理 `127.0.0.1:52596`：仅放行 Agent 工具用网，不放行 OpenAI（502）。
+- DSH web：`/d/dev/node-v25.5.0-win-x64/dsh web`，profile 在
+  `C:\Users\cheiapeng\.dsh\profiles\web`，监听 127.0.0.1:3080。
+- 插件挂载：profile/node_modules 下 `dsh-llm-account-auth` 用 PowerShell Junction 指向
+  `E:\workspace\workflow-manager\packages\dsh-llm-account-auth`（符号链接被 Windows 权限拒）。
+- DSH bundle 须声明 `package.json` 的 `dsh.bundle.patch` + 包根 `cordis.patch.yml`
+  （insert entry id=llm-account-auth），否则加载报 `declares no dsh.bundle`。
+
+## accountOnly 修复：退出登录误报「API key is invalid」（晚续 2）
+
+用户反馈：已登录 GPT-5.4 正确回复（Responses 线格式 OK）；**退出登录后报「API key is invalid」，
+未提示重登录**。
+
+**根因**：`~/.codex/auth.json` 退出登录后整个 ENOENT（消失），`resolveCredential` ② 文件路读不到
+→ 落到 ③ `tokenEnv: ['OPENAI_API_KEY']` 兜底。该 `OPENAI_API_KEY` 是 **Windows 系统环境变量**
+（被 `dsh.exe` 原生进程继承，Git Bash 与 profile `.env` 里都查不到），无效/占位 → 退化成
+`api-key` 模式 → 走 Chat Completions 打 `api.openai.com` → 报误导的「API key is invalid」。
+
+**这是设计缺陷**：OpenAI 账户模式（codex 后端 `chatgpt.com/backend-api/codex`）与 OpenAI 官方
+API（`api.openai.com` Chat Completions）是**两套鉴权体系**，账户模式不该退化到 API Key。
+
+**修复**：
+- `profiles.js` openai 加 `accountOnly: true`（账户专用，禁止 API Key 退化）；Anthropic 不标
+  （账户与 API Key 同端点 `api.anthropic.com`，退化可接受）。
+- `credentials.js` resolveCredential：③ 兜底加 `if (!profile.accountOnly)` 守卫；AUTH 文案对
+  accountOnly 改为明确引导 `npx @openai/codex login`、并声明「该模式不接受 OPENAI_API_KEY」。
+- 加回归测试「accountOnly 退出登录不退化到 API Key」（构造 profile + 注入无效 OPENAI_API_KEY，
+  断言抛 AUTH 且文案含 codex login）；另修旧测试 5 因 `{...PROFILES.openai}` 展开 accountOnly
+  导致 API Key 子断言失效应显式 `accountOnly:false`。**13/13 测试全绿**。
+- 重启 DSH（XU7tze，带代理）加载新代码。
+
+**提示**：Windows 系统环境变量里那枚 `OPENAI_API_KEY` 是无效占位，仍存在于 `dsh.exe` 进程环境；
+现在本包 openai adapter 已忽略它，但 DSH 框架其他 OpenAI 入口若读它仍可能报 invalid——本包不再受影响。
+README 覆盖范围表、凭据解析优先级、已知点均已同步。改动未 commit（确认无误再收口）。
+
+## accountOnly 二次加固：文件路 sk- 令牌降级（晚续 3，本次）
+
+用户实测「退出登录仍报 API key is invalid」——上轮 XU7tze（已带 accountOnly）其实是
+**活进程**，说明 `accountOnly` 守卫不完整：它只挡了 ③ env 兜底，**② 文件路仍跑
+`classifyToken`**，若 codex `auth.json` 残留一枚 `sk-` 形令牌（含我曾把 `OPENAI_API_KEY`
+列为 codex 文件 `keys` 第一项）即被判成 API Key → 误打官方 API → 误导「API key is invalid」。
+（另一可能：上轮重启未真正接管 3080，旧进程续命——但 XU7tze 失败通知证实它就是被我 kill 的
+活进程，故根因确为 ② 路降级。）
+
+**二次修复**：
+- `credentials.js`：② 文件路判定改为 `profile.accountOnly ? 'account' : (entry.forceMode ?? classifyToken(...))`
+  ——账户专用模式下文件来源一律强制 account，杜绝 sk- 误降级。
+- `profiles.js`：codex `credentialFiles.keys` 移除 `OPENAI_API_KEY`（登录态文件不该含 API Key），
+  只留 `['access_token','tokens.access_token','tokens.id_token']`。
+- 加回归测试「accountOnly · 文件中即使出现 sk- 形令牌也不降级为 API Key」（造临时 auth.json
+  含 `sk-spurious-from-file`，断言 `mode==='account'`）。**14/14 测试全绿**。
+- **干净重启**：PowerShell `Stop-Process -Id 22340 -Force` 杀旧活进程（taskkill/cmd 被安全策略拦），
+  确认 3080 释放，再 `HTTPS_PROXY=... dsh web` 起新实例（task izSzVq，PID 39860，日志正常）。
+- README 凭据解析节补「accountOnly 双重守卫」说明。
+
+**结论**：退出登录（auth.json 消失 或 残留 sk- 令牌）→ 一律 account 模式 → 干净 AUTH 引导
+`codex login`，不再误报「API key is invalid」。改动仍未 commit，待用户浏览器复验确认收口。

--- a/docs/异源问题核实.md
+++ b/docs/异源问题核实.md
@@ -1,0 +1,45 @@
+# 开发工作流 2.0 · 异源问题核实（给另一台电脑核实）
+
+> 用途：核实「异源异模型」硬规则的现状、违规点，以及引擎侧落地的可行性。gold-band 删除前可临时抓取其规则作参考（已批准其为参考模板）。
+> 约束：gold-band 相关问题不再回答，此处仅借用其《工作流编辑器》规则作为引擎实现参考。
+
+## 1. 硬规则定义
+
+`开发(dev)` 与 `审核(review)` 节点必须**异源异模型**（不同 provider，至少不同模型），保证审查独立、不护短。
+
+- 依据：`dsh/README.md:163-184`（推荐分配 dev=`deepseek-v4-pro` / review=`kimi-coding/k3`）、`dsh/workflow/dev-workflow-2.0.mjs:51-54`（当前仅 `log` 警告，**不阻断**）。
+
+## 2. 当前违规事实（已确认）
+
+- `packages/dsh-visual-workflow/src/host.js:37-57`：7 节点默认全 `deepseek-official`（dev=`v4-pro`、review=`v4-flash`）→ 同 provider，仅弱异源，**违反硬规则**。
+- `host.js:442-448`（`vwf.workflows.save`）与 `host.js:453`（`vwf.validate`）只调 `validateDsl`，**不校验异源**，可绕过保存。
+
+## 3. 目标要求（用户决策）
+
+把该规则**下沉到底层引擎**；skill 或 dsh 插件更新工作流时，若 dev/review（及待确认的调度/验收）不满足异源，引擎**拒绝保存/更新**并返回明确错误。
+
+## 4. 需另一台电脑核实的项
+
+- **引擎位置与接口**：底层引擎实际在哪？gold-band 侧是 Rust `validate_workflow`（`SKILL.md:59-72`），DSH 侧是当前 `workflow` 工具——确认统一引擎的 save/update 入口能否插入「异源检查」钩子。
+- **能否在 save 路径硬拒**：引擎是否支持在持久化前校验节点 provider/model；若引擎暂不可改，过渡方案是分别在 `vwf.validate/save`（`host.js`）与 DSH skill 写入前加硬拒绝（需确认不会与引擎重复校验冲突）。
+- **gold-band 参考规则抓取**：gold-band 桌面端《工作流编辑器》是否原本就有「异源」类校验？删除前先抓取其规则，作为 vwf 对齐参考（`README.md` 第 1-3 行已说明 vwf 编辑器对齐 Gold-Band《工作流编辑器》）。
+- **异源作用范围**：仅 `dev↔review` 必须异源，还是调度/验收也需？影响校验实现范围与报错文案。
+
+## 5. 验证 / 落地检查清单（action items）
+
+- [ ] 在引擎 save/update 入口确认可挂校验；给出钩子签名。
+- [ ] 用 `host.js:37-57` 当前全-deepseek 模板跑一次 save，确认**应被拒**并返回 `dev/review 同 provider` 类错误。
+- [ ] 用 `dsh/README.md:167-184` 推荐分配跑一次，确认**应通过**。
+- [ ] 明确异源范围（仅 dev↔review 或更多），写入引擎校验与文档。
+- [ ] 在 `vwf.validate`（`host.js:453`）与 DSH skill 写入前补同样拒绝，保证引擎改不动时也有护栏。
+
+## 6. 附：相关代码位置速查
+
+| 内容 | 位置 |
+|------|------|
+| vwf 内嵌模板默认模型 | `packages/dsh-visual-workflow/src/host.js:37-57` |
+| vwf 保存校验 | `packages/dsh-visual-workflow/src/host.js:442-448` |
+| vwf 校验入口 | `packages/dsh-visual-workflow/src/host.js:453` |
+| DSH 异源警告（仅警告） | `dsh/workflow/dev-workflow-2.0.mjs:51-54` |
+| DSH 推荐异源分配 | `dsh/README.md:163-184` |
+| gold-band 校验参考 | 根 `SKILL.md:59-72`（`validate_workflow`） |

--- a/docs/通用问题分析.md
+++ b/docs/通用问题分析.md
@@ -1,0 +1,53 @@
+# 开发工作流 2.0 · 通用问题分析（本电脑可分析 / 解决）
+
+> 范围说明：gold-band 视为已完成参考使命、待删除的遗留。以下条目只动 DSH 编排脚本（`dsh/`）与 vwf 插件（`packages/dsh-visual-workflow/`），以及仓库基建。gold-band 专属产物（`workflows/*.json`、`profiles/*`、根 `SKILL.md`、`evals.json`）列入「待清理」，不修复。
+> 约束：gold-band 相关问题不再回答。
+
+## A. 主线目标（重述）
+
+一套**底层引擎**同时驱动两种入口：
+
+- 文本触发的 skill：`dsh/skill/SKILL.md` → `dsh/workflow/dev-workflow-2.0.mjs`
+- 图形触发的 vwf 插件：`packages/dsh-visual-workflow/src/host.js`（编译 DSL → 脚本）
+
+当前两份是同一工作流的独立定义，需收敛到底层引擎。
+
+## B. 同一工作流两份定义、无单一事实源
+
+- `dsh/workflow/dev-workflow-2.0.mjs`：`分流`是**脚本内 `if`**，不调 LLM（`dsh/README.md` 第 9-17 行）。
+- `packages/dsh-visual-workflow/src/host.js:29-74`：内嵌 `TEMPLATES['dev-workflow-2-0']`，`分流`是 **route 节点**，整份拓扑硬编码在 JS 里。
+- 改任一节点要手动同步两处，且无自动化一致性校验。
+- **建议**：抽一份共享拓扑源（JSON 或 `.mjs` 导出）→ 生成 mjs 编排脚本 + vwf 内嵌模板；过渡期至少加一个测试断言「两份定义的节点集合 / 边 / 角色绑定一致」。
+
+## C. 文档路径引用失效（可能未提交 GitHub）
+
+失效引用（已确认本机不存在 `src/` 与 `docs/gold-band/`）：
+
+- 根 `SKILL.md:15` → `docs/gold-band/开发计划/工作流模板/*.json`
+- 根 `SKILL.md:18` → `docs/gold-band/开发计划/开发工作流优化设计.md`（实际在 `docs/开发工作流优化设计.md`）
+- 根 `SKILL.md:51` → `src/prompts/zh-CN/profile/`（无 `src/`）
+- `docs/开发工作流2.0需求规格.md:6` → `工作流模板/issue-driven-dev-workflow.json`（隐含 `docs/gold-band/...`）
+- `docs/工作流状态机.md:9` 称「六个核心状态」，与 7 节点事实不符（节点数口径矛盾）
+
+**两种假设**：(a) 本地路径写错；(b) 被引文档未提交 GitHub。本机已确认路径不存在；需另一台电脑核对 GitHub 仓库是否含 `docs/gold-band/` 与 `src/prompts/`（见《异源问题核实》文档）。
+
+## D. `.scratch/` 草稿与交付物混杂
+
+- `.scratch/dsh-visual-workflow-p0/` 同时含设计稿（`requirements-analysis.md`、`issues/*`）与**编译产物**（`compiled/*.gen.mjs`、`meta.json`）。
+- **建议**：编译产物 `gitignore` / 移出；设计稿保留但移出根目录或归入 `docs/design/`，与 `packages/` 明确分层。
+
+## E. 缺根级清单与统一校验
+
+- 仅 `packages/dsh-visual-workflow/` 有 `package.json`；无根 `package.json`、无根 `README`、无 CI。
+- **建议**：加根 `package.json`（workspaces）+ 一个 `validate` 脚本，一键跑 packages 测试并校验「DSH mjs ↔ vwf 模板」一致性。
+
+## F. 两份 SKILL 门面待合并
+
+- 根 `SKILL.md`（gold-band，待删）与 `dsh/skill/SKILL.md`（DSH）并存。gold-band 删除后，根 `SKILL.md` 应移除或改写指向 DSH，避免新人困惑入口。
+
+## 落地顺序建议
+
+1. 抽共享拓扑源（B）
+2. 修文档死链（C）+ 加根 README / 清单（E）
+3. 清理 `.scratch`（D）与 gold-band 产物（F）
+4. 引擎统一（A，详见《异源问题核实》文档）

--- a/packages/dsh-llm-account-auth/README.md
+++ b/packages/dsh-llm-account-auth/README.md
@@ -1,0 +1,174 @@
+# dsh-llm-account-auth
+
+DSH 账户鉴权 LLM 适配器骨架：给宿主注册 `openai` / `anthropic` 两条 provider 路由，
+**凭据取自各自 CLI 的本地登录态，设置 profile 里不写 API Key**。
+
+对应诉求 A（「只是想用 OpenAI / Anthropic 账户鉴权的 LLM 做推理」）。
+诉求 B（codex / cursor 作为**执行体** + 权限模式）不在本包范围内，按 ACP 协议远期实现。
+
+## 目录
+
+```
+src/
+  index.js        插件入口：apply(ctx) → llm.registerAdapter(['openai','anthropic'], adapter)
+  profiles.js     provider 画像：端点 / 凭据来源 / 鉴权头 / 建议模型目录
+  credentials.js  凭据解析：账户令牌 env → CLI 凭据库 → API Key env；账户 id 提取
+  openai-jwt.js   从 ChatGPT OAuth JWT 载荷取 chatgpt_account_id（解析失败不抛错）
+  adapter.js      LlmAdapter 实现（只有 stream() 是必须实现的抽象方法）
+  wire-openai.js  OpenAI Chat Completions 线格式（API Key 模式）
+  wire-openai-responses.js OpenAI Responses 线格式（ChatGPT 账户 / codex 后端）
+  wire-anthropic.js Anthropic Messages 线格式
+  sse.js          零依赖 SSE 解析
+  blocks.js       块索引分配与累积 → StreamChunk 归一
+tests/adapter.test.mjs  离线冒烟（桩 fetch，13 项，无需真实凭据）
+```
+
+## 当前覆盖范围
+
+| provider | 模式 | 状态 |
+|---|---|---|
+| `anthropic` | API Key（`sk-ant-…`） | ✅ 可用 |
+| `anthropic` | **账户（Claude 账号 OAuth）** | ✅ 可用（Bearer + `anthropic-beta: oauth-2025-04-20`） |
+| `openai` | API Key（`sk-…`） | 不适用（此 profile 为**账户专用**，不退化到 `OPENAI_API_KEY`；纯 API Key / Chat Completions 模式需另立独立 provider） |
+| `openai` | **账户（ChatGPT 账号令牌）** | ✅ 已实装并通过上机验证（Responses 线格式，codex 后端；GPT-5.4 实测正常回复）；账户 id 三级提取可用 |
+
+`openaiWire()` 按凭据模式分发：API Key → Chat Completions（`api.openai.com`），
+账户令牌 → Responses（`chatgpt.com/backend-api/codex/responses`）。
+
+## 凭据解析优先级
+
+1. `DSH_OPENAI_ACCOUNT_TOKEN` / `DSH_ANTHROPIC_ACCOUNT_TOKEN`（显式覆盖，测试与 CI 用）
+2. CLI 本地凭据库（账户登录态，主路径）
+   - OpenAI：`$CODEX_HOME/auth.json` 或 `~/.codex/auth.json`
+   - Anthropic：`~/.claude/.credentials.json`、`~/.claude.json`
+3. `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`（API Key 兜底）——**仅非账户专用 profile 生效**：
+   OpenAI 账户模式为 `accountOnly`，跳过此兜底（codex 后端不接受 `OPENAI_API_KEY`，退化过去会报
+   误导性的「API key is invalid」）；Anthropic 账户与 API Key 同端点，保留兜底。
+
+令牌分类是启发式：命中 provider 的 `apiKeyPrefix`（`sk-` / `sk-ant-`）判为 API Key，
+其余（JWT 等）判为账户令牌，据此选择鉴权头与端点。**例外**：凭据库条目可声明
+`forceMode: 'account'` 跳过启发式——Claude 的 OAuth 令牌（`sk-ant-oat01-…`）也以
+`sk-ant-` 开头，不声明会被误判成 API Key（本机已实测踩中并修复）。
+
+**账户专用 profile（`accountOnly`）的双重守卫**：
+- 第 3 路（API Key env 兜底）整体跳过——见上。
+- 第 2 路（CLI 凭据库）读到的令牌**一律强制 account 模式**，不走 `classifyToken` 启发式。
+  否则若 codex `auth.json` 里混有一枚 `sk-` 形令牌（含误把 `OPENAI_API_KEY` 当凭据读），
+  会被降级成 API Key 去打官方 `api.openai.com`，报出误导性「API key is invalid」
+  （本机实测踩中：退出登录后 `auth.json` 残留 `sk-` 形值即触发）。codex 凭据文件
+  `keys` 已移除 `OPENAI_API_KEY`，只留 `tokens.access_token` / `tokens.id_token`。
+三条路都取不到时抛 `LlmError` code `AUTH`（`accountOnly` 时第 3 路被跳过，
+未登录即抛 AUTH 并引导 `codex login`，不会出现误导性 API Key 错误）。
+
+### 账户 id（openai 账户模式必需）
+
+codex 后端是 Cloudflare 前置的，缺账户 id 的请求会拿 403，与令牌是否有效无关。
+三级来源，先到先得（见 `credentials.js` 的 `withAccountId`）：
+
+1. env 覆盖：`DSH_OPENAI_CHATGPT_ACCOUNT_ID` / `CHATGPT_ACCOUNT_ID`
+2. 凭据文档直存键：`tokens.account_id`（codex auth.json 实测存在）→ `account_id`
+3. JWT 载荷 claim：`payload['https://api.openai.com/auth'].chatgpt_account_id`
+   （优先已选令牌，再扫文档里其他 JWT）
+
+取不到**不阻断请求**——宁可把请求发出去暴露真实的 403，也不在凭据阶段崩掉。
+
+### OpenAI 账户模式的请求形态（codex 后端）
+
+- 头部：`authorization: Bearer <令牌>`、`chatgpt-account-id`、`openai-beta: responses=experimental`、
+  `originator: codex_cli_rs`、`session_id`（每次请求新的 UUID v4）
+- 请求体：`store: false`（仅接受 stream:true + store:false）、`instructions` 必填非空
+  （无 system 时用中性兜底）、`input` 必须是 item 数组、tools 扁平化 + `strict: false`
+- 采样参数（`max_output_tokens` / `temperature` / `stop` …）**默认剔除**——codex 后端拒收；
+  把端点指到官方 Responses 时用 `DSH_OPENAI_ACCOUNT_ALLOW_SAMPLING=1` 放行
+- 事件流：块生命周期由 `response.output_item.added/done` 划定，`done` 携带权威完整值
+  （覆盖增量累积，防截断）；usage 按 dsh-llm 互斥契约拆分（`input_tokens` 扣掉缓存命中）
+
+### 环境变量一览
+
+| 变量 | 作用 |
+|---|---|
+| `DSH_OPENAI_ACCOUNT_TOKEN` / `CODEX_ACCESS_TOKEN` | 账户令牌显式覆盖（测试与 CI） |
+| `DSH_OPENAI_CHATGPT_ACCOUNT_ID` / `CHATGPT_ACCOUNT_ID` | 账户 id 显式覆盖 |
+| `DSH_OPENAI_ACCOUNT_BASE_URL` / `DSH_OPENAI_ACCOUNT_PATH` | 覆盖 codex 端点（上机试错不改代码） |
+| `DSH_OPENAI_ACCOUNT_ALLOW_SAMPLING` | `1` 时放行采样参数（非 codex 目标用） |
+| `DSH_OPENAI_ACCOUNT_USER_AGENT` | UA 三档：`omit`（默认）/ `codex` / `dsh` |
+| `DSH_ANTHROPIC_ACCOUNT_TOKEN` / `CLAUDE_ACCESS_TOKEN` | Anthropic 账户令牌覆盖 |
+| `DSH_ACCOUNT_AUTH_PROXY` | **专用代理覆盖**（最高优先级）；企业内网出网到此代理 |
+| `HTTPS_PROXY` / `HTTP_PROXY` | 通用代理（大小写兼容）；未设 `DSH_ACCOUNT_AUTH_PROXY` 时生效 |
+
+## 网络代理（企业内网必读）
+
+Node 的全局 `fetch`（undici）**默认不读 `HTTPS_PROXY` 环境变量**，企业内网下会直连超时，
+上层只看到笼统的 `fetch failed`（根因 `UND_ERR_CONNECT_TIMEOUT`）。本适配器在构造时检测
+`DSH_ACCOUNT_AUTH_PROXY` → `HTTPS_PROXY` → `HTTP_PROXY`，若存在则用 undici `ProxyAgent`
+注入 fetch 的 `dispatcher`，**只代理本适配器的账户鉴权请求，不动 DSH 其他流量**。
+
+- 代理必须是 **HTTP(S) CONNECT 代理**（如 Clash 的 mixed 端口），undici 不直接支持 SOCKS5。
+- 实测（Windows / WeBank 内网）：Clash HTTP 代理在 `127.0.0.1:7890` 可出网到
+  `chatgpt.com` / `api.openai.com`；沙箱自带代理（如 `127.0.0.1:52596`）不放行 OpenAI，会 502。
+- 启动 DSH 时把代理传进环境即可：`HTTPS_PROXY=http://127.0.0.1:7890 dsh web`。
+- 无代理环境（本机直连可达）不设这个变量，请求照常直连，不会被拦截。
+
+## 接入核验清单（首次上机必做）
+
+骨架里的凭据文件布局与账户模式头部是按常见形态预填的，**必须在本机核实后回填**：
+
+- [x] ~~`codex login` 后，确认凭据文件真实路径与键名~~
+      （Windows 侧已核验：`~/.codex/auth.json`，命中键 `tokens.access_token`，
+      `tokens.account_id` 直存键存在，JWT claim 提取可用）
+- [x] ~~`claude login` 后确认凭据落点~~
+      （Windows 侧已核验：`~/.claude/.credentials.json#claudeAiOauth.accessToken` 存在；
+      **macOS 上 Claude 可能主要存 Keychain**，文件形态未必存在——若取不到，
+      需改走 `security find-generic-password` 读取，Mac 侧待办）
+- [x] ~~Windows 侧发现并修复：Claude OAuth 令牌（`sk-ant-oat01-…`）被 `sk-ant-` 前缀
+      误判为 API Key——已加凭据库条目 `forceMode: 'account'`~~
+- [ ] 抓一次真实请求，确认 `anthropic-beta` 的当前值（骨架填 `oauth-2025-04-20`）
+- [ ] **真实发起一次 OpenAI 账户模式请求**，核实头部集合：
+      `originator: codex_cli_rs` 是否放行、`chatgpt-account-id` 大小写是否挑剔、
+      User-Agent 三档（`omit`/`codex`/`dsh`，默认 omit）哪档能过 Cloudflare——
+      opencode 记录说后端见不得第三方 UA，hermes-agent 却要求 `codex_cli_rs/` 前缀，说法矛盾
+- [x] ~~模型 id 目录~~（用户 2026-09-03 核实 ChatGPT 账户模式可选：
+      `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` / `gpt-5.5` / `gpt-5.4`；
+      Anthropic：`claude-sonnet-5` / `claude-opus-5`）。目录为建议性，DSH 不因此拒绝未列出的 model id；
+      **context（上下文窗口）仍故意留空**——未知容量不喂给宿主决策
+- [ ] 网络代理：企业内网下 `HTTPS_PROXY` 必须指向可达 OpenAI 的 HTTP CONNECT 代理，否则报 `fetch failed`
+      （已修复：适配器自动读 `HTTPS_PROXY` 并经 undici `ProxyAgent` 出网）
+
+## 挂载
+
+宿主注册后 `llm.listProviders()` 就会列出这两条路由——vwf 编辑器节点模型下拉的数据源即此
+（`client.js` 的下拉项来自 `listProviders`，不是硬编码）。挂载方式参照同仓库
+`packages/dsh-visual-workflow/cordis.patch.yml` 的 `dsh plugin add link:<绝对路径>` 模式。
+
+随后蓝图里直接写即可：
+
+```json
+"bindings": { "models": {
+  "dev":    { "provider": "openai",    "model": "gpt-5.6" },
+  "review": { "provider": "anthropic", "model": "claude-opus-5" }
+}}
+```
+
+改完 `npm run generate` 重生成（生成物禁手改）。
+
+## 已知限制 / 下一步
+
+- **OpenAI 账户模式头部集合已通过上机验证**：GPT-5.4 实测正常回复，确认
+  `originator: codex_cli_rs` / `chatgpt-account-id` / `openai-beta: responses=experimental` /
+  `session_id` 这套头能被 codex 后端接受（UA 默认 `omit` 档已验证可过）。
+- **未调用 `registerConfigurableProviders`**：这两条路由靠 CLI 登录态激活，不经设置页配置，
+  故未登记进可配置 provider 目录；若希望设置页显示 live/dormant 状态，再补该调用。
+- **未填上下文窗口**：`resolveModel` 只回 `defaultMaxTokens`，context 保持未知。
+- 账户令牌**过期/刷新**未处理：骨架每次调用重新读凭据文件，但不会主动 refresh
+  （Windows 侧实测 `expiresAt` 字段存在；过期后续接 refresh_token 是下一步）。
+- 诉求 B（执行体 + 权限模式）需先扩展蓝图 schema（per-node `executor`/`permissionMode`），
+  再按 ACP 协议对接 codex / cursor——与本包是两条独立的轴。
+- **网络代理已支持**（2026-09-03 修复 `fetch failed`）：适配器读 `HTTPS_PROXY`/`HTTP_PROXY`
+  （或 `DSH_ACCOUNT_AUTH_PROXY`），经 undici `ProxyAgent` 注入 fetch dispatcher，只代理账户鉴权请求。
+  企业内网启动 DSH 须 `HTTPS_PROXY=http://<可达 OpenAI 的 HTTP 代理> dsh web`。
+
+## 测试
+
+```bash
+cd packages/dsh-llm-account-auth && npm test   # 13 项，桩 fetch，离线可跑
+```

--- a/packages/dsh-llm-account-auth/cordis.patch.yml
+++ b/packages/dsh-llm-account-auth/cordis.patch.yml
@@ -1,0 +1,9 @@
+# dsh-llm-account-auth bundle for DeepSeek Harness (dsh).
+# 通过官方 CLI 安装即挂载：
+#   dsh plugin --profile web add link:E:/workspace/workflow-manager/packages/dsh-llm-account-auth
+# 入口走包的 exports["."]（src/index.js，导出 Cordis 插件 { name, apply }），
+# apply 内把 openai / anthropic 两条账户鉴权路由注册进 ctx.llm。
+# 插件行按包名经 profile 的 node_modules 解析。
+- insert:
+    - id: llm-account-auth
+      name: 'dsh-llm-account-auth'

--- a/packages/dsh-llm-account-auth/package.json
+++ b/packages/dsh-llm-account-auth/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "dsh-llm-account-auth",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "DSH 账户鉴权 LLM 适配器：openai / anthropic 两条路由，凭据取自 CLI 本地登录态（设置 profile 不写 API Key）",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "scripts": {
+    "test": "node --test tests/adapter.test.mjs"
+  },
+  "dependencies": {
+    "undici": "^6.28.0"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  }
+}

--- a/packages/dsh-llm-account-auth/src/adapter.js
+++ b/packages/dsh-llm-account-auth/src/adapter.js
@@ -1,0 +1,165 @@
+// 账户鉴权 LLM 适配器：为 openai / anthropic 两条路由提供 LlmAdapter 实现。
+//
+// 契约要点（dsh-llm）：
+//   · 只有 stream() 是抽象方法，其余（providerInfo/listModels/resolveModel/prepareCall）都有默认实现；
+//   · 适配器内部可以 throw，LlmRuntime.stream() 会把异常归一成终态 error/aborted finish；
+//   · 每个 provider HTTP 请求都必须带 attributionHeaders()。
+
+import { LlmAdapter, LlmError } from '@deepseek-ai/dsh-llm';
+import { ProxyAgent } from 'undici';
+import { PROFILES } from './profiles.js';
+import { resolveCredential } from './credentials.js';
+import { parseSse } from './sse.js';
+import { openaiWire } from './wire-openai.js';
+import { anthropicWire } from './wire-anthropic.js';
+
+// Node 的全局 fetch（undici）默认不读 HTTPS_PROXY 环境变量，企业内网下会直连超时
+// （UND_ERR_CONNECT_TIMEOUT → 上层只看到 "fetch failed"）。这里显式把代理注入 fetch 的
+// dispatcher，只影响本适配器的账户鉴权请求，不动 DSH 其他流量。
+// 优先级：专用覆盖键 > HTTPS_PROXY > HTTP_PROXY（大小写兼容）。
+function resolveProxyUrl(env) {
+  const url =
+    env.DSH_ACCOUNT_AUTH_PROXY ||
+    env.HTTPS_PROXY ||
+    env.HTTP_PROXY ||
+    env.https_proxy ||
+    env.http_proxy;
+  return typeof url === 'string' && url.trim() ? url.trim() : undefined;
+}
+
+// 每个 provider 给一个「按凭据模式选线格式」的工厂：
+// openai 在账户模式下切到 Responses，anthropic 两种模式同线格式。
+const WIRES = {
+  openai: openaiWire,
+  anthropic: anthropicWire,
+};
+
+export class AccountAuthLlmAdapter extends LlmAdapter {
+  #fetchImpl;
+  #env;
+  #resolve;
+  #proxyAgent;
+
+  /**
+   * @param {{
+   *   fetch?: typeof globalThis.fetch,
+   *   env?: NodeJS.ProcessEnv,
+   *   resolveCredential?: (profile: object, env: NodeJS.ProcessEnv) => Promise<{mode:string,token:string,source:string}>
+   * }} [options]
+   *   fetch / env / resolveCredential 均可注入，便于离线测试（见 tests/adapter.test.mjs）。
+   */
+  constructor(options = {}) {
+    super();
+    this.#fetchImpl = options.fetch ?? globalThis.fetch;
+    this.#env = options.env ?? process.env;
+    this.#resolve = options.resolveCredential ?? resolveCredential;
+
+    // 代理：仅在环境变量显式给出时启用，避免无代理环境（如本机直连）被意外拦截。
+    const proxyUrl = resolveProxyUrl(this.#env);
+    if (proxyUrl) {
+      try {
+        this.#proxyAgent = new ProxyAgent(proxyUrl);
+      } catch {
+        // 代理 URL 非法（如手滑写错）：不阻断启动，只是不走代理，请求会暴露真实网络错误。
+        this.#proxyAgent = null;
+      }
+    } else {
+      this.#proxyAgent = null;
+    }
+  }
+
+  providerInfo(provider) {
+    return { id: provider, name: PROFILES[provider]?.name ?? provider };
+  }
+
+  /** 目录是建议性的：适配器接受未列出的 model id，消费方不得因未列出而拒请求。 */
+  async listModels(provider) {
+    return (PROFILES[provider]?.models ?? []).map((id) => ({ provider, id, name: id }));
+  }
+
+  /**
+   * 精确模型元数据。context 一律省略（未知容量）——不填未经核实的能力数字。
+   * defaultMaxTokens 是适配器自定的请求级输出上限，仅在调用方未给 maxTokens 时生效。
+   */
+  async resolveModel(provider, model, _signal) {
+    const profile = PROFILES[provider];
+    return {
+      provider,
+      id: model,
+      name: model,
+      ...(profile?.defaultMaxTokens ? { defaultMaxTokens: profile.defaultMaxTokens } : {}),
+    };
+  }
+
+  async *stream(options) {
+    const profile = PROFILES[options.provider];
+    if (!profile) {
+      throw new LlmError(`未注册的 provider 路由：${options.provider}`, 'NO_ADAPTER');
+    }
+    const makeWire = WIRES[profile.wire];
+    if (!makeWire) {
+      throw new LlmError(`provider ${options.provider} 缺少线格式实现：${profile.wire}`, 'NO_ADAPTER');
+    }
+
+    // 账户鉴权的主路径：设置 profile 不写凭据，由 CLI 本地登录态解析。
+    const credential = await this.#resolve(profile, this.#env);
+    const wire = makeWire(credential);
+    const { url, headers, body } = wire.request(profile, options, credential, this.#env);
+
+    let response;
+    try {
+      response = await this.#fetchImpl(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: options.signal,
+        // 仅此请求走代理（企业内网出网必需）；无代理则为 undefined，fetch 直连。
+        ...(this.#proxyAgent ? { dispatcher: this.#proxyAgent } : {}),
+      });
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        throw new LlmError(`${profile.name} 请求被取消`, 'ABORTED', { cause: error });
+      }
+      const hint = this.#proxyAgent
+        ? '（请检查 HTTPS_PROXY 指向的代理是否可达 OpenAI/Anthropic）'
+        : '（企业内网请通过 HTTPS_PROXY 配置代理后再试）';
+      throw new LlmError(
+        `无法连接 ${profile.name}：${error?.message ?? String(error)}${hint}`,
+        'NETWORK',
+        { cause: error },
+      );
+    }
+
+    if (!response.ok || !response.body) {
+      throw await httpError(profile, response);
+    }
+
+    yield* wire.chunks(parseSse(response.body));
+  }
+}
+
+async function httpError(profile, response) {
+  let detail = '';
+  try {
+    detail = await response.text();
+  } catch {
+    /* 读不到响应体也要给出可用错误 */
+  }
+  const status = response.status;
+  const code = status === 401 || status === 403 ? 'AUTH' : status === 429 ? 'RATE_LIMIT' : 'PROVIDER';
+  const requestId =
+    response.headers?.get?.('x-request-id') || response.headers?.get?.('request-id') || undefined;
+
+  const retryAfter = response.headers?.get?.('retry-after');
+  let providerRetryAfterMs;
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds > 0) providerRetryAfterMs = seconds * 1000;
+  }
+
+  return new LlmError(
+    `${profile.name} 返回 ${status}${requestId ? `（request-id ${requestId}）` : ''}：${detail.slice(0, 500)}`,
+    code,
+    { status, requestId, providerRetryAfterMs },
+  );
+}

--- a/packages/dsh-llm-account-auth/src/blocks.js
+++ b/packages/dsh-llm-account-auth/src/blocks.js
@@ -1,0 +1,87 @@
+// 流式块索引与累积：把两家 provider 的增量事件归一到 dsh-llm 的 StreamChunk 协议。
+// StreamChunk 约定：block-start 开块 → 若干 *-delta（同 index 关联）→ block-end 携带完整块；
+// usage 先于 finish，且 finish 之后不再有任何块。
+
+import { CallId } from '@deepseek-ai/dsh-llm';
+
+export function createStreamBuilder() {
+  const byKey = new Map(); // 逻辑键（如 'text' / 'tool:0'）→ 块 index
+  const blocks = new Map(); // index → 可变草稿块
+  let next = 0;
+
+  /**
+   * 开块（幂等）：同一逻辑键复用同一 index。
+   * @returns {{index:number, isNew:boolean, blockType:string}} isNew 时由调用方 yield block-start。
+   */
+  function open(key, blockType) {
+    const known = byKey.get(key);
+    if (known !== undefined) return { index: known, isNew: false, blockType };
+    const index = next++;
+    byKey.set(key, index);
+    blocks.set(
+      index,
+      blockType === 'text'
+        ? { type: 'text', text: '' }
+        : blockType === 'reasoning'
+          ? { type: 'reasoning', text: '' }
+          : { type: 'tool-call', id: undefined, name: '', arguments: '' },
+    );
+    return { index, isNew: true, blockType };
+  }
+
+  function appendText(index, delta) {
+    const block = blocks.get(index);
+    if (block && typeof delta === 'string') block.text += delta;
+  }
+
+  function appendTool(index, { id, name, argumentsDelta }) {
+    const block = blocks.get(index);
+    if (!block || block.type !== 'tool-call') return;
+    if (id) block.id = CallId(id);
+    if (name) block.name += name;
+    if (argumentsDelta) block.arguments += argumentsDelta;
+  }
+
+  /** 已开块的 CallId（tool-call-delta 的必填字段）；未开块返回 undefined。 */
+  function idOf(index) {
+    return blocks.get(index)?.id;
+  }
+
+  /** 该逻辑键是否已开块。供显式 block-stop 事件判断，避免凭空建块。 */
+  function has(key) {
+    return byKey.has(key);
+  }
+
+  /** 取已开块的 index；未开块返回 undefined。 */
+  function indexOf(key) {
+    return byKey.get(key);
+  }
+
+  /**
+   * 收口单个块，返回 block-end（已关闭或未开块返回 null）。
+   * patch 用于 provider 在 done 事件里给出的**权威完整值**（如 Responses 的
+   * output_item.done 携带全文/完整参数），覆盖增量累积结果，避免截断。
+   */
+  function close(index, patch) {
+    const block = blocks.get(index);
+    if (!block) return null;
+    if (patch) {
+      for (const [key, value] of Object.entries(patch)) {
+        if (typeof value === 'string' && value) block[key] = value;
+      }
+    }
+    blocks.delete(index);
+    for (const [key, value] of byKey) if (value === index) byKey.delete(key);
+    return { type: 'block-end', index, block: { ...block } };
+  }
+
+  /** 按 index 升序收口所有仍未关闭的块（流结束兜底）。 */
+  function* closeAll() {
+    for (const index of [...blocks.keys()].sort((a, b) => a - b)) {
+      const chunk = close(index);
+      if (chunk) yield chunk;
+    }
+  }
+
+  return { open, appendText, appendTool, idOf, has, indexOf, close, closeAll };
+}

--- a/packages/dsh-llm-account-auth/src/credentials.js
+++ b/packages/dsh-llm-account-auth/src/credentials.js
@@ -1,0 +1,162 @@
+// 账户鉴权的凭据解析：环境变量覆盖 → CLI 本地凭据库（账户登录态）→ API Key 兜底。
+//
+// 设计依据（dsh-llm api-key 契约）：
+//   「a profile naming no credential authenticates through the provider's own
+//     ambient discovery or OAuth」——即设置 profile 里不写凭据，
+//     由 provider 自己 CLI 的本地登录态完成鉴权。本模块就是那条 ambient discovery 通道。
+
+import fs from 'node:fs/promises';
+import { LlmError } from '@deepseek-ai/dsh-llm';
+import { chatgptAccountId } from './openai-jwt.js';
+
+/** 按 'a.b.c' 路径取值，任一层缺失返回 undefined。 */
+function getPath(obj, keyPath) {
+  return keyPath.split('.').reduce((o, k) => (o == null ? undefined : o[k]), obj);
+}
+
+/**
+ * 判定一枚令牌是 API Key 还是账户 OAuth 令牌。
+ * 启发式：命中 provider 的 apiKeyPrefix 视为 API Key，其余（JWT 等）视为账户令牌。
+ */
+export function classifyToken(profile, token) {
+  if (profile.apiKeyPrefix && token.startsWith(profile.apiKeyPrefix)) return 'api-key';
+  return 'account';
+}
+
+/** 读一枚凭据文件，按候选键顺序取第一个非空字符串，并保留原文档供账户 id 提取。 */
+async function readFileToken(entry) {
+  let json;
+  try {
+    json = JSON.parse(await fs.readFile(entry.path(), 'utf8'));
+  } catch {
+    return null; // 文件不存在或不是 JSON：不是错误，只是这条路走不通。
+  }
+  for (const key of entry.keys) {
+    const value = getPath(json, key);
+    if (typeof value === 'string' && value.trim()) {
+      return { token: value.trim(), source: `${entry.path()}#${key}`, doc: json };
+    }
+  }
+  return null;
+}
+
+/**
+ * 给账户凭据补上账户 id（仅 account 模式且 profile 声明需要时）。
+ * codex 后端是 Cloudflare 前置的，缺账户 id 的请求会拿到 403，与令牌是否有效无关。
+ * 三级来源，先到先得：
+ *   ① env 覆盖（profile.accountIdEnv，如 DSH_OPENAI_CHATGPT_ACCOUNT_ID）
+ *   ② 凭据文档直存字段（profile.accountIdKeys，如 codex auth.json 的 tokens.account_id）
+ *   ③ JWT 载荷的 chatgpt_account_id claim（优先已选令牌，再扫文档里其他 JWT）
+ * 取不到返回 undefined 不抛错——宁可把请求发出去暴露真实的 403，也不在凭据阶段崩掉。
+ */
+function withAccountId(profile, credential, doc, env) {
+  if (credential.mode !== 'account' || !profile.requiresAccountId) return credential;
+
+  for (const name of profile.accountIdEnv || []) {
+    const value = env[name];
+    if (typeof value === 'string' && value.trim()) return { ...credential, accountId: value.trim() };
+  }
+
+  for (const key of profile.accountIdKeys || []) {
+    const value = getPath(doc, key);
+    if (typeof value === 'string' && value.trim()) return { ...credential, accountId: value.trim() };
+  }
+
+  for (const candidate of jwtCandidates(credential.token, doc)) {
+    const id = chatgptAccountId(candidate);
+    if (id) return { ...credential, accountId: id };
+  }
+  return credential;
+}
+
+/** 已选令牌优先，其后是凭据文档里所有形似 JWT 的字符串（auth.json 很小，限深扫描无妨）。 */
+function jwtCandidates(token, doc) {
+  const seen = new Set();
+  const candidates = [];
+  const push = (value) => {
+    if (
+      typeof value === 'string' &&
+      value.length > 20 &&
+      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\./.test(value) &&
+      !seen.has(value)
+    ) {
+      seen.add(value);
+      candidates.push(value);
+    }
+  };
+  push(token);
+  const walk = (node, depth) => {
+    if (node == null || depth > 5 || candidates.length >= 8) return;
+    if (typeof node === 'string') {
+      push(node);
+    } else if (Array.isArray(node)) {
+      for (const item of node) walk(item, depth + 1);
+    } else if (typeof node === 'object') {
+      for (const value of Object.values(node)) walk(value, depth + 1);
+    }
+  };
+  walk(doc, 0);
+  return candidates;
+}
+
+/**
+ * 解析一次调用要用的凭据。
+ * @returns {{mode:'api-key'|'account', token:string, source:string, accountId?:string}}
+ * @throws {LlmError} 三条路都没有凭据时抛 AUTH，文案给出可执行的修复指引。
+ */
+export async function resolveCredential(profile, env = process.env) {
+  // ① 账户令牌显式覆盖（最高优先级，便于测试与 CI）。
+  for (const name of profile.accountTokenEnv || []) {
+    const value = env[name];
+    if (typeof value === 'string' && value.trim()) {
+      return withAccountId(
+        profile,
+        { mode: 'account', token: value.trim(), source: `env:${name}` },
+        undefined,
+        env,
+      );
+    }
+  }
+
+  // ② CLI 本地凭据库：codex login / claude login 留下的登录态（账户鉴权主路径）。
+  for (const entry of profile.credentialFiles || []) {
+    const found = await readFileToken(entry);
+    if (found) {
+      // 模式判定：
+      //  · profile.accountOnly（如 OpenAI 账户模式，codex 后端）：文件来源一律视为账户凭据，
+      //    强制 account——绝不走 classifyToken 把 sk- 形令牌降级成 API Key 误打官方 API。
+      //  · entry.forceMode：键名结构已明确是账户登录态（如 claudeAiOauth.*）时直接声明，
+      //    跳过前缀启发式——Claude 的 OAuth 令牌（sk-ant-oat01-…）也以 sk-ant- 开头。
+      //  · 其余：按前缀启发式 classifyToken 兜底。
+      const mode = profile.accountOnly
+        ? 'account'
+        : (entry.forceMode ?? classifyToken(profile, found.token));
+      return withAccountId(
+        profile,
+        { mode, token: found.token, source: found.source },
+        found.doc,
+        env,
+      );
+    }
+  }
+
+  // ③ API Key 环境变量兜底——仅当 profile 允许退化时（非账户专用）。
+  // accountOnly（如 OpenAI 账户模式，codex 后端）禁止此兜底：拿 OPENAI_API_KEY 去打
+  // 官方 Chat Completions 端点语义错误且误导。账户凭据缺失就直接报 AUTH 引导重登录。
+  if (!profile.accountOnly) {
+    for (const name of profile.tokenEnv || []) {
+      const value = env[name];
+      if (typeof value === 'string' && value.trim()) {
+        return { mode: 'api-key', token: value.trim(), source: `env:${name}` };
+      }
+    }
+  }
+
+  const files = (profile.credentialFiles || []).map((e) => e.path()).join('、');
+  const loginHint = profile.accountOnly
+    ? `请运行 \`npx @openai/codex login\`（或 \`codex login\`）完成 ChatGPT 账户授权后重试；` +
+      `该模式走 codex 后端，不接受 OPENAI_API_KEY。`
+    : `请先完成账户登录（凭据文件：${files || '未配置'}），` +
+      `或设置 ${[...(profile.accountTokenEnv || []), ...(profile.tokenEnv || [])].join(' / ')}。`;
+  throw new LlmError(`${profile.name}：未找到可用的账户凭据。${loginHint}`, 'AUTH');
+}

--- a/packages/dsh-llm-account-auth/src/index.js
+++ b/packages/dsh-llm-account-auth/src/index.js
@@ -1,0 +1,47 @@
+// DSH 插件入口：把 openai / anthropic 两条账户鉴权路由注册进 ctx.llm。
+//
+// 注册后：
+//   · llm.listProviders() 会列出这两条路由 → vwf 编辑器节点模型下拉即可选中
+//     （client.js 的下拉项来自 listProviders，不是硬编码）；
+//   · 蓝图 bindings.models 里写 {"provider":"anthropic","model":"claude-sonnet-5"} 即可路由过来。
+//
+// 注册随调用 fiber 释放，无需手动 dispose。
+
+import { AccountAuthLlmAdapter } from './adapter.js';
+import { PROFILES, ROUTE_IDS } from './profiles.js';
+
+export const name = 'llm-account-auth';
+
+export { AccountAuthLlmAdapter, PROFILES, ROUTE_IDS };
+
+/**
+ * @param {object} ctx Cordis 上下文（DSH 宿主）。
+ * @param {{routes?: string[], fetch?: typeof globalThis.fetch, env?: NodeJS.ProcessEnv}} [config]
+ */
+export function apply(ctx, config = {}) {
+  // 与本仓库 vwf 插件一致的取服务方式（动态插件用 ctx.get，Cordis 风格也可直接 ctx.llm）。
+  const llm = ctx.get ? ctx.get('llm') : ctx.llm;
+  if (!llm) {
+    throw new Error('[llm-account-auth] 未取到 llm 服务：请在 dsh 插件环境中挂载');
+  }
+
+  const routes = config.routes ?? ROUTE_IDS;
+  const unknown = routes.filter((id) => !PROFILES[id]);
+  if (unknown.length) {
+    throw new Error(`[llm-account-auth] 未知路由：${unknown.join('、')}（可用：${ROUTE_IDS.join('、')}）`);
+  }
+
+  const adapter = new AccountAuthLlmAdapter(config);
+
+  try {
+    // all-or-nothing：任一条路由已被别的适配器占用则整批失败（DUPLICATE_ADAPTER）。
+    llm.registerAdapter(routes, adapter);
+  } catch (error) {
+    throw new Error(
+      `[llm-account-auth] 注册 ${routes.join('、')} 失败（可能已被其他适配器占用）：${error?.message ?? error}`,
+      { cause: error },
+    );
+  }
+}
+
+export default { name, apply };

--- a/packages/dsh-llm-account-auth/src/openai-jwt.js
+++ b/packages/dsh-llm-account-auth/src/openai-jwt.js
@@ -1,0 +1,40 @@
+// 从 ChatGPT OAuth 的 JWT 里取 chatgpt_account_id。
+//
+// 为什么必须取：chatgpt.com 的 codex 后端是 Cloudflare 前置的，缺少账户标识的
+// 请求会拿到 403（cf-mitigated: challenge），与凭据本身是否正确无关。
+// 账户 id 不在 auth.json 的顶层，而是**内嵌在 JWT 载荷**里：
+//   payload['https://api.openai.com/auth'].chatgpt_account_id
+//
+// 设计取舍：解析失败一律返回 undefined 而不抛错——拿不到账户 id 时宁可发一个
+// 可能被后端拒绝的请求，把真实的 403 暴露给用户，也不要在凭据解析阶段就崩掉。
+
+const ACCOUNT_CLAIM = 'https://api.openai.com/auth';
+
+function decodeSegment(segment) {
+  // JWT 段是 base64url（无填充）。Node 的 Buffer 也能吃 base64url。
+  return Buffer.from(segment, 'base64url').toString('utf8');
+}
+
+/** 取 JWT 的载荷对象；任何形态异常都返回 undefined（不抛）。 */
+export function decodeJwtPayload(token) {
+  if (typeof token !== 'string' || !token) return undefined;
+  const parts = token.split('.');
+  if (parts.length < 2 || !parts[1]) return undefined;
+  try {
+    const parsed = JSON.parse(decodeSegment(parts[1]));
+    return parsed && typeof parsed === 'object' ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * 取账户 id。命中返回字符串，否则 undefined。
+ * @param {string} token OAuth access_token / id_token
+ */
+export function chatgptAccountId(token) {
+  const payload = decodeJwtPayload(token);
+  const claim = payload?.[ACCOUNT_CLAIM];
+  const id = claim?.chatgpt_account_id;
+  return typeof id === 'string' && id.trim() ? id.trim() : undefined;
+}

--- a/packages/dsh-llm-account-auth/src/profiles.js
+++ b/packages/dsh-llm-account-auth/src/profiles.js
@@ -1,0 +1,92 @@
+// provider 画像：端点 / 凭据来源 / 鉴权方案 / 建议模型目录。
+//
+// 【需本机核实】账户模式（ChatGPT 账号、Claude 账号）的凭据文件布局与附加头部随 CLI 版本变化，
+// 首次接入请按 README「接入核验清单」逐项核对后回填 credentialFiles / accountHeaders。
+//
+// 【不臆造】本骨架不填写任何未经核实的能力数字：context（上下文窗口）一律留空，
+// 由 resolveModel 保持「未知容量」语义，避免把猜测值写进宿主决策。
+
+import os from 'node:os';
+import path from 'node:path';
+
+const home = () => os.homedir();
+
+export const PROFILES = {
+  openai: {
+    id: 'openai',
+    name: 'OpenAI',
+    wire: 'openai',
+    // API Key 模式：官方 API，Chat Completions 线格式（本骨架已实现）。
+    endpoint: { baseURL: 'https://api.openai.com/v1', path: '/chat/completions' },
+    // 账户模式：codex 的 ChatGPT 后端走 Responses 协议（wire-openai-responses.js）。
+    // 端点各版本有差异，允许用 DSH_OPENAI_ACCOUNT_BASE_URL / DSH_OPENAI_ACCOUNT_PATH
+    // 在调用时覆盖，便于上机试错时不必改代码。
+    accountEndpoint: { baseURL: 'https://chatgpt.com/backend-api/codex', path: '/responses' },
+    accountWireSupported: true,
+    // 账户专用：codex 后端（chatgpt.com）根本不接受 OPENAI_API_KEY，
+    // 与 OpenAI 官方 API（api.openai.com 走 Chat Completions）是两套鉴权体系。
+    // 因此不能退化到 API Key 兜底——否则退出登录后会拿 OPENAI_API_KEY 误打官方 API，
+    // 报出误导性的「API key is invalid」（实测踩中）。未找到账户凭据时直接报 AUTH 引导重登录。
+    // 纯 API Key（Chat Completions）模式若需保留，应另立独立 provider，而非从账户模式退化。
+    accountOnly: true,
+    // 账户 id（chatgpt_account_id）：codex 后端必需，缺失会被 Cloudflare 403。
+    // 三级来源：env 覆盖 > auth.json 直存键 > JWT 载荷 claim（见 credentials.js withAccountId）。
+    requiresAccountId: true,
+    accountIdEnv: ['DSH_OPENAI_CHATGPT_ACCOUNT_ID', 'CHATGPT_ACCOUNT_ID'],
+    accountIdKeys: ['tokens.account_id', 'account_id'],
+    apiKeyPrefix: 'sk-',
+    tokenEnv: ['OPENAI_API_KEY'],
+    accountTokenEnv: ['DSH_OPENAI_ACCOUNT_TOKEN', 'CODEX_ACCESS_TOKEN'],
+    credentialFiles: [
+      {
+        // codex 登录态只含账户令牌（tokens.access_token / tokens.id_token 为 JWT），
+        // 绝不包含 OPENAI_API_KEY——该字段若出现在 auth.json 里也不应被当凭据读，
+        // 否则会被误判成 API Key 退化为官方 API（见 accountOnly 守卫）。
+        path: () => path.join(process.env.CODEX_HOME || path.join(home(), '.codex'), 'auth.json'),
+        keys: ['access_token', 'tokens.access_token', 'tokens.id_token'],
+      },
+    ],
+    headers: {},
+    accountHeaders: {},
+    // ChatGPT 账户模式下可选模型（用户 2026-09-03 核实：gpt-5.6 已拆为 sol/terra/luna 三档，
+    // 另有 5.5 / 5.4）。目录为建议性，DSH 不因此拒绝未列出的 model id；真实可用集以
+    // codex 后端 GET /models?client_version= 枚举为准，上机若遇 404 以该枚举回填。
+    models: ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4'],
+  },
+
+  anthropic: {
+    id: 'anthropic',
+    name: 'Anthropic',
+    wire: 'anthropic',
+    // API Key 与账户（Claude 账号 OAuth）模式同端点、同线格式，
+    // 差别只在鉴权头部与 anthropic-beta——账户模式已可用。
+    endpoint: { baseURL: 'https://api.anthropic.com/v1', path: '/messages' },
+    accountEndpoint: { baseURL: 'https://api.anthropic.com/v1', path: '/messages' },
+    accountWireSupported: true,
+    apiKeyPrefix: 'sk-ant-',
+    tokenEnv: ['ANTHROPIC_API_KEY'],
+    accountTokenEnv: ['DSH_ANTHROPIC_ACCOUNT_TOKEN', 'CLAUDE_ACCESS_TOKEN'],
+    credentialFiles: [
+      {
+        path: () => path.join(home(), '.claude', '.credentials.json'),
+        keys: ['claudeAiOauth.accessToken', 'accessToken', 'oauthToken'],
+        // claudeAiOauth.* 键就是 OAuth 登录态；其令牌（sk-ant-oat01-…）以 sk-ant- 开头，
+        // 不声明会被 apiKeyPrefix 误判成 API Key（本机已实测踩中）。
+        forceMode: 'account',
+      },
+      {
+        path: () => path.join(home(), '.claude.json'),
+        keys: ['claudeAiOauth.accessToken', 'oauthToken'],
+        forceMode: 'account',
+      },
+    ],
+    headers: { 'anthropic-version': '2023-06-01' },
+    // 账户（OAuth）模式必需的 beta 头；Claude CLI 走的即此路径。
+    accountHeaders: { 'anthropic-version': '2023-06-01', 'anthropic-beta': 'oauth-2025-04-20' },
+    // Anthropic 的 max_tokens 是必填项；这是请求级输出上限，不是模型硬上限。
+    defaultMaxTokens: 8192,
+    models: ['claude-sonnet-5', 'claude-opus-5'],
+  },
+};
+
+export const ROUTE_IDS = Object.keys(PROFILES);

--- a/packages/dsh-llm-account-auth/src/sse.js
+++ b/packages/dsh-llm-account-auth/src/sse.js
@@ -1,0 +1,55 @@
+// 零依赖 SSE 解析器：把 Response.body 读成 {event, data} 帧流。
+// 仅覆盖 LLM 流式响应用到的子集（data / event 字段、注释行、[DONE] 哨兵）。
+
+/**
+ * @param {ReadableStream<Uint8Array>} body
+ * @yields {{event:string, data:string}}
+ */
+export async function* parseSse(body) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const flush = function* (final) {
+    if (!buffer.trim()) return;
+    const frame = parseFrame(buffer);
+    buffer = '';
+    if (frame) yield frame;
+    if (final) return;
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let sep;
+      while ((sep = buffer.indexOf('\n\n')) !== -1) {
+        const frameText = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        const frame = parseFrame(frameText);
+        if (frame) yield frame;
+      }
+    }
+    yield* flush(true);
+  } finally {
+    reader.releaseLock?.();
+  }
+}
+
+function parseFrame(frameText) {
+  let event = 'message';
+  const data = [];
+  for (const rawLine of frameText.split('\n')) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    if (!line || line.startsWith(':')) continue;
+    const idx = line.indexOf(':');
+    const field = idx === -1 ? line : line.slice(0, idx);
+    let value = idx === -1 ? '' : line.slice(idx + 1);
+    if (value.startsWith(' ')) value = value.slice(1);
+    if (field === 'event') event = value;
+    else if (field === 'data') data.push(value);
+  }
+  if (!data.length) return null;
+  return { event, data: data.join('\n') };
+}

--- a/packages/dsh-llm-account-auth/src/wire-anthropic.js
+++ b/packages/dsh-llm-account-auth/src/wire-anthropic.js
@@ -1,0 +1,197 @@
+// Anthropic Messages 线格式（流式）。
+// 覆盖：API Key 模式与账户（Claude 账号 OAuth）模式——两者同端点、同线格式，
+// 差别只在鉴权头：账户模式用 Bearer + anthropic-beta: oauth-2025-04-20（Claude CLI 即此路径）。
+
+import { attributionHeaders } from '@deepseek-ai/dsh-llm';
+import { createStreamBuilder } from './blocks.js';
+
+/** 两种模式同端点、同线格式，只按凭据模式换鉴权头，故此处忽略 credential。 */
+export function anthropicWire() {
+  return { request: anthropicRequest, chunks: anthropicChunks };
+}
+
+export function anthropicRequest(profile, options, credential) {
+  const target = credential.mode === 'account' ? profile.accountEndpoint : profile.endpoint;
+  const url = `${target.baseURL.replace(/\/+$/, '')}${target.path}`;
+
+  const headers = {
+    'content-type': 'application/json',
+    accept: 'text/event-stream',
+    ...attributionHeaders(),
+    ...(credential.mode === 'account' ? profile.accountHeaders : profile.headers),
+  };
+  // Anthropic：API Key 走 x-api-key，账户 OAuth 令牌走 Authorization: Bearer。
+  if (credential.mode === 'account') headers.authorization = `Bearer ${credential.token}`;
+  else headers['x-api-key'] = credential.token;
+
+  const body = {
+    model: options.model,
+    stream: true,
+    // max_tokens 是 Anthropic 必填项；这里是请求级输出上限，不是模型硬上限。
+    max_tokens: options.maxTokens ?? profile.defaultMaxTokens ?? 8192,
+    messages: toMessages(options),
+  };
+  if (options.system) body.system = options.system;
+  if (options.tools?.length) {
+    body.tools = options.tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      input_schema: t.parameters,
+    }));
+  }
+  if (options.temperature != null) body.temperature = options.temperature;
+  if (options.stop?.length) body.stop_sequences = options.stop;
+
+  return { url, headers, body };
+}
+
+function textOf(blocks) {
+  return (blocks || [])
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}
+
+function parseArguments(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {}; // 模型可能吐出不完整 JSON；交给 provider 侧报错而不是在此崩溃。
+  }
+}
+
+function toMessages(options) {
+  const out = [];
+  for (const message of options.messages) {
+    if (message.role === 'system') continue; // system 走顶层字段。
+    const content = [];
+    for (const block of message.content || []) {
+      if (block.type === 'text') content.push({ type: 'text', text: block.text });
+      else if (block.type === 'reasoning') content.push({ type: 'thinking', thinking: block.text });
+      else if (block.type === 'tool-call') {
+        content.push({ type: 'tool_use', id: block.id, name: block.name, input: parseArguments(block.arguments) });
+      } else if (block.type === 'tool-result') {
+        content.push({
+          type: 'tool_result',
+          tool_use_id: block.toolCallId,
+          content: textOf(block.content),
+          ...(block.isError ? { is_error: true } : {}),
+        });
+      }
+    }
+    if (content.length) out.push({ role: message.role === 'assistant' ? 'assistant' : 'user', content });
+  }
+  return out;
+}
+
+const STOP = {
+  end_turn: 'stop',
+  stop_sequence: 'stop',
+  tool_use: 'tool-calls',
+  max_tokens: 'max-tokens',
+};
+
+/**
+ * SSE 帧流 → dsh-llm StreamChunk 流。
+ * @param {AsyncIterable<{event:string,data:string}>} frames
+ */
+export async function* anthropicChunks(frames) {
+  const builder = createStreamBuilder();
+  const usage = { inputTokens: 0, outputTokens: 0 };
+  let reason = { kind: 'stop' };
+
+  for await (const frame of frames) {
+    let event;
+    try {
+      event = JSON.parse(frame.data);
+    } catch {
+      continue;
+    }
+
+    switch (event.type) {
+      case 'message_start': {
+        const u = event.message?.usage || {};
+        usage.inputTokens = u.input_tokens ?? 0;
+        if (u.cache_read_input_tokens) usage.cacheReadTokens = u.cache_read_input_tokens;
+        if (u.cache_creation_input_tokens) usage.cacheWriteTokens = u.cache_creation_input_tokens;
+        break;
+      }
+
+      case 'content_block_start': {
+        const block = event.content_block || {};
+        const key = `block:${event.index}`;
+        if (block.type === 'text') {
+          const { index, isNew } = builder.open(key, 'text');
+          if (isNew) yield { type: 'block-start', index, blockType: 'text' };
+        } else if (block.type === 'thinking') {
+          const { index, isNew } = builder.open(key, 'reasoning');
+          if (isNew) yield { type: 'block-start', index, blockType: 'reasoning' };
+        } else if (block.type === 'tool_use') {
+          const { index, isNew } = builder.open(key, 'tool-call');
+          if (isNew) yield { type: 'block-start', index, blockType: 'tool-call' };
+          builder.appendTool(index, { id: block.id, name: block.name, argumentsDelta: '' });
+        }
+        break;
+      }
+
+      case 'content_block_delta': {
+        const delta = event.delta || {};
+        const key = `block:${event.index}`;
+        if (delta.type === 'text_delta') {
+          const { index, isNew } = builder.open(key, 'text');
+          if (isNew) yield { type: 'block-start', index, blockType: 'text' };
+          builder.appendText(index, delta.text);
+          yield { type: 'text-delta', index, text: delta.text };
+        } else if (delta.type === 'thinking_delta') {
+          const { index, isNew } = builder.open(key, 'reasoning');
+          if (isNew) yield { type: 'block-start', index, blockType: 'reasoning' };
+          builder.appendText(index, delta.thinking);
+          yield { type: 'reasoning-delta', index, text: delta.thinking };
+        } else if (delta.type === 'input_json_delta') {
+          const { index, isNew } = builder.open(key, 'tool-call');
+          if (isNew) yield { type: 'block-start', index, blockType: 'tool-call' };
+          builder.appendTool(index, { argumentsDelta: delta.partial_json });
+          yield {
+            type: 'tool-call-delta',
+            index,
+            id: builder.idOf(index) ?? '',
+            argumentsDelta: delta.partial_json,
+          };
+        }
+        break;
+      }
+
+      case 'content_block_stop': {
+        // 只收口已开块：避免 provider 单独下发 stop 时凭空建出一个空文本块。
+        const index = builder.indexOf(`block:${event.index}`);
+        if (index !== undefined) {
+          const chunk = builder.close(index);
+          if (chunk) yield chunk;
+        }
+        break;
+      }
+
+      case 'message_delta': {
+        if (event.usage?.output_tokens != null) usage.outputTokens = event.usage.output_tokens;
+        if (event.delta?.stop_reason) reason = { kind: STOP[event.delta.stop_reason] ?? 'stop' };
+        break;
+      }
+
+      case 'message_stop':
+        break;
+
+      case 'error':
+        throw Object.assign(new Error(event.error?.message || 'anthropic stream error'), {
+          code: 'PROVIDER',
+          status: event.error?.status,
+        });
+
+      default:
+        break;
+    }
+  }
+
+  yield* builder.closeAll(); // 收口兜底。
+  yield { type: 'usage', usage };
+  yield { type: 'finish', reason };
+}

--- a/packages/dsh-llm-account-auth/src/wire-openai-responses.js
+++ b/packages/dsh-llm-account-auth/src/wire-openai-responses.js
@@ -1,0 +1,329 @@
+// OpenAI Responses 线格式（流式）——ChatGPT 账户（codex 后端）模式。
+//
+// 与 Chat Completions 的四点不同：
+//   · 端点与鉴权：chatgpt.com/backend-api/codex/responses + Bearer 账户令牌 + chatgpt-account-id
+//   · 请求体：instructions/input/tools 扁平化（tool 无 function 包装），store:false，
+//     采样参数（max_output_tokens 等）默认剔除——codex 后端拒收
+//   · 必需头：originator / openai-beta / session_id / chatgpt-account-id
+//   · 事件流：response.* 事件族，块生命周期由 output_item.added/done 划定，
+//     done 事件携带权威完整值（覆盖增量累积，防截断）
+//
+// 头部事实来自公开逆向记录（codex CLI / opencode / hermes-agent），个别字段说法相互矛盾
+// （如 User-Agent），已做成 env 开关，见 README「接入核验清单」逐项上机核实。
+
+import { randomUUID } from 'node:crypto';
+import { attributionHeaders } from '@deepseek-ai/dsh-llm';
+import { createStreamBuilder } from './blocks.js';
+import { chatgptAccountId } from './openai-jwt.js';
+
+// codex 后端要求 instructions 非空；无 system 时补一条中性默认，避免整个请求被拒。
+const FALLBACK_INSTRUCTIONS = 'You are a helpful assistant.';
+
+// 账户 id 的 env 覆盖键（与 credentials.js 保持同一组，调用侧最后一手覆盖）。
+const ACCOUNT_ID_ENV = ['DSH_OPENAI_CHATGPT_ACCOUNT_ID', 'CHATGPT_ACCOUNT_ID'];
+
+/**
+ * 构造 Responses 请求。
+ * @param {object} profile PROFILES.openai（含 accountEndpoint / accountHeaders）
+ * @param {object} options dsh-llm 调用选项（model/messages/system/tools/maxTokens…）
+ * @param {{mode:'account', token:string, accountId?:string}} credential
+ * @param {NodeJS.ProcessEnv} env
+ */
+export function responsesRequest(profile, options, credential, env = process.env) {
+  if (credential.mode !== 'account') {
+    // 防御性守卫：API Key 模式走 Chat Completions，不应路由到这里。
+    throw new Error('openai-responses wire 只服务账户模式；API Key 模式请用 openai wire');
+  }
+
+  const url = accountUrl(profile, env);
+  const accountId = resolveAccountId(credential, env);
+
+  const headers = {
+    'content-type': 'application/json',
+    accept: 'text/event-stream',
+    ...attributionHeaders(),
+    ...(profile.accountHeaders || {}),
+    authorization: `Bearer ${credential.token}`,
+    // codex 后端（Cloudflare 前置）必需的协议头：
+    'openai-beta': 'responses=experimental',
+    // Cloudflare 只放行一小撮第一方 originator，codex_cli_rs 是其中之一。
+    originator: 'codex_cli_rs',
+    // 每次请求新的 UUID v4（codex CLI 的会话语义）。
+    session_id: randomUUID(),
+    // 文档记录的规范大小写是 ChatGPT-Account-ID；HTTP 头名不区分大小写，
+    // 这里统一小写，若上机核实后端挑剔再改（README 核验项）。
+    ...(accountId ? { 'chatgpt-account-id': accountId } : {}),
+  };
+  applyUserAgent(headers, env);
+
+  const body = {
+    model: options.model,
+    stream: true,
+    // codex 后端要求不落服务端存储，且仅接受 stream:true + store:false 组合。
+    store: false,
+    // 必填非空；input 必须是 item 数组（不接受字符串简写）。
+    instructions: options.system || FALLBACK_INSTRUCTIONS,
+    input: toInputItems(options),
+  };
+
+  if (options.tools?.length) {
+    // Responses 的 tools 是扁平结构（没有 function 包装）；strict schema 校验关闭，
+    // 用户自带的 tool schema 未必满足 strict 模式的全部要求。
+    body.tools = options.tools.map((t) => ({
+      type: 'function',
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+      strict: false,
+    }));
+    body.tool_choice = 'auto';
+  }
+
+  // codex 后端拒收采样参数（max_output_tokens / temperature / top_p / … 实测 400）。
+  // 默认剔除；用 env 把端点指到官方 Responses（api.openai.com/v1/responses）等
+  // 接受采样参数的目标时，可放行。
+  if (env.DSH_OPENAI_ACCOUNT_ALLOW_SAMPLING === '1') {
+    if (options.maxTokens != null) body.max_output_tokens = options.maxTokens;
+    if (options.temperature != null) body.temperature = options.temperature;
+    if (options.stop?.length) body.stop = options.stop;
+  }
+
+  return { url, headers, body };
+}
+
+/** 端点：允许 env 覆盖（上机试错不改代码），默认 codex 后端。 */
+function accountUrl(profile, env) {
+  const baseURL = env.DSH_OPENAI_ACCOUNT_BASE_URL || profile.accountEndpoint.baseURL;
+  const path = env.DSH_OPENAI_ACCOUNT_PATH || profile.accountEndpoint.path;
+  return `${baseURL.replace(/\/+$/, '')}${path}`;
+}
+
+/**
+ * 账户 id 来源优先级：env 显式覆盖 → 凭据解析阶段提取的 credential.accountId
+ * （credentials.js：env > 凭据文档直存键 > JWT 载荷 claim）→ 已选令牌自身的 JWT 载荷。
+ * 取不到返回 undefined，不阻断请求——宁可发出去吃真实的 403，也不在这里崩。
+ */
+function resolveAccountId(credential, env) {
+  for (const name of ACCOUNT_ID_ENV) {
+    const value = env[name];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  if (credential.accountId) return credential.accountId;
+  return chatgptAccountId(credential.token);
+}
+
+/**
+ * User-Agent 三档开关（核验点：opencode 记录说后端见不得第三方 UA，
+ * hermes-agent 却要求 codex_cli_rs/ 前缀——矛盾，用 env 让上机试错）：
+ *   omit（默认）剔除 attribution 注入的 UA
+ *   codex        伪装 codex CLI 的 UA
+ *   dsh          保留 dsh-llm attributionHeaders() 的 UA
+ */
+function applyUserAgent(headers, env) {
+  const mode = (env.DSH_OPENAI_ACCOUNT_USER_AGENT || 'omit').toLowerCase();
+  if (mode === 'codex') {
+    headers['user-agent'] = 'codex_cli_rs/0.0.0';
+  } else if (mode !== 'dsh') {
+    delete headers['user-agent'];
+  }
+}
+
+function textOf(blocks) {
+  return (blocks || [])
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}
+
+function toInputItems(options) {
+  const items = [];
+  for (const message of options.messages) {
+    const blocks = message.content || [];
+
+    if (message.role === 'assistant') {
+      const text = textOf(blocks);
+      if (text) {
+        items.push({ type: 'message', role: 'assistant', content: [{ type: 'output_text', text }] });
+      }
+      for (const block of blocks) {
+        if (block.type === 'tool-call') {
+          items.push({ type: 'function_call', call_id: block.id, name: block.name, arguments: block.arguments });
+        }
+      }
+      continue;
+    }
+
+    // user / system：system 走顶层 instructions，这里只处理 user。
+    if (message.role === 'system') continue;
+    for (const block of blocks) {
+      if (block.type === 'tool-result') {
+        items.push({ type: 'function_call_output', call_id: block.toolCallId, output: textOf(block.content) || '' });
+      }
+    }
+    const texts = blocks.filter((b) => b.type === 'text');
+    if (texts.length) {
+      items.push({
+        type: 'message',
+        role: 'user',
+        content: texts.map((b) => ({ type: 'input_text', text: b.text })),
+      });
+    }
+  }
+  return items;
+}
+
+/**
+ * dsh-llm 契约：counts 互斥——inputTokens 只计未缓存输入。
+ * Responses 的 usage 与 Chat Completions 同约定：input_tokens 含缓存命中，扣掉单报；
+ * reasoning_tokens 是 output_tokens 的子集明细（同 DeepSeek completion 约定），不扣减。
+ */
+function toUsage(usage) {
+  if (!usage) return undefined;
+  const cached = usage.input_tokens_details?.cached_tokens ?? 0;
+  return {
+    inputTokens: Math.max(0, (usage.input_tokens ?? 0) - cached),
+    outputTokens: usage.output_tokens ?? 0,
+    ...(cached ? { cacheReadTokens: cached } : {}),
+    ...(usage.output_tokens_details?.reasoning_tokens
+      ? { reasoningTokens: usage.output_tokens_details.reasoning_tokens }
+      : {}),
+  };
+}
+
+/** output_item.done 携带的权威完整值；没有就保持增量累积结果。 */
+function donePatch(item) {
+  if (item.type === 'function_call') {
+    const patch = {};
+    if (typeof item.arguments === 'string' && item.arguments) patch.arguments = item.arguments;
+    if (item.call_id) patch.id = item.call_id;
+    return Object.keys(patch).length ? patch : undefined;
+  }
+  if (item.type === 'message') {
+    const text = (item.content || []).find((c) => c.type === 'output_text')?.text;
+    return typeof text === 'string' && text ? { text } : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * response.* 事件流 → dsh-llm StreamChunk 流。
+ * @param {AsyncIterable<{event:string,data:string}>} frames
+ */
+export async function* responsesChunks(frames) {
+  const builder = createStreamBuilder();
+  let usage;
+  let status;
+  let incompleteReason;
+  let sawToolCall = false;
+
+  for await (const frame of frames) {
+    if (frame.data === '[DONE]') break;
+    let event;
+    try {
+      event = JSON.parse(frame.data);
+    } catch {
+      continue; // 非 JSON 帧忽略（心跳、注释）。
+    }
+    const type = event.type || frame.event;
+
+    switch (type) {
+      case 'response.output_item.added': {
+        const item = event.item || {};
+        const key = `item:${item.id}`;
+        if (item.type === 'function_call') {
+          const { index, isNew } = builder.open(key, 'tool-call');
+          sawToolCall = true;
+          if (isNew) yield { type: 'block-start', index, blockType: 'tool-call' };
+          // call_id 是与 function_call_output 配对的调用 id；item.id 只是事件流标识。
+          builder.appendTool(index, { id: item.call_id ?? item.id, name: item.name, argumentsDelta: '' });
+        } else if (item.type === 'reasoning') {
+          const { index, isNew } = builder.open(key, 'reasoning');
+          if (isNew) yield { type: 'block-start', index, blockType: 'reasoning' };
+        } else if (item.type === 'message') {
+          const { index, isNew } = builder.open(key, 'text');
+          if (isNew) yield { type: 'block-start', index, blockType: 'text' };
+        }
+        break;
+      }
+
+      case 'response.output_text.delta': {
+        const { index, isNew } = builder.open(`item:${event.item_id}`, 'text');
+        if (isNew) yield { type: 'block-start', index, blockType: 'text' };
+        builder.appendText(index, event.delta);
+        yield { type: 'text-delta', index, text: event.delta };
+        break;
+      }
+
+      // 原始推理文本与摘要文本都归入同一 reasoning 块（按 item 聚合）。
+      case 'response.reasoning_text.delta':
+      case 'response.reasoning_summary_text.delta': {
+        const { index, isNew } = builder.open(`item:${event.item_id}`, 'reasoning');
+        if (isNew) yield { type: 'block-start', index, blockType: 'reasoning' };
+        builder.appendText(index, event.delta);
+        yield { type: 'reasoning-delta', index, text: event.delta };
+        break;
+      }
+
+      case 'response.function_call_arguments.delta': {
+        const { index, isNew } = builder.open(`item:${event.item_id}`, 'tool-call');
+        if (isNew) {
+          sawToolCall = true;
+          yield { type: 'block-start', index, blockType: 'tool-call' };
+        }
+        builder.appendTool(index, { argumentsDelta: event.delta });
+        yield {
+          type: 'tool-call-delta',
+          index,
+          id: builder.idOf(index) ?? '',
+          argumentsDelta: event.delta,
+        };
+        break;
+      }
+
+      case 'response.output_item.done': {
+        const item = event.item || {};
+        const index = builder.indexOf(`item:${item.id}`);
+        if (index !== undefined) {
+          const chunk = builder.close(index, donePatch(item));
+          if (chunk) yield chunk;
+        }
+        break;
+      }
+
+      case 'response.completed': {
+        usage = toUsage(event.response?.usage) ?? usage;
+        status = event.response?.status ?? 'completed';
+        break;
+      }
+
+      case 'response.incomplete': {
+        usage = toUsage(event.response?.usage) ?? usage;
+        status = 'incomplete';
+        incompleteReason = event.response?.incomplete_details?.reason;
+        break;
+      }
+
+      case 'response.failed':
+      case 'response.error': {
+        const error = event.response?.error || event.error || {};
+        throw Object.assign(new Error(error.message || 'openai responses stream error'), {
+          code: 'PROVIDER',
+          status: error.status,
+        });
+      }
+
+      default:
+        break;
+    }
+  }
+
+  yield* builder.closeAll(); // 收口兜底：异常截断的流也要补齐 block-end。
+  if (usage) yield { type: 'usage', usage };
+  const kind =
+    status === 'incomplete' && incompleteReason === 'max_output_tokens'
+      ? 'max-tokens'
+      : sawToolCall
+        ? 'tool-calls'
+        : 'stop';
+  yield { type: 'finish', reason: { kind } };
+}

--- a/packages/dsh-llm-account-auth/src/wire-openai.js
+++ b/packages/dsh-llm-account-auth/src/wire-openai.js
@@ -1,0 +1,171 @@
+// OpenAI Chat Completions 线格式（流式）——API Key 模式走这条。
+// 账户（ChatGPT 账号令牌）模式走 Responses 协议，见 wire-openai-responses.js；
+// openaiWire() 按凭据模式分发。
+
+import { attributionHeaders } from '@deepseek-ai/dsh-llm';
+import { createStreamBuilder } from './blocks.js';
+import { responsesRequest, responsesChunks } from './wire-openai-responses.js';
+
+/** 按凭据模式选择线格式。 */
+export function openaiWire(credential) {
+  return credential.mode === 'account'
+    ? { request: responsesRequest, chunks: responsesChunks }
+    : { request: chatRequest, chunks: chatChunks };
+}
+
+export function chatRequest(profile, options, credential) {
+  const target = profile.endpoint;
+  const url = `${target.baseURL.replace(/\/+$/, '')}${target.path}`;
+
+  const headers = {
+    'content-type': 'application/json',
+    accept: 'text/event-stream',
+    ...attributionHeaders(),
+    ...(profile.headers || {}),
+    authorization: `Bearer ${credential.token}`,
+  };
+
+  const body = {
+    model: options.model,
+    stream: true,
+    // 让 usage 以独立 chunk 下发（位于 finish_reason 之后、流结束之前）。
+    stream_options: { include_usage: true },
+    messages: toMessages(options),
+  };
+  if (options.tools?.length) {
+    body.tools = options.tools.map((t) => ({
+      type: 'function',
+      function: { name: t.name, description: t.description, parameters: t.parameters },
+    }));
+  }
+  if (options.temperature != null) body.temperature = options.temperature;
+  if (options.maxTokens != null) body.max_tokens = options.maxTokens;
+  if (options.stop?.length) body.stop = options.stop;
+
+  return { url, headers, body };
+}
+
+function textOf(blocks) {
+  return (blocks || [])
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}
+
+function toMessages(options) {
+  const out = [];
+  if (options.system) out.push({ role: 'system', content: options.system });
+
+  for (const message of options.messages) {
+    if (message.role === 'system') {
+      out.push({ role: 'system', content: textOf(message.content) });
+      continue;
+    }
+    if (message.role === 'assistant') {
+      const text = textOf(message.content);
+      const calls = (message.content || []).filter((b) => b.type === 'tool-call');
+      const item = { role: 'assistant' };
+      if (text) item.content = text;
+      if (calls.length) {
+        item.tool_calls = calls.map((c) => ({
+          id: c.id,
+          type: 'function',
+          function: { name: c.name, arguments: c.arguments },
+        }));
+      }
+      if (!item.content && !item.tool_calls) item.content = '';
+      out.push(item);
+      continue;
+    }
+    // user：工具结果必须独立成 tool 角色消息，其余内容合成一条 user 消息。
+    const results = (message.content || []).filter((b) => b.type === 'tool-result');
+    for (const result of results) {
+      out.push({
+        role: 'tool',
+        tool_call_id: result.toolCallId,
+        content: textOf(result.content) || '',
+      });
+    }
+    const rest = (message.content || []).filter((b) => b.type !== 'tool-result');
+    if (rest.length) out.push({ role: 'user', content: textOf(rest) });
+  }
+  return out;
+}
+
+const FINISH = { stop: 'stop', tool_calls: 'tool-calls', length: 'max-tokens', content_filter: 'stop' };
+
+/**
+ * SSE 帧流 → dsh-llm StreamChunk 流。
+ * @param {AsyncIterable<{event:string,data:string}>} frames
+ */
+export async function* chatChunks(frames) {
+  const builder = createStreamBuilder();
+  let usage;
+  let reason = { kind: 'stop' };
+
+  for await (const frame of frames) {
+    if (frame.data === '[DONE]') break;
+    let chunk;
+    try {
+      chunk = JSON.parse(frame.data);
+    } catch {
+      continue; // 非 JSON 帧忽略（心跳、注释）。
+    }
+
+    if (chunk.usage) {
+      // 计数互斥契约：prompt_tokens 含缓存，故扣掉 cached_tokens 后再报 inputTokens。
+      const cached = chunk.usage.prompt_tokens_details?.cached_tokens ?? 0;
+      usage = {
+        inputTokens: Math.max(0, (chunk.usage.prompt_tokens ?? 0) - cached),
+        outputTokens: chunk.usage.completion_tokens ?? 0,
+        ...(cached ? { cacheReadTokens: cached } : {}),
+      };
+    }
+
+    const choice = chunk.choices?.[0];
+    if (!choice) continue;
+    const delta = choice.delta || {};
+
+    if (typeof delta.content === 'string' && delta.content) {
+      const { index, isNew } = builder.open('text', 'text');
+      if (isNew) yield { type: 'block-start', index, blockType: 'text' };
+      builder.appendText(index, delta.content);
+      yield { type: 'text-delta', index, text: delta.content };
+    }
+
+    const reasoning = delta.reasoning_content ?? delta.reasoning;
+    if (typeof reasoning === 'string' && reasoning) {
+      const { index, isNew } = builder.open('reasoning', 'reasoning');
+      if (isNew) yield { type: 'block-start', index, blockType: 'reasoning' };
+      builder.appendText(index, reasoning);
+      yield { type: 'reasoning-delta', index, text: reasoning };
+    }
+
+    for (const call of delta.tool_calls || []) {
+      const key = `tool:${call.index ?? 0}`;
+      const { index, isNew } = builder.open(key, 'tool-call');
+      if (isNew) yield { type: 'block-start', index, blockType: 'tool-call' };
+      builder.appendTool(index, {
+        id: call.id,
+        name: call.function?.name,
+        argumentsDelta: call.function?.arguments,
+      });
+      yield {
+        type: 'tool-call-delta',
+        index,
+        id: call.id ?? '',
+        ...(call.function?.name ? { name: call.function.name } : {}),
+        argumentsDelta: call.function?.arguments ?? '',
+      };
+    }
+
+    if (choice.finish_reason) {
+      yield* builder.closeAll();
+      reason = { kind: FINISH[choice.finish_reason] ?? 'stop' };
+    }
+  }
+
+  yield* builder.closeAll(); // 收口兜底：provider 未给 finish_reason 时也补齐 block-end。
+  if (usage) yield { type: 'usage', usage };
+  yield { type: 'finish', reason };
+}

--- a/packages/dsh-llm-account-auth/tests/adapter.test.mjs
+++ b/packages/dsh-llm-account-auth/tests/adapter.test.mjs
@@ -1,0 +1,440 @@
+// 离线冒烟：用桩 fetch 验证 StreamChunk 协议与鉴权头，不依赖真实凭据与网络。
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AccountAuthLlmAdapter } from '../src/adapter.js';
+import { resolveCredential, classifyToken } from '../src/credentials.js';
+import { PROFILES } from '../src/profiles.js';
+import { responsesRequest } from '../src/wire-openai-responses.js';
+import { apply } from '../src/index.js';
+
+const JWT_CLAIM = 'https://api.openai.com/auth';
+
+/** 造一枚带指定载荷的 JWT 形状令牌（签名段不校验，仅走解析路径）。 */
+function makeJwt(payload) {
+  const b64 = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${b64({ alg: 'none' })}.${b64(payload)}.sig`;
+}
+
+/** 把 SSE 帧数组变成 Response 形状的桩。 */
+function sseResponse(frames, { tail = 'data: [DONE]\n\n' } = {}) {
+  const text =
+    frames.map((f) => `event: ${f.event ?? 'message'}\ndata: ${JSON.stringify(f.data)}\n\n`).join('') +
+    tail;
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+  return { ok: true, status: 200, headers: new Headers(), body, text: async () => text };
+}
+
+async function collect(gen) {
+  const out = [];
+  for await (const chunk of gen) out.push(chunk);
+  return out;
+}
+
+const BASE = {
+  provider: 'openai',
+  model: 'gpt-5.6',
+  messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+};
+
+test('openai · API Key 模式产出规范的文本块流', async () => {
+  let seen;
+  const adapter = new AccountAuthLlmAdapter({
+    env: { OPENAI_API_KEY: 'sk-test' },
+    resolveCredential: async () => ({ mode: 'api-key', token: 'sk-test', source: 'test' }),
+    fetch: async (url, init) => {
+      seen = { url, init };
+      return sseResponse([
+        { data: { choices: [{ delta: { role: 'assistant', content: '你好' } }] } },
+        { data: { choices: [{ delta: { content: '世界' } }] } },
+        { data: { choices: [{ delta: {}, finish_reason: 'stop' }] } },
+        {
+          data: {
+            choices: [],
+            usage: { prompt_tokens: 11, completion_tokens: 7, prompt_tokens_details: { cached_tokens: 3 } },
+          },
+        },
+      ]);
+    },
+  });
+
+  const chunks = await collect(adapter.stream({ ...BASE }));
+
+  assert.equal(seen.url, 'https://api.openai.com/v1/chat/completions');
+  assert.equal(seen.init.headers.authorization, 'Bearer sk-test');
+  assert.ok(seen.init.headers['user-agent'], '每个 provider 请求都必须带归属头');
+
+  assert.deepEqual(
+    chunks.map((c) => c.type),
+    ['block-start', 'text-delta', 'text-delta', 'block-end', 'usage', 'finish'],
+  );
+  // counts 互斥契约：prompt_tokens 含缓存命中，扣掉 cached 后单报 inputTokens。
+  assert.deepEqual(chunks.at(-2).usage, { inputTokens: 8, outputTokens: 7, cacheReadTokens: 3 });
+  assert.deepEqual(chunks.at(-1).reason, { kind: 'stop' });
+  assert.deepEqual(chunks[3].block, { type: 'text', text: '你好世界' });
+});
+
+test('openai · 账户模式（Responses）文本流：严格 codex 头 + 权威值覆盖 + 互斥 usage', async () => {
+  let seen;
+  const adapter = new AccountAuthLlmAdapter({
+    env: {},
+    resolveCredential: async () => ({ mode: 'account', token: 'jwt-token', accountId: 'acct_test', source: 'test' }),
+    fetch: async (url, init) => {
+      seen = { url, init };
+      return sseResponse([
+        { event: 'response.output_item.added', data: { type: 'response.output_item.added', item: { id: 'msg_1', type: 'message', role: 'assistant' } } },
+        { event: 'response.output_text.delta', data: { type: 'response.output_text.delta', item_id: 'msg_1', delta: '你好' } },
+        { event: 'response.output_text.delta', data: { type: 'response.output_text.delta', item_id: 'msg_1', delta: '世界' } },
+        // done 事件携带权威全文（比增量更长）：应覆盖增量累积，防截断。
+        { event: 'response.output_item.done', data: { type: 'response.output_item.done', item: { id: 'msg_1', type: 'message', content: [{ type: 'output_text', text: '你好世界！' }] } } },
+        { event: 'response.completed', data: { type: 'response.completed', response: { status: 'completed', usage: { input_tokens: 11, input_tokens_details: { cached_tokens: 3 }, output_tokens: 7, output_tokens_details: { reasoning_tokens: 4 } } } } },
+      ]);
+    },
+  });
+
+  const chunks = await collect(adapter.stream({ ...BASE }));
+
+  assert.equal(seen.url, 'https://chatgpt.com/backend-api/codex/responses');
+  assert.equal(seen.init.headers.authorization, 'Bearer jwt-token');
+  assert.equal(seen.init.headers['chatgpt-account-id'], 'acct_test');
+  assert.equal(seen.init.headers.originator, 'codex_cli_rs');
+  assert.equal(seen.init.headers['openai-beta'], 'responses=experimental');
+  assert.match(
+    seen.init.headers.session_id,
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    'session_id 是每次请求新生成的 UUID v4',
+  );
+  assert.equal(seen.init.headers['user-agent'], undefined, 'UA 默认 omit 档：剔除 attribution 注入的 UA');
+
+  const body = JSON.parse(seen.init.body);
+  assert.equal(body.stream, true);
+  assert.equal(body.store, false);
+  assert.ok(body.instructions, 'codex 后端要求 instructions 非空（无 system 时用中性兜底）');
+  assert.ok(Array.isArray(body.input), 'input 必须是 item 数组，不接受字符串简写');
+  assert.equal(body.max_output_tokens, undefined, 'codex 后端拒收采样参数，默认剔除');
+
+  assert.deepEqual(
+    chunks.map((c) => c.type),
+    ['block-start', 'text-delta', 'text-delta', 'block-end', 'usage', 'finish'],
+  );
+  assert.deepEqual(chunks[3].block, { type: 'text', text: '你好世界！' });
+  // counts 互斥契约：input_tokens 含缓存命中，扣掉单报；reasoning_tokens 是输出子集明细。
+  assert.deepEqual(chunks.at(-2).usage, { inputTokens: 8, outputTokens: 7, cacheReadTokens: 3, reasoningTokens: 4 });
+  assert.deepEqual(chunks.at(-1).reason, { kind: 'stop' });
+});
+
+test('openai · 账户模式（Responses）工具调用流：扁平 tools + done 权威参数覆盖', async () => {
+  let seen;
+  const adapter = new AccountAuthLlmAdapter({
+    env: {},
+    resolveCredential: async () => ({ mode: 'account', token: 'jwt-token', accountId: 'acct_test', source: 'test' }),
+    fetch: async (url, init) => {
+      seen = { url, init };
+      return sseResponse([
+        { event: 'response.output_item.added', data: { type: 'response.output_item.added', item: { id: 'fc_1', type: 'function_call', call_id: 'call_1', name: 'read_file', arguments: '' } } },
+        { event: 'response.function_call_arguments.delta', data: { type: 'response.function_call_arguments.delta', item_id: 'fc_1', delta: '{"path":' } },
+        { event: 'response.function_call_arguments.delta', data: { type: 'response.function_call_arguments.delta', item_id: 'fc_1', delta: '"b.txt"}' } },
+        { event: 'response.output_item.done', data: { type: 'response.output_item.done', item: { id: 'fc_1', type: 'function_call', call_id: 'call_1', name: 'read_file', arguments: '{"path":"a.ts"}' } } },
+        { event: 'response.completed', data: { type: 'response.completed', response: { status: 'completed', usage: { input_tokens: 5, output_tokens: 3 } } } },
+      ]);
+    },
+  });
+
+  const chunks = await collect(
+    adapter.stream({
+      ...BASE,
+      system: '你是审核者',
+      tools: [{ name: 'read_file', description: '读文件', parameters: { type: 'object' } }],
+    }),
+  );
+
+  const body = JSON.parse(seen.init.body);
+  assert.equal(body.instructions, '你是审核者', '有 system 时直接透传为 instructions');
+  assert.deepEqual(body.tools, [
+    { type: 'function', name: 'read_file', description: '读文件', parameters: { type: 'object' }, strict: false },
+  ]);
+  assert.equal(body.tool_choice, 'auto');
+
+  assert.deepEqual(
+    chunks.map((c) => c.type),
+    ['block-start', 'tool-call-delta', 'tool-call-delta', 'block-end', 'usage', 'finish'],
+  );
+  assert.deepEqual(
+    chunks[3].block,
+    { type: 'tool-call', id: 'call_1', name: 'read_file', arguments: '{"path":"a.ts"}' },
+    'done 携带的权威参数覆盖增量累积',
+  );
+  assert.deepEqual(chunks.at(-1).reason, { kind: 'tool-calls' });
+});
+
+test('账户 id 三级来源与 UA 三档开关（responsesRequest 纯函数矩阵）', () => {
+  const jwt = makeJwt({ [JWT_CLAIM]: { chatgpt_account_id: 'acct_jwt' } });
+  const profile = PROFILES.openai;
+  const options = { model: 'gpt-5.6', messages: BASE.messages };
+  const request = (credential, env = {}) => responsesRequest(profile, options, credential, env);
+
+  // ① env 显式覆盖最优先
+  assert.equal(
+    request({ mode: 'account', token: jwt, accountId: 'acct_cred' }, { DSH_OPENAI_CHATGPT_ACCOUNT_ID: 'acct_env' }).headers['chatgpt-account-id'],
+    'acct_env',
+  );
+  // ② 凭据解析阶段提取的 credential.accountId
+  assert.equal(request({ mode: 'account', token: jwt, accountId: 'acct_cred' }).headers['chatgpt-account-id'], 'acct_cred');
+  // ③ 兜底：从令牌自身的 JWT 载荷取 claim
+  assert.equal(request({ mode: 'account', token: jwt }).headers['chatgpt-account-id'], 'acct_jwt');
+  // ④ 都没有：不阻断请求，把可能的 403 暴露出去
+  assert.equal(request({ mode: 'account', token: 'opaque-token' }).headers['chatgpt-account-id'], undefined);
+
+  // UA 三档：omit（默认）/ codex / dsh
+  const ua = (env) => request({ mode: 'account', token: 'opaque' }, env).headers['user-agent'];
+  assert.equal(ua({}), undefined, '默认 omit');
+  assert.match(ua({ DSH_OPENAI_ACCOUNT_USER_AGENT: 'codex' }), /^codex_cli_rs\//);
+  assert.ok(ua({ DSH_OPENAI_ACCOUNT_USER_AGENT: 'dsh' }), 'dsh 档保留 attribution 注入的 UA');
+});
+
+test('凭据解析补全账户 id：env 覆盖 > 文档直存键 > JWT 载荷 claim', async () => {
+  const jwt = makeJwt({ [JWT_CLAIM]: { chatgpt_account_id: 'acct_jwt' } });
+  const file = join(tmpdir(), 'dsh-llm-account-auth-test-auth.json');
+  const profile = {
+    ...PROFILES.openai,
+    accountOnly: false, // 本测试验证账户 id 提取逻辑，不关心 accountOnly 退化守卫
+    accountTokenEnv: ['TEST_ACCOUNT_TOKEN'],
+    credentialFiles: [{ path: () => file, keys: ['tokens.access_token'] }],
+  };
+
+  // ① accountTokenEnv 令牌 + accountIdEnv 显式覆盖
+  const fromEnv = await resolveCredential(profile, { TEST_ACCOUNT_TOKEN: jwt, DSH_OPENAI_CHATGPT_ACCOUNT_ID: 'acct_env' });
+  assert.equal(fromEnv.accountId, 'acct_env');
+
+  // ② accountTokenEnv 路径没有凭据文档：从 JWT 载荷提取
+  const fromJwt = await resolveCredential(profile, { TEST_ACCOUNT_TOKEN: jwt });
+  assert.equal(fromJwt.accountId, 'acct_jwt');
+
+  // ③ CLI 凭据库路径：文档直存键优先于 JWT claim
+  await writeFile(file, JSON.stringify({ tokens: { access_token: jwt, account_id: 'acct_doc' } }));
+  try {
+    const fromDoc = await resolveCredential(profile, {});
+    assert.equal(fromDoc.accountId, 'acct_doc');
+  } finally {
+    await rm(file, { force: true });
+  }
+
+  // ④ API Key 模式不做账户 id 提取
+  const apiKey = await resolveCredential(profile, { OPENAI_API_KEY: 'sk-xyz' });
+  assert.equal(apiKey.mode, 'api-key');
+  assert.equal(apiKey.accountId, undefined);
+});
+
+test('anthropic · 账户（OAuth）模式走 Bearer + oauth beta 头，工具调用流正确', async () => {
+  let seen;
+  const adapter = new AccountAuthLlmAdapter({
+    resolveCredential: async () => ({ mode: 'account', token: 'oauth-token', source: 'test' }),
+    fetch: async (url, init) => {
+      seen = { url, init };
+      return sseResponse(
+        [
+          { event: 'message_start', data: { type: 'message_start', message: { usage: { input_tokens: 20 } } } },
+          {
+            event: 'content_block_start',
+            data: { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'toolu_1', name: 'read_file' } },
+          },
+          { event: 'content_block_delta', data: { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"path":' } } },
+          { event: 'content_block_delta', data: { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '"a.ts"}' } } },
+          { event: 'content_block_stop', data: { type: 'content_block_stop', index: 0 } },
+          { event: 'message_delta', data: { type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 9 } } },
+          { event: 'message_stop', data: { type: 'message_stop' } },
+        ],
+        { tail: '' },
+      );
+    },
+  });
+
+  const chunks = await collect(
+    adapter.stream({
+      provider: 'anthropic',
+      model: 'claude-sonnet-5',
+      system: '你是审核者',
+      messages: [{ role: 'user', content: [{ type: 'text', text: '读文件' }] }],
+      tools: [{ name: 'read_file', description: '读文件', parameters: { type: 'object' } }],
+    }),
+  );
+
+  assert.equal(seen.url, 'https://api.anthropic.com/v1/messages');
+  assert.equal(seen.init.headers.authorization, 'Bearer oauth-token');
+  assert.equal(seen.init.headers['anthropic-beta'], 'oauth-2025-04-20');
+  assert.equal(seen.init.headers['x-api-key'], undefined, '账户模式不应再发 x-api-key');
+
+  const body = JSON.parse(seen.init.body);
+  assert.equal(body.system, '你是审核者');
+  assert.equal(body.tools[0].input_schema.type, 'object');
+  assert.ok(body.max_tokens, 'Anthropic 的 max_tokens 必填');
+
+  assert.deepEqual(
+    chunks.map((c) => c.type),
+    ['block-start', 'tool-call-delta', 'tool-call-delta', 'block-end', 'usage', 'finish'],
+  );
+  assert.deepEqual(chunks[3].block, {
+    type: 'tool-call',
+    id: 'toolu_1',
+    name: 'read_file',
+    arguments: '{"path":"a.ts"}',
+  });
+  assert.deepEqual(chunks.at(-2).usage, { inputTokens: 20, outputTokens: 9 });
+  assert.deepEqual(chunks.at(-1).reason, { kind: 'tool-calls' });
+});
+
+test('无凭据时抛 AUTH，并给出可执行指引', async () => {
+  const profile = {
+    id: 'fake',
+    name: 'Fake',
+    apiKeyPrefix: 'sk-',
+    tokenEnv: ['FAKE_API_KEY'],
+    accountTokenEnv: ['FAKE_ACCOUNT_TOKEN'],
+    credentialFiles: [{ path: () => '/nonexistent/fake-auth.json', keys: ['token'] }],
+  };
+  await assert.rejects(() => resolveCredential(profile, {}), (e) => {
+    assert.equal(e.code, 'AUTH');
+    assert.match(e.message, /FAKE_ACCOUNT_TOKEN/);
+    return true;
+  });
+});
+
+test('401 映射为 AUTH 并保留 status', async () => {
+  const adapter = new AccountAuthLlmAdapter({
+    resolveCredential: async () => ({ mode: 'api-key', token: 'sk-bad', source: 'test' }),
+    fetch: async () => ({
+      ok: false,
+      status: 401,
+      headers: new Headers({ 'x-request-id': 'req_1' }),
+      body: null,
+      text: async () => 'invalid api key',
+    }),
+  });
+
+  await assert.rejects(() => collect(adapter.stream({ ...BASE })), (e) => {
+    assert.equal(e.code, 'AUTH');
+    // LlmError 把可序列化的 provider 事实收在 failure 上（status / requestId / retryAfter）。
+    assert.equal(e.failure.status, 401);
+    assert.equal(e.failure.requestId, 'req_1');
+    return true;
+  });
+});
+
+test('插件入口：两条路由注册进 llm，并可被 listProviders 发现', () => {
+  const registered = [];
+  const ctx = {
+    llm: {
+      registerAdapter(routes, adapter) {
+        registered.push({ routes, adapter });
+        return () => {};
+      },
+    },
+  };
+
+  apply(ctx);
+
+  assert.equal(registered.length, 1);
+  assert.deepEqual(registered[0].routes, ['openai', 'anthropic']);
+
+  // 宿主侧 listProviders 的等价物：路由 + providerInfo 就是编辑器下拉的数据源。
+  const adapter = registered[0].adapter;
+  assert.deepEqual(
+    ['openai', 'anthropic'].map((id) => adapter.providerInfo(id)),
+    [
+      { id: 'openai', name: 'OpenAI' },
+      { id: 'anthropic', name: 'Anthropic' },
+    ],
+  );
+});
+
+test('未知路由或重复注册要有明确失败，而不是静默降级', () => {
+  const ctx = { llm: { registerAdapter: () => () => {} } };
+  assert.throws(() => apply(ctx, { routes: ['gemini'] }), /未知路由/);
+
+  const busy = { llm: { registerAdapter: () => { throw new Error('DUPLICATE_ADAPTER'); } } };
+  assert.throws(() => apply(busy), /注册.*失败/);
+});
+
+test('令牌分类：前缀命中判为 API Key，其余判为账户令牌', () => {
+  assert.equal(classifyToken({ apiKeyPrefix: 'sk-' }, 'sk-abc'), 'api-key');
+  assert.equal(classifyToken({ apiKeyPrefix: 'sk-' }, 'eyJhbGciOi'), 'account');
+  assert.equal(classifyToken({ apiKeyPrefix: 'sk-ant-' }, 'sk-ant-abc'), 'api-key');
+  assert.equal(classifyToken({ apiKeyPrefix: 'sk-ant-' }, 'sk-ory'), 'account');
+});
+
+test('账户专用 profile（accountOnly）退出登录时不退化到 API Key，引导重登录', async () => {
+  // 复现真实踩坑：codex 退出登录后 ~/.codex/auth.json 整个消失，但 Windows 系统环境变量里
+  // 残留一枚无效 OPENAI_API_KEY。OpenAI 账户模式（codex 后端）若退化到它，会误打
+  // api.openai.com 的 Chat Completions 并报误导性的「API key is invalid」。
+  // accountOnly 必须忽略 API Key 兜底，直接抛 AUTH 引导重登录。
+  const profile = {
+    id: 'openai',
+    name: 'OpenAI',
+    requiresAccountId: true,
+    accountOnly: true,
+    apiKeyPrefix: 'sk-',
+    tokenEnv: ['OPENAI_API_KEY'],
+    accountTokenEnv: ['DSH_OPENAI_ACCOUNT_TOKEN'],
+    credentialFiles: [{ path: () => '/nonexistent/codex-auth.json', keys: ['tokens.access_token'] }],
+  };
+
+  await assert.rejects(
+    () => resolveCredential(profile, { OPENAI_API_KEY: 'sk-invalid-from-system' }),
+    (e) => {
+      assert.equal(e.code, 'AUTH');
+      assert.match(e.message, /codex login/, '应明确引导重新登录 codex');
+      // 文案应澄清「账户专用、不走 API Key」——而不是像通用兜底那样把 OPENAI_API_KEY 列为可设项。
+      assert.match(e.message, /不接受 OPENAI_API_KEY/, '应明确声明该模式不接受 OPENAI_API_KEY 退化');
+      return true;
+    },
+  );
+});
+
+test('accountOnly · 文件中即使出现 sk- 形令牌也不降级为 API Key（强制账户模式）', async () => {
+  // 复现潜在误判：若 codex auth.json 里混有一枚 sk- 开头的令牌（无论来源），classifyToken
+  // 默认会判成 API Key。但 accountOnly 模式（codex 后端）绝不该把它当 OPENAI_API_KEY 去打
+  // 官方 API——必须强制 account，走 codex 后端拿到真实的鉴权错误，而非误导性的「API key is invalid」。
+  const file = join(tmpdir(), `dsh-acct-${process.pid}-${Math.random().toString(36).slice(2)}.json`);
+  await writeFile(file, JSON.stringify({ tokens: { access_token: 'sk-spurious-from-file' } }), 'utf8');
+  try {
+    const profile = {
+      id: 'openai',
+      name: 'OpenAI',
+      requiresAccountId: true,
+      accountOnly: true,
+      apiKeyPrefix: 'sk-',
+      credentialFiles: [{ path: () => file, keys: ['tokens.access_token'] }],
+    };
+    const cred = await resolveCredential(profile, {});
+    assert.equal(cred.mode, 'account', 'accountOnly 下文件来源必须是账户模式');
+    assert.equal(cred.token, 'sk-spurious-from-file');
+  } finally {
+    await rm(file, { force: true });
+  }
+});
+
+test('凭据库条目声明 forceMode 时不走前缀启发式（Claude OAuth 令牌误判回归）', async () => {
+  // Claude 的 OAuth 令牌（sk-ant-oat01-…）以 sk-ant- 开头，前缀启发式会误判为 API Key；
+  // claudeAiOauth.* 键名结构已明确是账户登录态，条目级 forceMode 优先。
+  const file = join(tmpdir(), 'dsh-llm-account-auth-test-force-mode.json');
+  const profile = {
+    id: 'anthropic-like',
+    name: 'AnthropicLike',
+    apiKeyPrefix: 'sk-ant-',
+    credentialFiles: [{ path: () => file, keys: ['claudeAiOauth.accessToken'], forceMode: 'account' }],
+  };
+  await writeFile(file, JSON.stringify({ claudeAiOauth: { accessToken: 'sk-ant-oat01-test' } }));
+  try {
+    const credential = await resolveCredential(profile, {});
+    assert.equal(credential.mode, 'account', 'forceMode 优先于 apiKeyPrefix 启发式');
+  } finally {
+    await rm(file, { force: true });
+  }
+});


### PR DESCRIPTION
## 概述

新增 `packages/dsh-llm-account-auth`：为 DSH 提供账户鉴权（OAuth / CLI 本地登录态）的 LLM 适配器，注册 `openai` / `anthropic` 两条 provider 路由。

## 关键设计

- **OpenAI 账户模式**：走 codex 后端（chatgpt.com/backend-api/codex）Responses 线格式，严格 codex 头（originator / openai-beta / session_id / chatgpt-account-id），`accountOnly: true`。
- **accountOnly 双重守卫**：退出登录（auth.json 消失或残留 sk- 形令牌）一律保持 account 模式，绝不退化到 API Key 误打官方 Chat Completions；未找到凭据时抛干净 AUTH 引导 `npx @openai/codex login`，不再误报 "API key is invalid"。
- **Anthropic**：API Key 与 OAuth（`claudeAiOauth.accessToken`，forceMode 防 sk-ant-oat01- 前缀误判）双支持，账户模式带 `anthropic-beta: oauth-2025-04-20`。
- **企业代理**：undici ProxyAgent 显式 dispatcher（`DSH_ACCOUNT_AUTH_PROXY` > `HTTPS_PROXY` > `HTTP_PROXY`），仅代理账户鉴权请求，不动 DSH 其他流量。
- **模型目录**：gpt-5.6-sol / terra / luna + gpt-5.5 / gpt-5.4；context 一律留空不臆造。

## 验证

- 包内测试 **14/14 全绿**（含 accountOnly 退出登录不退化、文件路 sk- 令牌不降级两条回归）。
- 端到端（经 7890 代理，对假过期令牌）：codex 后端真实 401 → 归一 `LlmError code=AUTH`，不崩、不泄露令牌。
- 真实 DSH web（127.0.0.1:3080）人工验证：已登录 GPT-5.4 正确流式回复；退出登录给出干净重登录引导。

## 备注

- 基于 main (b1c5ebe) ，cherry-pick 自内部提交 71bf2f0（本地 main 与 main 已分叉，故走 PR 收口）。
- 测试命令：`cd packages/dsh-llm-account-auth && npm test`。