### PR TITLE
fix(visual-workflow): 静态 bundle inject 补 subprocess，修复删除/保存模板子进程不可用

### DIFF
--- a/packages/dsh-visual-workflow/scripts/build-bundle.mjs
+++ b/packages/dsh-visual-workflow/scripts/build-bundle.mjs
@@ -42,8 +42,10 @@ writeFileSync(
   `export const name = plugin.name;\n` +
   // 静态组合包行级激活必须等 webServer 与 tools 就绪：无 inject 的行会在
   // 这些服务激活前 apply，导致 RPC 路由或工具注册永久错过。
+  // #122: subprocess 必须加入 inject——否则 apply 时 ctx.get('subprocess') 返回 undefined，
+  // 导致删除模板/子进程调用等操作失败（子进程服务不可用）。
   // 动态会话插件仍走 harness.handle，不受影响（src 闭包体本身不声明 inject）。
-  `export const inject = ['webServer', 'tools'];\n` +
+  `export const inject = ['webServer', 'tools', 'subprocess'];\n` +
   `export function apply(ctx) { return plugin.apply(ctx); }\n`
 )
 

--- a/packages/dsh-visual-workflow/tests/static-bundle.test.mjs
+++ b/packages/dsh-visual-workflow/tests/static-bundle.test.mjs
@@ -90,9 +90,10 @@ test('T3：静态 bundle dist/host-entry.mjs 在无 harness 时 apply() 走 webS
   assert.equal(registered[0].path, '/dsh-visual-workflow')
 })
 
-test('T3：静态 bundle dist 导出 inject:[\'webServer\', \'tools\']——行级激活等待必需服务就绪', async (t) => {
-  // 回归：host 行无完整 inject 时会在 webServer/tools 激活前 apply，
-  // 导致 RPC 路由或工具注册永久错过。
+test('T3：静态 bundle dist 导出 inject:[\'webServer\', \'tools\', \'subprocess\']——行级激活等待必需服务就绪', async (t) => {
+  // 回归：host 行无完整 inject 时会在 webServer/tools/subprocess 激活前 apply，
+  // 导致 RPC 路由或工具注册永久错过；#122：缺少 subprocess 会让删除/保存模板报
+  // 「子进程服务不可用（node 解析失败）」。
   assert.ok(existsSync(distEntry), 'dist/host-entry.mjs 必须存在')
   try {
     await import('@deepseek-ai/dsh-tools')
@@ -101,7 +102,7 @@ test('T3：静态 bundle dist 导出 inject:[\'webServer\', \'tools\']——行�
     return
   }
   const mod = await import(pathToFileURL(distEntry).href + '?t=' + Date.now())
-  assert.deepEqual(mod.inject, ['webServer', 'tools'], '静态 host 出口必须声明 webServer/tools 依赖')
+  assert.deepEqual(mod.inject, ['webServer', 'tools', 'subprocess'], '静态 host 出口必须声明 webServer/tools/subprocess 依赖')
 })
 
 test('T3：webServer 晚于 apply 激活时经 ctx.inject 延迟注册路由（无 inject 旧安装位兜底）', () => {
@@ -183,7 +184,7 @@ test('Issue #37：消费者先进入 Cordis，webServer/tools 后出现时才一
 
   const disposeTools = ctx.provide('tools', tools)
   await fiber
-  assert.deepEqual(mod.inject, ['webServer', 'tools'], '静态 bundle 必须声明两个宿主依赖')
+  assert.deepEqual(mod.inject, ['webServer', 'tools', 'subprocess'], '静态 bundle 必须声明三个宿主依赖')
   assert.deepEqual([...activeRoutes.keys()], ['/dsh-visual-workflow'])
   assert.deepEqual([...activeTools.keys()].sort(), ['vwf_debug', 'vwf_workspace', 'wf_run'])
   assert.equal(routeCalls.length, 1, 'RPC 路由首次只注册一次')


### PR DESCRIPTION
## 背景

产品 web profile（删除/保存工作流模板）报「子进程服务不可用（node 解析失败）」。根因：

- 产品组合（dsh-base bundle）已含 `@deepseek-ai/dsh-subprocess-local`，动态 Cordis 插件能拿到 `ctx.subprocess`；
- 但 VWF **静态 host** 的 `inject` 只声明 `['webServer', 'tools']`，不含 `subprocess`；
- Cordis 行级激活只等待 inject 声明的服务，VWF 在 subprocess 注册前 apply，`ctx.get('subprocess')` 返回 `undefined` 并被永久捕获；
- 后果：`vwf.workflows.remove` / 保存闭环的 rm 子进程失败（`runNode` → 无 node），运行记录磁盘淘汰也暂停。

## 改动

- `packages/dsh-visual-workflow/scripts/build-bundle.mjs`：生成的 `export const inject` 增加 `'subprocess'` → `['webServer', 'tools', 'subprocess']`，Cordis 等 subprocess 就绪后才激活 VWF。
- `packages/dsh-visual-workflow/tests/static-bundle.test.mjs`：两处 inject 断言同步更新（140 项包测试通过）。

## 验证

- `npm test`（包）：140 项通过
- `npm run generate` / `npm run validate`：全绿
- 产品 DSH 重启后**人工验证删除/保存工作流模板均成功**

## 备注

dist 为 gitignore 构建产物，不随 PR 入库；产品侧已基于本提交重建并部署验证。