### PR TITLE
fix(workflow): HD 出边 choice id 归一化冲突校验期拒绝 (#159)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,6 +113,10 @@
   `FAILED_MAX_ROUNDS`（超过打回上限）/ `TECHNICAL_FAILURE`（技术执行失败）/ `ENDED_NO_SUCCESS_EDGE` / `ENDED_NO_FAILURE_EDGE` /
   `ERROR`；生成的 `SKILL.md` **runbook（操作手册）** 必须逐个覆盖。这是底层引擎一次执行的返回值，不是 Target 的 Run Lifecycle（运行生命周期）。
 - **rejected_choice**：业务 Decision Result 无匹配 `$human-decision` 出边时，引擎返回体上的被拒选项；`status` 仍为 `WAITING_HUMAN`，`decision_id` 不变，请求事件 `user_choice` 保持 null。
+- **HD 出边归一化 id（#159）**：运行期画卡装配与续跑查找均按 `e.result || String(e.outcome)` 归一化
+  `$human-decision` 出边 choice id——同一 HD 的出边归一化后不得相同（typed `false` 与字符串 `"false"`、
+  `outcome: "SHIP"` 与 `result: "SHIP"` 都会坍缩为一，其中一条出边静默不可达）。`validateBlueprint`
+  在校验期拒绝该归一化冲突并报告两条冲突边坐标与归一化 id；运行时保持纯字符串语义不做类型区分。
 - **执行路径（D5 正式化）**：编辑器「获取脚本」→ 粘贴主会话 → 平台 `workflow` 工具执行；
   `wf_run` 仅在引擎可达时条件注册。**推论：脚本返回值只回到主会话，插件进程拿不到**——
   看板只能看到事件流（阶段 / 子代理 / 日志）。

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,6 +117,10 @@
   `$human-decision` 出边 choice id——同一 HD 的出边归一化后不得相同（typed `false` 与字符串 `"false"`、
   `outcome: "SHIP"` 与 `result: "SHIP"` 都会坍缩为一，其中一条出边静默不可达）。`validateBlueprint`
   在校验期拒绝该归一化冲突并报告两条冲突边坐标与归一化 id；运行时保持纯字符串语义不做类型区分。
+  字段归属补充：业务 `outcome` 出边禁止同边携带 `result`（result 仅属 `on:"success"` 出边，混用会使
+  校验端与运行期对同一边取不同 id 身份）；归一化 choice id 命中 `toString`/`constructor`/`__proto__`
+  等 `Object.prototype` 保留键时校验期显式拒绝（运行期普通对象 `subsequent_effects` 无法承载，否则
+  该出边被静默丢弃）——两类均报真实边坐标（#159 A1/A2 复核）。
 - **执行路径（D5 正式化）**：编辑器「获取脚本」→ 粘贴主会话 → 平台 `workflow` 工具执行；
   `wf_run` 仅在引擎可达时条件注册。**推论：脚本返回值只回到主会话，插件进程拿不到**——
   看板只能看到事件流（阶段 / 子代理 / 日志）。

--- a/docs/design/blueprint-schema.md
+++ b/docs/design/blueprint-schema.md
@@ -63,6 +63,13 @@
 > 同名字符串）、`outcome: 0` 与 `outcome: "0"`、`outcome: "SHIP"` 与 `result: "SHIP"`（跨形态同名）都会
 > 坍缩为同一选项 id，其中一条合法出边在运行期静默不可达。`validateBlueprint` 在校验期显式拒绝该归一化
 > 冲突并报出两条冲突边坐标与归一化 id；应改用显式 `result` 命名（如 `result: REJECT_BOOL`）区分选项。
+>
+> **字段归属与保留键（#159 A1/A2 复核）**：`result` 只属于 `on: "success"` 的旧 HD 出边；业务 `outcome`
+> 出边**禁止**再携带 `result`（二者同边互斥——结构层只禁 `outcome` 与 `on`，而运行期 `e.result ||` 对
+> 任意 truthy result 优先，混用会让校验端与运行期对同一条边取不同 choice id 身份）。此外归一化 choice id
+> 命中运行时保留键（`toString` / `constructor` / `__proto__` 等 `Object.prototype` 成员）时校验期同样
+> 显式拒绝并报真实边坐标：画卡装配的 `subsequent_effects` 以普通对象承载，这些 id 会被判为已占用而把
+> 该出边静默丢弃，请改用显式 `result` 命名。
 
 ### 2.4 Human Decision 控制面键名（#116 钉死；机器英文）
 

--- a/docs/design/blueprint-schema.md
+++ b/docs/design/blueprint-schema.md
@@ -58,6 +58,12 @@
 | `countRound` | 可选 | 仅业务边。布尔；`true` 则走该边消耗 1 点自动回退额度；`false` 或缺省不消耗但仍记入 `history`。额度耗尽不走边，进入 `WAITING_HUMAN` + `MAX_ROUNDS_REACHED`，保留原 Node Business Outcome（#73） |
 | `result` | 旧 HD 出边必填 | 业务 Decision Result id（`SCREAMING_SNAKE`，如 `SHIP`）。**不得**占用框架控制类 `USER_ACCEPTED` / `ADD_BUDGET` / `STOP` |
 
+> **同一 `$human-decision` 的出边按运行时归一化 id 不得冲突（#159）**：画卡选项装配与续跑查找均取
+> `e.result || String(e.outcome)` 作为 choice id，因此 `outcome: false` 与 `outcome: "false"`（typed 与
+> 同名字符串）、`outcome: 0` 与 `outcome: "0"`、`outcome: "SHIP"` 与 `result: "SHIP"`（跨形态同名）都会
+> 坍缩为同一选项 id，其中一条合法出边在运行期静默不可达。`validateBlueprint` 在校验期显式拒绝该归一化
+> 冲突并报出两条冲突边坐标与归一化 id；应改用显式 `result` 命名（如 `result: REJECT_BOOL`）区分选项。
+
 ### 2.4 Human Decision 控制面键名（#116 钉死；机器英文）
 
 > 新蓝图走本协议；残留 `manualCheck` 仍用 `AWAITING_HUMAN_<id>` + `approved`。本表只锁字段名。挂起运行时：#77 引擎段命中 `$human-decision` 入边发出 `ROUTE_HALTED`（`reason=HUMAN_DECISION`）；#118 将其翻译为 `WAITING_HUMAN` 并装配 Decision Package 与追加-only 控制面事件。编译脚本对外返回 `WAITING_HUMAN`，不把 `ROUTE_HALTED` 作为人工决策终态。

--- a/scripts/test/human-decision-runtime.test.mjs
+++ b/scripts/test/human-decision-runtime.test.mjs
@@ -377,3 +377,33 @@ test('#159 归一化冲突蓝图无法通过校验进入运行时（无静默态
   assert.equal(v2.ok, false, 'result/outcome 同名蓝图不得通过校验')
   assert.ok(v2.errors.some((e) => String(e.message).includes('归一化') && String(e.message).includes('choice id "SHIP"')), JSON.stringify(v2.errors))
 })
+
+// Issue #159（A1/A2 复核）：原型键与混合字段出边同样不得携带静默不可达路径进入运行时。
+// A1：单条 outcome "toString" 在运行期画卡装配的普通对象 subsequent_effects 中判重伪命中、
+// 选项被静默丢弃（出边不可达），校验期须以"运行时保留键"契约错误拒绝且不伪报归一化冲突；
+// A2：outcome 与空白 result " " 同边混合字段会让校验端与运行期对同一边取不同 choice id
+// 身份（旧校验按 A/B 判不冲突、运行期两条边都坍缩为空白 result），校验期须以互斥错误拒绝。
+test('#159 A1/A2 原型键与混合字段出边无法通过校验进入运行时（无静默态）', () => {
+  // A1：单条合法字符串 outcome "toString" —— 不得伪报归一化冲突，但须因运行时保留键被拒
+  const proto = JSON.parse(JSON.stringify(hd))
+  const protoOut = proto.edges.filter((e) => e.from === '$human-decision')[0]
+  delete protoOut.result
+  protoOut.outcome = 'toString'
+  const v1 = validateBlueprint(proto)
+  assert.equal(v1.ok, false, '原型键 outcome 不得通过校验（运行期会静默丢弃该出边）')
+  assert.equal(
+    v1.errors.filter((e) => String(e.message).includes('归一化冲突')).length,
+    0,
+    '不得伪报归一化冲突：' + JSON.stringify(v1.errors),
+  )
+  assert.ok(v1.errors.some((e) => String(e.message).includes('保留键')), JSON.stringify(v1.errors))
+
+  // A2：两条 outcome 边各带空白 result " "（truthy，运行期优先于 outcome）
+  const mixed = JSON.parse(JSON.stringify(hd))
+  mixed.edges = mixed.edges.filter((e) => !(e && e.from === '$human-decision'))
+  mixed.edges.push({ from: '$human-decision', to: 'finish', outcome: 'A', result: ' ' })
+  mixed.edges.push({ from: '$human-decision', to: 'finish', outcome: 'B', result: ' ' })
+  const v2 = validateBlueprint(mixed)
+  assert.equal(v2.ok, false, '混合字段蓝图不得通过校验（运行期两条边将坍缩为同一空白 result）')
+  assert.ok(v2.errors.some((e) => String(e.message).includes('互斥')), JSON.stringify(v2.errors))
+})

--- a/scripts/test/human-decision-runtime.test.mjs
+++ b/scripts/test/human-decision-runtime.test.mjs
@@ -354,3 +354,26 @@ test('#149 outcome 出边无匹配选择仍保持等待', async () => {
   assert.equal(r2.result.rejected_choice, 'HOLD')
   assert.ok(!r2.agentCalls.some((c) => c.label === '收口'))
 })
+
+// Issue #159（方案 B）：HD 出边归一化冲突（typed outcome vs 同名字符串、result vs outcome
+// 同名）不存在"校验通过但运行期静默不可达"的路径——冲突蓝图必须在校验期被拒，不得进入
+// 运行时。此处断言校验拒绝（运行时行为不测：该蓝图根本不具备合法运行前提）。
+test('#159 归一化冲突蓝图无法通过校验进入运行时（无静默态）', () => {
+  const colliding = JSON.parse(JSON.stringify(hd))
+  const hdOuts = colliding.edges.filter((e) => e.from === '$human-decision')
+  // 同一 HD 声明 outcome:false 与 outcome:"false" 两条出边（运行期均坍缩为 choice id "false"）
+  hdOuts[0].result = undefined
+  hdOuts[0].outcome = false
+  colliding.edges.push({ from: '$human-decision', to: 'finish', outcome: 'false' })
+  const v = validateBlueprint(colliding)
+  assert.equal(v.ok, false, '归一化冲突蓝图不得通过校验（否则第二条出边运行期静默不可达）')
+  const hit = v.errors.filter((e) => String(e.message).includes('归一化') && String(e.message).includes('choice id "false"'))
+  assert.ok(hit.length >= 1, '应报归一化冲突并带 choice id "false"，实际 ' + JSON.stringify(v.errors))
+
+  // 跨形态：result "SHIP" 与 outcome "SHIP" 同名同样必须在校验期拒绝
+  const cross = JSON.parse(JSON.stringify(hd))
+  cross.edges.push({ from: '$human-decision', to: 'finish', outcome: 'SHIP' })
+  const v2 = validateBlueprint(cross)
+  assert.equal(v2.ok, false, 'result/outcome 同名蓝图不得通过校验')
+  assert.ok(v2.errors.some((e) => String(e.message).includes('归一化') && String(e.message).includes('choice id "SHIP"')), JSON.stringify(v2.errors))
+})

--- a/scripts/test/validate-blueprint.test.mjs
+++ b/scripts/test/validate-blueprint.test.mjs
@@ -442,3 +442,65 @@ test('#116 HD 与 manualCheck 同图拒绝；出边 result 不得占用控制类
   assert.equal(r2.ok, false);
   assert.ok(r2.errors.some((e) => String(e.fieldKey || '').endsWith(':result')), JSON.stringify(r2.errors));
 });
+
+// —— Issue #159（方案 B）：HD 出边按运行时归一化 id（e.result || String(e.outcome)）
+//    判重的冲突在校验期显式拒绝。typed outcome 与同名字符串、result 与 outcome 同名
+//    都会在运行期画卡/续跑坍缩为同一 choice id——绝不允许"校验通过但运行期静默不可达"。
+//    夹具说明：out 边逐个 push，fixture 删 HD 出边后余边数固定为 3（index 0..2），
+//    故第 k 条 HD 出边坐标为 $.edges[3+k]。
+const hdWithOutEdges = (outEdges) => {
+  const b = hdClone();
+  b.edges = b.edges.filter((e) => !(e && e.from === '$human-decision'));
+  outEdges.forEach((out) => b.edges.push(Object.assign({ from: '$human-decision', to: 'finish' }, out)));
+  return b;
+};
+const expectNormalizedReject = (bp, id, label) => {
+  const r = validateBlueprint(bp);
+  assert.equal(r.ok, false, label + '：应拒绝（存在校验通过但运行期不可达的静默态）');
+  const hit = r.errors.filter((e) => String(e.message).includes('归一化') && String(e.message).includes('choice id "' + id + '"'));
+  assert.ok(hit.length >= 1, label + '：缺归一化冲突错误，实际 ' + JSON.stringify(r.errors));
+  // 错误必须同时指明两条冲突边的坐标（fieldKey 指向后一条出边，消息引用首条坐标）
+  const coords = r.errors
+    .filter((e) => String(e.message).includes('归一化'))
+    .flatMap((e) => Array.from(String(e.message).matchAll(/\$\.edges\[(\d+)\]/g)).map((m) => Number(m[1])))
+    .concat(r.errors.filter((e) => String(e.message).includes('归一化')).map((e) => { const m = /\$\.edges\[(\d+)\]/.exec(e.at || ''); return m ? Number(m[1]) : -1; }));
+  assert.ok(coords.includes(3) && coords.includes(4), label + '：缺两条边坐标，coords=' + JSON.stringify(coords) + ' errors=' + JSON.stringify(r.errors));
+};
+
+test('#159 typed outcome false 与字符串 "false" 归一化冲突拒绝', () => {
+  expectNormalizedReject(hdWithOutEdges([{ outcome: false }, { outcome: 'false' }]), 'false', 'false-vs-string');
+});
+
+test('#159 typed outcome 0 与字符串 "0" 归一化冲突拒绝', () => {
+  expectNormalizedReject(hdWithOutEdges([{ outcome: 0 }, { outcome: '0' }]), '0', '0-vs-string');
+});
+
+test('#159 typed outcome true 与字符串 "true" 归一化冲突拒绝', () => {
+  expectNormalizedReject(hdWithOutEdges([{ outcome: true }, { outcome: 'true' }]), 'true', 'true-vs-string');
+});
+
+test('#159 outcome "SHIP" 与 result "SHIP" 跨形态同名冲突拒绝', () => {
+  // result 边先入（坐标 3），outcome 边后入（坐标 4）——归一化后同 id 亦拒绝
+  expectNormalizedReject(
+    hdWithOutEdges([{ on: 'success', result: 'SHIP' }, { outcome: 'SHIP' }]),
+    'SHIP',
+    'result-vs-outcome',
+  );
+  // 反向顺序：outcome 边先入、result 边后入，同样拒绝
+  const rev = hdWithOutEdges([{ outcome: 'HOLD' }, { on: 'success', result: 'HOLD' }]);
+  const r = validateBlueprint(rev);
+  assert.equal(r.ok, false, 'result 后入方向也应拒绝');
+  assert.ok(r.errors.some((e) => String(e.message).includes('归一化') && String(e.message).includes('choice id "HOLD"')), JSON.stringify(r.errors));
+});
+
+test('#159 归一化后不同的 typed/纯字符串 outcome 蓝图仍通过（不误伤）', () => {
+  // typed false vs 字符串 "no"：归一化 id 'false' 与 'no' 不同
+  const a = hdWithOutEdges([{ outcome: false }, { outcome: 'no' }]);
+  assert.equal(validateBlueprint(a).ok, true, JSON.stringify(validateBlueprint(a).errors));
+  // 纯字符串 outcome（如 SHIP / HOLD）各自归一化 id 不同 → 通过
+  const b = hdWithOutEdges([{ outcome: 'SHIP' }, { outcome: 'HOLD' }]);
+  assert.equal(validateBlueprint(b).ok, true, JSON.stringify(validateBlueprint(b).errors));
+  // 多个 result 边互不冲突 → 通过（旧行为）
+  const c = hdWithOutEdges([{ on: 'success', result: 'SHIP' }, { on: 'success', result: 'HOLD' }]);
+  assert.equal(validateBlueprint(c).ok, true, JSON.stringify(validateBlueprint(c).errors));
+});

--- a/scripts/test/validate-blueprint.test.mjs
+++ b/scripts/test/validate-blueprint.test.mjs
@@ -504,3 +504,71 @@ test('#159 归一化后不同的 typed/纯字符串 outcome 蓝图仍通过（�
   const c = hdWithOutEdges([{ on: 'success', result: 'SHIP' }, { on: 'success', result: 'HOLD' }]);
   assert.equal(validateBlueprint(c).ok, true, JSON.stringify(validateBlueprint(c).errors));
 });
+
+// —— Issue #159（A1）：判重表必须安全处理合法原型键。普通对象 seenHdChoiceIds 会把单条
+//    outcome "toString"/"constructor"/"__proto__" 经 Object.prototype 继承链伪报为"已登记"，
+//    误报归一化冲突并生成 "$.edges[function toString() { [native code] }]" 这类非真实边坐标。
+//    修复：判重表改 Map（无原型链）；这些 id 运行期也无法表示（画卡装配的 subsequent_effects
+//    为普通对象，判重会伪命中并把该出边静默丢弃），故校验期显式拒绝并报真实边坐标——
+//    由契约规则拒绝，不靠原型链伪造冲突。
+test('#159 A1 原型键 outcome：不伪报归一化冲突，显式保留键拒绝且坐标为真实边', () => {
+  ['toString', 'constructor', '__proto__'].forEach((key) => {
+    const r = validateBlueprint(hdWithOutEdges([{ outcome: key }]));
+    assert.equal(r.ok, false, key + '：运行期普通对象无法承载，须显式拒绝（不得静默放行）');
+    assert.equal(
+      r.errors.filter((e) => String(e.message).includes('归一化冲突')).length,
+      0,
+      key + '：不得伪报归一化冲突：' + JSON.stringify(r.errors),
+    );
+    assert.ok(
+      !JSON.stringify(r.errors).includes('function '),
+      key + '：错误不得含函数序列化的伪坐标：' + JSON.stringify(r.errors),
+    );
+    const hit = r.errors.find((e) => String(e.message).includes('保留键'));
+    assert.ok(hit, key + '：应有运行时保留键契约错误：' + JSON.stringify(r.errors));
+    assert.equal(hit.at, '$.edges[3].outcome', key + '：at 必须指向真实边坐标，实际 ' + hit.at);
+    assert.equal(hit.fieldKey, 'edge:3:outcome', key + '：fieldKey 必须映射真实边，实际 ' + hit.fieldKey);
+  });
+  // 两个不同的原型键（toString + constructor）：Map 判重表不得把它们伪报为同一 choice id
+  const pair = hdWithOutEdges([{ outcome: 'toString' }, { outcome: 'constructor' }]);
+  const rp = validateBlueprint(pair);
+  assert.equal(rp.ok, false, '原型键出边整体仍须拒绝（运行期无法承载）');
+  assert.equal(
+    rp.errors.filter((e) => String(e.message).includes('归一化冲突')).length,
+    0,
+    'toString 与 constructor 不得被伪报为归一化冲突：' + JSON.stringify(rp.errors),
+  );
+  assert.equal(
+    rp.errors.filter((e) => String(e.message).includes('保留键')).length,
+    2,
+    '两个原型键应各自报保留键错误：' + JSON.stringify(rp.errors),
+  );
+});
+
+// —— Issue #159（A2）：校验端 hdChoiceId 必须与运行期语义同构。运行期取 id 是
+//    `e.result || String(e.outcome)`——result 段"任意 truthy 值优先"（空白串 " " 同样优先），
+//    校验 helper 不得假设 result 必须是非空白字符串；且 outcome 与 result 不得同边混用
+//    （结构层只禁 outcome+on、不禁 outcome+result）。否则混合字段边可通过校验、运行期却取
+//    另一套身份：outcome "A"/"B" 各带空白 result " " 时，校验按 A/B 判不冲突，运行期两条边
+//    归一化 id 均为空白 result → 画卡只暴露一个选项（静默不可达）。
+test('#159 A2 outcome 与 result 同边（混合字段）拒绝，杜绝校验通过后运行期另取身份', () => {
+  // 审核示例：两条 outcome 边各带空白 result " "（truthy，运行期优先于 outcome）
+  const pair = hdWithOutEdges([{ outcome: 'A', result: ' ' }, { outcome: 'B', result: ' ' }]);
+  const r = validateBlueprint(pair);
+  assert.equal(r.ok, false, '混合字段边不得通过校验：' + JSON.stringify(r.errors));
+  const mixes = r.errors.filter((e) => String(e.message).includes('互斥'));
+  assert.ok(mixes.length >= 2, '两条混合边都应报 outcome 与 result 互斥：' + JSON.stringify(r.errors));
+  // 单条混合字段边同样拒绝（空白与非空白 result 都要拒）
+  for (const single of [{ outcome: 'SHIP', result: 'HOLD' }, { outcome: 'SHIP', result: ' ' }]) {
+    const r2 = validateBlueprint(hdWithOutEdges([single]));
+    assert.equal(r2.ok, false, '单条混合字段边也须拒绝：' + JSON.stringify(r2.errors));
+    assert.ok(r2.errors.some((e) => String(e.message).includes('互斥')), JSON.stringify(r2.errors));
+  }
+  // 显式 result: undefined（等价于未声明；JSON 往返会丢弃）不算混用 → 纯 outcome 边保持通过
+  const ud = hdWithOutEdges([{ outcome: 'SHIP', result: undefined }, { outcome: 'HOLD' }]);
+  const r3 = validateBlueprint(ud);
+  assert.equal(r3.ok, true, 'result:undefined 不应触发互斥：' + JSON.stringify(r3.errors));
+  // 纯字符串兼容不回归：合法 outcome 边与 result 边归一化 id 互异时仍通过
+  const clean = hdWithOutEdges([{ outcome: 'SHIP' }, { outcome: 'HOLD' }, { on: 'success', result: 'CARGO' }]);
+  assert.equal(validateBlueprint(clean).ok, true, JSON.stringify(validateBlueprint(clean).errors));
+});

--- a/scripts/validate-core.cjs
+++ b/scripts/validate-core.cjs
@@ -112,6 +112,18 @@ function outcomeKey(value) {
   return JSON.stringify(value)
 }
 
+// Issue #159（方案 B）：HD 出边 choice id 与运行时取 id 逻辑同构——
+// 运行时（scripts/generate.mjs assembleDecisionPackage / 续跑查找）用
+// `e.result || String(e.outcome)` 归一化出边 id；typed outcome（false/0 等）与同名字符串
+// （"false"/"0"），以及 result 与 outcome 同名，都会坍缩为同一 choice id，导致其中一条
+// 合法出边在运行期画卡/续跑永远不可达。校验端用同一归一化 id 建冲突表，杜绝"校验通过
+// 但运行期静默不可达"的中间态。字符串/布尔/数字统一走 String()，与运行时逐字一致。
+function hdChoiceId(e) {
+  if (typeof e.result === 'string' && e.result.trim()) return e.result
+  if (e.outcome !== undefined && e.outcome !== null && e.outcome !== '') return String(e.outcome)
+  return null
+}
+
 // ---------- 错误坐标 → 编辑器 fieldKey ----------
 function fieldKeyOf(at) {
   if (!at || typeof at !== 'string') return undefined
@@ -709,6 +721,11 @@ function validateBlueprint(bp, opts) {
     }
     const seenHdResults = {}
     const seenHdOutcomes = {}
+    // Issue #159：按运行时归一化 choice id 建统一冲突表——typed outcome 与同名字符串
+    // （outcome: false vs outcome: "false"）、以及 result 与 outcome 同名（result: "SHIP"
+    // vs outcome: "SHIP"）在运行期（generate.mjs e.result || String(e.outcome)）都坍缩为
+    // 同一 choice id，其中一条出边静默不可达；此处显式拒绝并报告两条冲突边坐标与归一化 id。
+    const seenHdChoiceIds = {}
     const hdIn = bp.edges.filter((e) => e && e.to === HUMAN_DECISION_ID && isStructuralEdge(e))
     const hdOut = bp.edges.filter((e) => e && e.from === HUMAN_DECISION_ID)
     if (hdIn.length === 0 && hdOut.some(hasOutcomeField)) {
@@ -726,8 +743,20 @@ function validateBlueprint(bp, opts) {
       if (e.from !== HUMAN_DECISION_ID) return
       if (hasOutcomeField(e)) {
         const key = outcomeKey(e.outcome)
-        if (seenHdOutcomes[key]) err(at + '.outcome', 'Decision Result 重复：' + key)
-        else seenHdOutcomes[key] = true
+        if (seenHdOutcomes[key]) {
+          err(at + '.outcome', 'Decision Result 重复：' + key)
+        } else {
+          seenHdOutcomes[key] = true
+          const id = hdChoiceId(e)
+          if (id !== null) {
+            const first = seenHdChoiceIds[id]
+            if (first !== undefined) {
+              err(at + '.outcome', 'HD 选项归一化冲突：与 $.edges[' + first + '] 归一化后为同一 choice id "' + id + '"（运行期画卡/续跑按 e.result || String(e.outcome) 归一化取 id，两条边坍缩为一、后者不可达）；请改用显式 result 命名区分')
+            } else {
+              seenHdChoiceIds[id] = i
+            }
+          }
+        }
         return
       }
       if (e.on !== 'success') {
@@ -744,6 +773,15 @@ function validateBlueprint(bp, opts) {
         err(at + '.result', 'Decision Result 重复：' + e.result)
       } else {
         seenHdResults[e.result] = true
+        const id = hdChoiceId(e)
+        if (id !== null) {
+          const first = seenHdChoiceIds[id]
+          if (first !== undefined) {
+            err(at + '.result', 'HD 选项归一化冲突：与 $.edges[' + first + '] 归一化后为同一 choice id "' + id + '"（运行期画卡/续跑按 e.result || String(e.outcome) 归一化取 id，两条边坍缩为一、后者不可达）；请改用显式 result 命名区分')
+          } else {
+            seenHdChoiceIds[id] = i
+          }
+        }
       }
     })
   }

--- a/scripts/validate-core.cjs
+++ b/scripts/validate-core.cjs
@@ -26,6 +26,12 @@ const FANOUT_ITEMS_RESULTS_RE = /^\$\.results\.([a-z0-9]+(?:-[a-z0-9]+)*)(?:\.[A
 const HD_RESULT_RE = /^[A-Z][A-Z0-9_]*$/
 const HD_REASONS = ['HUMAN_ACCEPTANCE', 'ESCALATED_DECISION', 'MAX_ROUNDS_REACHED']
 const HD_CONTROL_RESULTS = ['USER_ACCEPTED', 'ADD_BUDGET', 'STOP']
+// Issue #159（A1）：运行期画卡装配把 `subsequent_effects` 建成普通对象 `{}`——choice id 若命中
+// Object.prototype 继承键（toString / constructor / __proto__ 等），其判重 `pkg.subsequent_effects[id]`
+// 会伪命中并把该出边静默丢弃（选项永不进画卡、续跑不可达）。这类 id 运行期无法表示，校验期
+// 显式拒绝（报真实边坐标），不得依赖无原型判重表放行后再让运行期静默不可达。
+const HD_RUNTIME_RESERVED_IDS = new Set(Object.getOwnPropertyNames(Object.prototype))
+HD_RUNTIME_RESERVED_IDS.add('__proto__')
 const HD_PACKAGE_REQUIRED = ['why', 'current_state', 'options', 'subsequent_effects']
 const HD_PACKAGE_OPTIONAL_UNKNOWN = ['cost', 'benefit', 'risk', 'recommendation']
 const HD_EVENT_FIELDS = [
@@ -112,15 +118,19 @@ function outcomeKey(value) {
   return JSON.stringify(value)
 }
 
-// Issue #159（方案 B）：HD 出边 choice id 与运行时取 id 逻辑同构——
+// Issue #159（方案 B）：HD 出边 choice id 与运行时取 id 逻辑逐字同构——
 // 运行时（scripts/generate.mjs assembleDecisionPackage / 续跑查找）用
-// `e.result || String(e.outcome)` 归一化出边 id；typed outcome（false/0 等）与同名字符串
-// （"false"/"0"），以及 result 与 outcome 同名，都会坍缩为同一 choice id，导致其中一条
-// 合法出边在运行期画卡/续跑永远不可达。校验端用同一归一化 id 建冲突表，杜绝"校验通过
-// 但运行期静默不可达"的中间态。字符串/布尔/数字统一走 String()，与运行时逐字一致。
+// `e.result || String(e.outcome)` 归一化出边 id，其中 result 段是"任意 truthy 值优先"
+// （空白串 " "、数字等同样优先，绝无"非空白字符串"假设）；typed outcome（false/0 等）
+// 与同名字符串（"false"/"0"），以及 result 与 outcome 同名，都会坍缩为同一 choice id，
+// 导致其中一条合法出边在运行期画卡/续跑永远不可达。校验端用同一归一化 id 建冲突表，
+// 杜绝"校验通过但运行期静默不可达"的中间态。HD 出边的 result+outcome 混用已在出边校验处
+// 显式互斥拒绝（#159 A2），故进入本函数时二者不同边共存、取值永不分叉。
 function hdChoiceId(e) {
-  if (typeof e.result === 'string' && e.result.trim()) return e.result
-  if (e.outcome !== undefined && e.outcome !== null && e.outcome !== '') return String(e.outcome)
+  if (!e) return null
+  if (e.result) return e.result
+  const outcome = e.outcome
+  if (outcome !== undefined && outcome !== null && outcome !== '') return String(outcome)
   return null
 }
 
@@ -725,7 +735,10 @@ function validateBlueprint(bp, opts) {
     // （outcome: false vs outcome: "false"）、以及 result 与 outcome 同名（result: "SHIP"
     // vs outcome: "SHIP"）在运行期（generate.mjs e.result || String(e.outcome)）都坍缩为
     // 同一 choice id，其中一条出边静默不可达；此处显式拒绝并报告两条冲突边坐标与归一化 id。
-    const seenHdChoiceIds = {}
+    // 判重表用 Map 而非普通对象（#159 A1）：普通对象会把 toString/constructor/__proto__ 等
+    // 经 Object.prototype 继承链伪报为已登记，既误伤合法单边又让冲突错误生成
+    // "$.edges[function toString()...]" 这类非真实边坐标。
+    const seenHdChoiceIds = new Map()
     const hdIn = bp.edges.filter((e) => e && e.to === HUMAN_DECISION_ID && isStructuralEdge(e))
     const hdOut = bp.edges.filter((e) => e && e.from === HUMAN_DECISION_ID)
     if (hdIn.length === 0 && hdOut.some(hasOutcomeField)) {
@@ -741,6 +754,16 @@ function validateBlueprint(bp, opts) {
         err(at + '.on', '升 Human Decision 的入边须为 success（failure 边仍表示打回）')
       }
       if (e.from !== HUMAN_DECISION_ID) return
+      // Issue #159（A2）：outcome 与 result 同边混合字段显式互斥——result 只属于 on:"success"
+      // 出边（SCREAMING_SNAKE 显式命名）；结构层仅禁 outcome 与 on 互斥、不禁 outcome 与 result，
+      // 而运行期画卡/续跑一律 `e.result || String(e.outcome)`（任意 truthy result 优先，含空白串
+      // " "）。outcome 边若夹带 truthy result，校验端与运行期会对同一条边取不同 choice id 身份，
+      // 冲突蓝图可穿过校验（如 outcome:"A" 与 outcome:"B" 各带 result:" " 时校验视为 A/B 不冲突、
+      // 运行期两条边都坍缩为空白 result）。此处显式拒绝，杜绝该分叉。
+      if (hasOutcomeField(e) && e.result !== undefined) {
+        err(at + '.result', 'outcome 与 result 互斥：result 仅用于 on:"success" 出边；业务 outcome 边携带 result 时运行期 e.result || String(e.outcome) 会改取其身份（#159）')
+        return
+      }
       if (hasOutcomeField(e)) {
         const key = outcomeKey(e.outcome)
         if (seenHdOutcomes[key]) {
@@ -749,11 +772,18 @@ function validateBlueprint(bp, opts) {
           seenHdOutcomes[key] = true
           const id = hdChoiceId(e)
           if (id !== null) {
-            const first = seenHdChoiceIds[id]
-            if (first !== undefined) {
-              err(at + '.outcome', 'HD 选项归一化冲突：与 $.edges[' + first + '] 归一化后为同一 choice id "' + id + '"（运行期画卡/续跑按 e.result || String(e.outcome) 归一化取 id，两条边坍缩为一、后者不可达）；请改用显式 result 命名区分')
+            if (HD_RUNTIME_RESERVED_IDS.has(id)) {
+              // #159（A1）：判重表本身已无原型污染（Map），但该 id 运行期无法表示——
+              // 普通对象 subsequent_effects 会把继承键当已占用、静默丢弃该出边；此处
+              // 显式拒绝并给出真实边坐标与修复指引，不允许校验放行后运行期再次不可达。
+              err(at + '.outcome', 'choice id "' + id + '" 为运行时保留键（画卡装配的 subsequent_effects 以普通对象承载，toString/constructor/__proto__ 等原型键会被判为已占用而静默丢弃该出边）；请改用显式 result 命名（如 result: SHIP）区分（#159）')
             } else {
-              seenHdChoiceIds[id] = i
+              const first = seenHdChoiceIds.get(id)
+              if (first !== undefined) {
+                err(at + '.outcome', 'HD 选项归一化冲突：与 $.edges[' + first + '] 归一化后为同一 choice id "' + id + '"（运行期画卡/续跑按 e.result || String(e.outcome) 归一化取 id，两条边坍缩为一、后者不可达）；请改用显式 result 命名区分')
+              } else {
+                seenHdChoiceIds.set(id, i)
+              }
             }
           }
         }
@@ -775,11 +805,11 @@ function validateBlueprint(bp, opts) {
         seenHdResults[e.result] = true
         const id = hdChoiceId(e)
         if (id !== null) {
-          const first = seenHdChoiceIds[id]
+          const first = seenHdChoiceIds.get(id)
           if (first !== undefined) {
             err(at + '.result', 'HD 选项归一化冲突：与 $.edges[' + first + '] 归一化后为同一 choice id "' + id + '"（运行期画卡/续跑按 e.result || String(e.outcome) 归一化取 id，两条边坍缩为一、后者不可达）；请改用显式 result 命名区分')
           } else {
-            seenHdChoiceIds[id] = i
+            seenHdChoiceIds.set(id, i)
           }
         }
       }


### PR DESCRIPTION
## Summary
- Issue #159（follow-up of #149）：HD outcome 字符串归一化后选项/出边冲突（`false` vs `"false"`）。
- 采用设计包裁决的**方案 B（校验期拒绝归一化冲突）**：`scripts/validate-core.cjs` HD 出边校验段新增统一冲突表（Map），按运行时 `e.result || String(e.outcome)` 同构语义拒绝归一化后相同的 choice id（typed↔同名字符串、result↔outcome 跨形态同名），错误指明冲突边坐标与归一化 id。
- 顺带收口 A1/A2：运行时保留键（`toString`/`constructor`/`__proto__`）显式拒绝且报真实边坐标；`outcome`+`result` 同边混合字段显式互斥，杜绝"校验通过但运行期静默不可达"中间态。
- 运行时 `scripts/generate.mjs` **零改动**（方案 B 单一策略，无混合态）；`packages/dsh-visual-workflow`、`templates/`、测试夹具均未触碰。
- 改动范围：`scripts/validate-core.cjs`、两份 HD 回归测试、`docs/design/blueprint-schema.md`、`CONTEXT.md`。

Closes #159

## Test plan
- [x] `npm test`：293/293 pass（含 #159 A1/A2 用例）
- [x] `npm run generate`：幂等通过
- [x] `npm run validate`：蓝图 2 份 / 重生成一致性 21 文件 / 引擎层 / 包测试全绿
- [x] 建设 Run `cwf-159-01`：dev/review/test 三方同 HEAD（1fd14d4）通过；人工验收 accept

## Reports（Run cwf-159-01）
- `.agent-runs/cwf-159-01/requirements-baseline.md`
- `.agent-runs/cwf-159-01/design-package.md`
- `.agent-runs/cwf-159-01/dev-report.md`
- `.agent-runs/cwf-159-01/review-report.md`
- `.agent-runs/cwf-159-01/test-report.md`
- `.agent-runs/cwf-159-01/accept-report.md` / `acceptance-summary.md`