### PR TITLE
feat: 蓝图 JSON 导入 / 历史模板迁自定义 / 角色库深化

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,7 +74,7 @@
 ## 插件界面层（编辑器与运行看板）
 
 - **工作流面板**：DSH 设置页注入的 `settings.section`（`client.js` 末尾 `slots.inject`），内含两个页签。
-- **模板库（templates 页签）**：工作流清单（一行一个模板，内置标 builtin 且只读），操作 = 新建 / 编辑 / 删除。
+- **模板库（templates 页签）**：工作流清单（一行一个模板）。正式内置标 builtin 且只读；当前两套历史模板 `default-workflow` / `dev-workflow-2-0` 已迁为自定义（无内置标签，可编辑/删除）。操作 = 新建 / 编辑 / 删除。
 - **运行看板（dashboard 页签）**：每 3 秒轮询 `vwf.runs.list` + `vwf.state`，呈现**运行列表**（可点选切换）、
   当前 run 的状态/阶段、只读画布（节点按状态染色，按 workflowId 匹配模板 DSL）、**子代理表格**与
   最近 20 条日志。**与模板库无关**（两者常被混指）。

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,6 +11,9 @@
 - **蓝图（blueprint）**：`templates/*.json`，工作流唯一事实源——人只改它，生成物禁手改。
 - **生成物（artifact）**：`.generated/<id>/` 四件套（`script.mjs` / `vwf-dsl.json` / `SKILL.md` / `meta.json`），gitignore + 重生成比对保护。其中 `SKILL.md` 含 **runbook（操作手册）**：按脚本返回状态告诉主会话下一步怎么做。
 - **节点 / 边 / 入口 / $end**：蓝图图结构。边分 success（成功/打回后继续）与 failure（打回/终止）两类。
+- **角色库（Role Library）**：供工作流节点选择与管理角色的目录，由正式内置角色与自定义角色组成；角色身份与节点结果契约彼此独立。
+- **内置角色（Built-in Role）**：产品定义的正式角色，机器 ID 与展示顺序稳定，始终可选、只读，可作为创建自定义角色的起点。
+- **自定义角色（Custom Role）**：用户可创建和维护的角色；历史 `dispatcher` 属于自定义角色，迁移后仍保持既有引用可解析。
 
 ## 引擎层（框架，与业务无关）
 

--- a/dsh/roles/builtin-roles.json
+++ b/dsh/roles/builtin-roles.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "builtins": [
+    { "id": "requirements", "name": "需求分析", "summary": "需求分析角色：三要素门禁，产出需求基线", "definition": "dsh/roles/requirements.md", "builtin": true, "readonly": true },
+    { "id": "designer", "name": "方案设计", "summary": "方案设计角色：实施路径、关键取舍与风险", "definition": "dsh/roles/designer.md", "builtin": true, "readonly": true },
+    { "id": "dev", "name": "开发", "summary": "开发角色：测试驱动施工，满足质量闸门", "definition": "dsh/roles/dev.md", "builtin": true, "readonly": true },
+    { "id": "review", "name": "审核", "summary": "审核角色：规范与需求符合性、代码质量双轴审查", "definition": "dsh/roles/review.md", "builtin": true, "readonly": true },
+    { "id": "test", "name": "测试", "summary": "测试角色：运行态验证，证据驱动判定", "definition": "dsh/roles/test.md", "builtin": true, "readonly": true },
+    { "id": "evaluator", "name": "评估", "summary": "评估角色：按节点评价契约独立评估，场景差异由节点表达", "definition": "dsh/roles/evaluator.md", "builtin": true, "readonly": true },
+    { "id": "accept", "name": "验收助手", "summary": "验收助手角色：对照验收标准最终核验并等待人工签字", "definition": "dsh/roles/accept.md", "builtin": true, "readonly": true },
+    { "id": "closeout", "name": "收口", "summary": "收口角色：一致性收口与交接产物汇总", "definition": "dsh/roles/closeout.md", "builtin": true, "readonly": true },
+    { "id": "diagnose", "name": "缺陷诊断", "summary": "缺陷诊断角色：先取证后结论，收敛到根因", "definition": "dsh/roles/diagnose.md", "builtin": true, "readonly": true },
+    { "id": "orchestrator", "name": "探索统筹", "summary": "探索统筹角色：设计研究方案与专家任务书", "definition": "dsh/roles/orchestrator.md", "builtin": true, "readonly": true },
+    { "id": "researcher", "name": "专家研究", "summary": "专家研究角色：按任务书独立取证，含反证", "definition": "dsh/roles/researcher.md", "builtin": true, "readonly": true },
+    { "id": "synthesizer", "name": "综合分析", "summary": "综合分析角色：把独立判断整合为可决策的观点地图", "definition": "dsh/roles/synthesizer.md", "builtin": true, "readonly": true }
+  ],
+  "compatibilityRoles": [
+    { "id": "dispatcher", "builtin": false, "visibility": "workspace-or-bundle" }
+  ]
+}

--- a/packages/dsh-visual-workflow/README.md
+++ b/packages/dsh-visual-workflow/README.md
@@ -112,7 +112,8 @@ dsh --profile web --dump-config | grep visual-workflow   # 可见 patch 层
 | `vwf.script` | 统一编译器管道（T-IMP-12）：DSL → `scripts/generate.mjs compileBlueprint` 译文（CLI 兜底），返回脚本全文、meta 与 engineAvailable。`vwf.compile` 已随统一编译器删除 |
 | `vwf.state` | 运行状态（runId → status/phase/agents/logs） |
 | `vwf.models` | 对接 DSH 宿主 `llm` 服务的 provider/model 列表（编辑器的 Agent/模型下拉数据源） |
-| `vwf.roles` | 读取工作区 `dsh/roles/*.md`（`fs` 服务，多形态兜底；不可用回退内置六角色） |
+| `vwf.roles / roles.get / roles.usage / roles.validate` | 角色库（issue-58/81）：内置 12 角色（清单事实源 `dsh/roles/builtin-roles.json`）+ 自定义（工作区 `dsh/roles/*.md`）+ 打包回退；决策内核 `scripts/role-library.cjs`（名称规则/来源优先级/摘要/引用统计/CRUD 裁决），`vwf.roles.validate` 为客户端权威名称校验；core 不可用时降级为内置只读清单 |
+| `vwf.roles.create / update / remove` | 自定义角色生命周期：内核裁决（内置只读、重命名零引用、引用阻止删除）→ Host 适配器执行（写盘/重命名回滚/删除） |
 
 ## 测试
 

--- a/packages/dsh-visual-workflow/scripts/build-bundle.mjs
+++ b/packages/dsh-visual-workflow/scripts/build-bundle.mjs
@@ -16,12 +16,18 @@ mkdirSync(dist, { recursive: true })
 const hostPath = join(root, 'src', 'host.js')
 const clientPath = join(root, 'src', 'client.js')
 const formalArtifactsSrc = join(root, '..', '..', 'scripts', 'formal-artifacts.cjs')
+const roleLibrarySrc = join(root, '..', '..', 'scripts', 'role-library.cjs')
+const roleManifestSrc = join(root, '..', '..', 'dsh', 'roles', 'builtin-roles.json')
 const hostBody = readFileSync(hostPath, 'utf8')
 const clientBody = readFileSync(clientPath, 'utf8')
+const roleLibraryBody = readFileSync(roleLibrarySrc, 'utf8')
+const roleManifestBody = readFileSync(roleManifestSrc, 'utf8')
 const sha256 = (buf) => createHash('sha256').update(buf).digest('hex')
 const stamp = {
   host: sha256(hostBody),
   client: sha256(clientBody),
+  roleLibrary: sha256(roleLibraryBody),
+  roleManifest: sha256(roleManifestBody),
   builtAt: new Date().toISOString(),
 }
 
@@ -68,6 +74,10 @@ writeFileSync(
 
 writeFileSync(join(dist, '.src-stamp.json'), JSON.stringify(stamp, null, 2) + '\n')
 copyFileSync(formalArtifactsSrc, join(dist, 'formal-artifacts.cjs'))
+copyFileSync(join(root, '..', '..', 'scripts', 'validate-core.cjs'), join(dist, 'validate-core.cjs'))
+// 角色库内核 + 内置角色清单：静态安装的可信加载源（host.js 候选根 pluginRoot/dist）
+copyFileSync(roleLibrarySrc, join(dist, 'role-library.cjs'))
+copyFileSync(roleManifestSrc, join(dist, 'builtin-roles.json'))
 console.log('built:', join(dist, 'host-entry.mjs'))
 console.log('built:', join(dist, 'client.js'))
 console.log('stamp:', stamp.host.slice(0, 12), stamp.client.slice(0, 12))

--- a/packages/dsh-visual-workflow/scripts/check-dist-fresh.mjs
+++ b/packages/dsh-visual-workflow/scripts/check-dist-fresh.mjs
@@ -9,9 +9,13 @@ import { fileURLToPath } from 'node:url'
 const root = dirname(dirname(fileURLToPath(import.meta.url)))
 const hostPath = join(root, 'src', 'host.js')
 const clientPath = join(root, 'src', 'client.js')
+const roleLibraryPath = join(root, '..', '..', 'scripts', 'role-library.cjs')
+const roleManifestPath = join(root, '..', '..', 'dsh', 'roles', 'builtin-roles.json')
 const stampPath = join(root, 'dist', '.src-stamp.json')
 const distHost = join(root, 'dist', 'host-entry.mjs')
 const distClient = join(root, 'dist', 'client.js')
+const distRoleLibrary = join(root, 'dist', 'role-library.cjs')
+const distRoleManifest = join(root, 'dist', 'builtin-roles.json')
 
 const sha256 = (file) => createHash('sha256').update(readFileSync(file)).digest('hex')
 const fail = (msg) => {
@@ -22,6 +26,9 @@ const fail = (msg) => {
 
 if (!existsSync(distHost) || !existsSync(distClient) || !existsSync(stampPath)) {
   fail('缺少 dist/host-entry.mjs、dist/client.js 或 dist/.src-stamp.json')
+}
+if (!existsSync(distRoleLibrary) || !existsSync(distRoleManifest)) {
+  fail('缺少 dist/role-library.cjs 或 dist/builtin-roles.json（角色库内核随包分发）')
 }
 
 let stamp
@@ -35,6 +42,12 @@ const host = sha256(hostPath)
 const client = sha256(clientPath)
 if (stamp.host !== host || stamp.client !== client) {
   fail('源码哈希与 stamp 不符（host ' + host.slice(0, 12) + ' / client ' + client.slice(0, 12) + '）')
+}
+// 角色库内核与清单也纳入新鲜度闸门：改内核/manifest 未重建 dist 时正式安装会加载过期逻辑
+const roleLibrary = sha256(roleLibraryPath)
+const roleManifest = sha256(roleManifestPath)
+if (stamp.roleLibrary !== roleLibrary || stamp.roleManifest !== roleManifest) {
+  fail('角色库内核/清单哈希与 stamp 不符（roleLibrary ' + roleLibrary.slice(0, 12) + ' / roleManifest ' + roleManifest.slice(0, 12) + '）')
 }
 
 const body = readFileSync(distHost, 'utf8')

--- a/packages/dsh-visual-workflow/src/client.js
+++ b/packages/dsh-visual-workflow/src/client.js
@@ -536,8 +536,42 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
 
     function clone(x) { return JSON.parse(JSON.stringify(x)) }
 
+    // 编辑器 JSON tab 同时接受蓝图落盘格式（displayName / bindings.models）与 DSL。
+    // 粘贴 templates/*.json 时把模型绑到节点、展示名写入 name，画布才能显示 provider/model。
+    function ingestEditorJson(raw) {
+      if (!raw || typeof raw !== 'object' || !Array.isArray(raw.nodes)) return raw
+      const models = (raw.bindings && raw.bindings.models && typeof raw.bindings.models === 'object')
+        ? raw.bindings.models : {}
+      const isBlueprint = typeof raw.displayName === 'string' || Object.keys(models).length > 0
+      if (!isBlueprint) return raw
+      const nodes = raw.nodes.map((n) => {
+        if (!n || typeof n !== 'object') return n
+        if (n.model || !models[n.id]) return n
+        return { ...n, model: models[n.id] }
+      })
+      const name = (typeof raw.name === 'string' && raw.name.trim() && raw.name !== raw.id)
+        ? raw.name
+        : (typeof raw.displayName === 'string' ? raw.displayName : (raw.name || ''))
+      const next = { ...raw, nodes, name }
+      delete next.displayName
+      delete next.bindings
+      return next
+    }
+
     // ── 拓扑与布局（对应 workflowGraph.ts 的 successTopologyOrder /
     //    deriveEntryCandidateIds / computeBackwardLanes / layoutSuccessPath）──
+    function hasOutcomeField(e) {
+      return !!(e && e.outcome !== undefined && e.outcome !== null && e.outcome !== '')
+    }
+    function isStructuralEdge(e) {
+      return !!(e && (e.on === 'success' || hasOutcomeField(e)))
+    }
+    // 与校验内核同构：countRound 声明 / 自环 = 回退边，不参与入口入边与主链分层。
+    function isRollbackEdge(e) {
+      if (!isStructuralEdge(e)) return false
+      if (e.from === e.to) return true
+      return e.countRound !== undefined
+    }
     function successTopologyOrder(dsl) {
       const ids = (dsl.nodes || []).map(n => n && n.id).filter(Boolean)
       const idSet = new Set(ids)
@@ -545,7 +579,8 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       const indegree = new Map()
       ids.forEach(id => { adjacency.set(id, []); indegree.set(id, 0) })
       ;(dsl.edges || []).forEach(e => {
-        if (e.on !== 'success') return
+        if (!isStructuralEdge(e) || isRollbackEdge(e)) return
+        if (e.from === e.to) return
         if (!idSet.has(e.from) || !idSet.has(e.to)) return
         adjacency.get(e.from).push(e.to)
         indegree.set(e.to, (indegree.get(e.to) || 0) + 1)
@@ -556,7 +591,9 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       pushRoot(dsl.entry)
       ids.forEach(id => { if ((indegree.get(id) || 0) === 0) pushRoot(id) })
       const ordered = []
-      while (queue.length) {
+      const leftover = () => ids.filter(id => !queued.has(id))
+      while (queue.length || leftover().length) {
+        if (!queue.length) pushRoot(leftover()[0])
         const id = queue.shift()
         ordered.push(id)
         ;(adjacency.get(id) || []).forEach(next => {
@@ -564,7 +601,6 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
           if ((indegree.get(next) || 0) === 0) pushRoot(next)
         })
       }
-      ids.forEach(id => { if (!queued.has(id)) ordered.push(id) })
       const order = new Map()
       ordered.forEach((id, i) => order.set(id, i))
       return order
@@ -578,14 +614,14 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
 
     function deriveEntryCandidates(dsl) {
       const ids = new Set((dsl.nodes || []).map(n => n && n.id).filter(Boolean))
-      const order = successTopologyOrder({ ...dsl, entry: '' })
       const incoming = new Set()
       ;(dsl.edges || []).forEach(e => {
-        if (!ids.has(e.from) || !ids.has(e.to)) return
-        if (e.on !== 'success' && isBackwardEdge(e.from, e.to, order)) return
+        if (!isStructuralEdge(e) || isRollbackEdge(e)) return
+        if (!e.to || e.to === END_NODE || e.to === '$human-decision' || !ids.has(e.to)) return
+        if (!(ids.has(e.from) || e.from === '$human-decision')) return
         incoming.add(e.to)
       })
-      return (dsl.nodes || []).map(n => n.id).filter(id => Boolean(id) && !incoming.has(id))
+      return (dsl.nodes || []).map(n => n && n.id).filter(id => Boolean(id) && !incoming.has(id))
     }
 
     function normalizeEntry(dsl) {
@@ -719,7 +755,7 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       const allIds = nodeIds.concat(terminalIds)
       const sizeOf = (id) => id === END_NODE ? { w: TERM_W, h: TERM_H } : { w: NODE_W, h: NODE_H }
 
-      // rank：success + 前向非 success 边参与最长路（对应 layoutSuccessPath 的过滤）
+      // rank：前向结构边（success ∪ 非回退 outcome）定最长路；回退/失败边不把目标拉到更右
       const rank = {}
       allIds.forEach(id => { rank[id] = 0 })
       let changed = true
@@ -731,7 +767,7 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
           if (e.from === e.to) continue
           if (!idSet.has(e.from)) continue
           if (!(idSet.has(e.to) || e.to === END_NODE)) continue
-          if (e.on !== 'success' && isBackwardEdge(e.from, e.to, order)) continue
+          if (isRollbackEdge(e) || (!isStructuralEdge(e) && isBackwardEdge(e.from, e.to, order))) continue
           if (rank[e.from] + 1 > (rank[e.to] || 0)) { rank[e.to] = rank[e.from] + 1; changed = true }
         }
       }
@@ -863,7 +899,7 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       const panRef = React.useRef(null)
       const lay = React.useMemo(
         () => layoutGraph(dsl, props.visibleTerminals || []),
-        [JSON.stringify({ entry: dsl.entry || '', n: (dsl.nodes || []).map(n => n.id), e: (dsl.edges || []).map(e => [e.from, e.to, e.on]), v: props.visibleTerminals || [] })]
+        [JSON.stringify({ entry: dsl.entry || '', n: (dsl.nodes || []).map(n => n.id), e: (dsl.edges || []).map(e => [e.from, e.to, e.on, e.outcome, e.countRound]), v: props.visibleTerminals || [] })]
       )
       const pos = lay.pos
       const W = lay.W
@@ -2087,7 +2123,7 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
             setJsonError(t('outputSchemaInvalid'))
             return
           }
-          toSave = normalizeEntry(parsed)
+          toSave = normalizeEntry(ingestEditorJson(parsed))
           setWf(toSave)
         }
         const v = await host.call('vwf.validate', { dsl: toSave }).catch(() => null)
@@ -2144,7 +2180,7 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
         try {
           const parsed = JSON.parse(value)
           if (parsed && Array.isArray(parsed.nodes)) {
-            const next = normalizeEntry(parsed)
+            const next = normalizeEntry(ingestEditorJson(parsed))
             setWf(next)
           }
         } catch (e) { /* 保留草稿，保存时报错 */ }

--- a/packages/dsh-visual-workflow/src/client.js
+++ b/packages/dsh-visual-workflow/src/client.js
@@ -111,7 +111,6 @@ return {
       customRoleBadge: '自定义角色',
       saveRole: '保存角色',
       cancelRole: '取消',
-      roleDupName: '已存在同名角色，请使用其他名称。',
       roleNameRequired: '角色名称不能为空',
       roleContentRequired: '角色配置不能为空',
       roleNameInvalid: '角色名称不能为空，且最长 64 字符、不含非法字符（/\\:*?"<>|）',
@@ -267,7 +266,6 @@ return {
       customRoleBadge: 'Custom',
       saveRole: 'Save Role',
       cancelRole: 'Cancel',
-      roleDupName: 'A role with the same name already exists; please use another name.',
       roleNameRequired: 'Role name is required',
       roleContentRequired: 'Role configuration is required',
       roleNameInvalid: 'Role name is required, at most 64 chars, no illegal chars (/\\:*?"<>|)',
@@ -1703,13 +1701,19 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
           } else setError((r && r.errors && r.errors[0] && r.errors[0].message) || t('roleSaveFailed'))
         }).catch((e) => setError(String(e)))
       }
-      const validForm = () => {
+      // 名称权威校验（Host：完整规则——非法字符/首尾点/Windows 保留名 + 唯一性含内置/
+      // 自定义/打包回退）。客户端不再维护规则副本；本地只保留空值即时提示（非权威快速通道）。
+      const validateNameWithHost = async (name) => {
+        const v = await host.call('vwf.roles.validate', { name: name, excludeId: (current && current.builtin === false) ? current.id : undefined }).catch((e) => ({ ok: false, errors: [{ message: String(e) }] }))
+        if (v && v.ok === true) return null
+        return (v && v.errors && v.errors[0] && v.errors[0].message) || t('roleNameInvalid')
+      }
+      const validForm = async () => {
         const name = draftName.trim()
-        if (!name || name.length > 64 || /[\\/:*?"<>|\x00-\x1F\x7F]/.test(name)) { setError(t('roleNameInvalid')); return null }
+        if (!name) { setError(t('roleNameRequired')); return null }
         if (!draftContent.trim()) { setError(t('roleContentRequired')); return null }
-        const key = (s) => String(s || '').normalize('NFC').toLowerCase()
-        const dup = (roles || []).some(r => key(r.id) === key(name) && (!current || r.id !== current.id))
-        if (dup) { setError(t('roleDupName')); return null }
+        const bad = await validateNameWithHost(name)
+        if (bad) { setError(bad); return null }
         return name
       }
       const submitForm = (name, content) => {
@@ -1728,8 +1732,8 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
           } else setError((r && r.errors && r.errors[0] && r.errors[0].message) || t('roleSaveFailed'))
         }).catch((e) => setError(t('roleSaveFailed') + String(e))).then(() => setSaving(false))
       }
-      const save = () => {
-        const name = validForm()
+      const save = async () => {
+        const name = await validForm()
         if (!name) return
         const editingCustom = !!(current && current.builtin === false)
         if (!editingCustom) { submitForm(name, draftContent); return }
@@ -1759,8 +1763,14 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       }
       const askDelete = (role) => {
         host.call('vwf.roles.usage', { id: role.id, draftDsl: props.draftDsl }).then((u) => {
-          setConfirm({ kind: (u && u.ok && u.count > 0) ? 'blocked' : 'delete', role: role, usage: (u && u.ok) ? u : null })
-        }).catch((e) => setError(String(e)))
+          if (!u || u.ok !== true) {
+            // fail-closed：引用统计失败时绝不进入删除确认（修复 fail-open：ok:false 曾被
+            // 折叠为「零引用」直接放行删除）
+            setError(t('roleUsageFailed') + ((u && u.errors && u.errors[0] && u.errors[0].message) || ''))
+            return
+          }
+          setConfirm({ kind: u.count > 0 ? 'blocked' : 'delete', role: role, usage: u })
+        }).catch((e) => setError(t('roleUsageFailed') + String(e)))
       }
       const doDelete = () => {
         if (!confirm || !confirm.role) return
@@ -1834,6 +1844,13 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
             h('input', {
               className: 'vwf-input', value: draftName, placeholder: t('roleNamePlaceholder'),
               onChange: (ev) => setDraftName(ev.target.value),
+              onBlur: () => {
+                const name = draftName.trim()
+                if (!name) return
+                // 失焦即时提示（Host 权威裁决）：.foo/foo./CON/COM1 等过去仅在保存时报错的
+                // 名称现在输入即提示；输入过程不打断，错误在失焦/保存时呈现
+                validateNameWithHost(name).then((bad) => { if (bad) setError(bad) })
+              },
             })
           ),
           h('div', { className: 'vwf-field' },

--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -110,6 +110,19 @@ return {
       if (sp && typeof sp.workspaceRoot === 'string' && sp.workspaceRoot) return sp.workspaceRoot
       return null
     }
+    // 静态 bundle 注入 __VWF_REPO_ROOT__；历史动态 loader 注入 __VWF_REPO__。
+    function injectedRepoRoot() {
+      if (typeof __VWF_REPO_ROOT__ === 'string' && __VWF_REPO_ROOT__) return __VWF_REPO_ROOT__
+      if (typeof __VWF_REPO__ === 'string' && __VWF_REPO__) return __VWF_REPO__
+      return null
+    }
+    function parentDir(dir) {
+      if (!dir || dir === '/') return null
+      const trimmed = String(dir).replace(/\/+$/, '')
+      const slash = trimmed.lastIndexOf('/')
+      if (slash <= 0) return null
+      return trimmed.slice(0, slash)
+    }
 
     let nodePathPromise = null
     function resolveNode() {
@@ -171,16 +184,19 @@ return {
           // 都写在该变量里。子进程 -e 必须读取它，不能无条件 os.homedir()+/.dsh，
           // 否则 workspace 会落到产品 ~/.dsh/workspaces（Codex Round 3）。
           const injected = hostProcessDshHome()
+          // 明确注入的 DSH_HOME 是宿主事实，必须直接采用。此前先信任 probe 输出，
+          // 当 subprocess 未继承 env 覆盖时 probe 成功返回 ~/.dsh，反而覆盖开发
+          // ~/.dsh-workflow-dev，导致动态插件污染产品 Home。
+          if (injected) return injected
           const probe = "console.log(process.env.DSH_HOME || require('path').join(require('os').homedir(), '.dsh'))"
           const r = await runNode(['-e', probe], {
             cwd: repoRoot() || '/',
-            env: injected ? { DSH_HOME: injected } : {},
+            env: {},
           })
           if (r.ok) {
             const home = (r.stdout || '').trim()
             if (home) return home
           }
-          if (injected) return injected
           try {
             if (typeof process !== 'undefined' && process && process.env && typeof process.env.HOME === 'string' && process.env.HOME) {
               return process.env.HOME.replace(/\/$/, '') + '/.dsh'
@@ -192,10 +208,22 @@ return {
       return dshHomePromise
     }
 
+    async function homeRepoPointer() {
+      const home = await dshHome()
+      if (!home || fs === undefined) return null
+      try {
+        const target = await fs.resolve(home + '/visual-workflow/repo-root')
+        const info = await fs.stat(target)
+        if (!info || info.type !== 'file') return null
+        const text = String(await fs.readText(target) || '').trim()
+        return text || null
+      } catch (e) { return null }
+    }
+
     async function rootPaths() {
       const repo = repoRoot()
       const home = await dshHome()
-      const packageRepo = (typeof __VWF_REPO_ROOT__ === 'string' && __VWF_REPO_ROOT__) ? __VWF_REPO_ROOT__ : null
+      const packageRepo = injectedRepoRoot() || (await homeRepoPointer())
       const generatorRoot = packageRepo || repo
       return {
         repo: repo,
@@ -304,6 +332,8 @@ return {
     }
     // 与 apply 时序解耦的异步同步：不阻塞 apply，失败仅在终端日志留痕
     syncBuiltins().catch((e) => console.log('[vwf] 内置模板同步失败：' + String((e && e.message) || e)))
+    syncValidatorCore().catch((e) => console.log('[vwf] 校验内核同步失败：' + String((e && e.message) || e)))
+    syncRoleAssets().catch((e) => console.log('[vwf] 角色库内核同步失败：' + String((e && e.message) || e)))
 
     // 历史两套正式模板已按目标规格迁为 Custom Workflow，不再占用内置身份。
     // 生成物仍可出现在模板库（任意项目可见的 default-workflow / 仓库内的
@@ -536,31 +566,124 @@ return {
     //   → 错误坐标映射 fieldErrors（node:<id>:<field> / edge:<i>:<field> / control:<field>）。
     // 原 validateDsl / heteroCheck / 拓扑推导 / COND_RE 已删除（唯一实现收敛进内核）。
     let validatorCorePromise = null
+    function addValidatorRoot(paths, seen, root) {
+      let dir = root
+      for (let i = 0; i < 8 && dir; i++) {
+        const file = dir + '/scripts/validate-core.cjs'
+        if (!seen.has(file)) {
+          seen.add(file)
+          paths.push(file)
+        }
+        dir = parentDir(dir)
+      }
+    }
+    async function validatorCoreCandidatePaths() {
+      const paths = []
+      const seen = new Set()
+      function addFile(file) {
+        if (!file || seen.has(file)) return
+        seen.add(file)
+        paths.push(file)
+      }
+      // 浏览器保存没有会话 cwd。Home 副本与仓库指针是动态模式的稳定来源，
+      // 必须排在 sandboxPolicy.workspaceRoot（DSH 部署目录）前面。
+      const home = await dshHome()
+      if (home) addFile(home + '/visual-workflow/validate-core.cjs')
+      addValidatorRoot(paths, seen, await homeRepoPointer())
+      addValidatorRoot(paths, seen, injectedRepoRoot())
+      if (typeof __VWF_PLUGIN_ROOT__ === 'string' && __VWF_PLUGIN_ROOT__) {
+        const pluginRoot = __VWF_PLUGIN_ROOT__
+        addFile(pluginRoot + '/dist/validate-core.cjs')
+        addValidatorRoot(paths, seen, parentDir(parentDir(pluginRoot)))
+      }
+      addValidatorRoot(paths, seen, repoRoot())
+      return paths
+    }
+    async function evalValidatorCore(src) {
+      const module = { exports: {} }
+      new Function('module', 'exports', src)(module, module.exports)
+      if (!module.exports || typeof module.exports.validateBlueprint !== 'function') return null
+      return module.exports
+    }
+    async function syncValidatorCore() {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        fs = ctx.get('fs')
+        subprocess = ctx.get('subprocess')
+        if (fs !== undefined) break
+        try {
+          await new Promise((r) => setTimeout(r, 100 * (attempt + 1)))
+        } catch (e) { break }
+      }
+      if (fs === undefined) return
+      const home = await dshHome()
+      if (!home) return
+      const policy = writePolicy()
+      const dest = home + '/visual-workflow/validate-core.cjs'
+      const pointer = home + '/visual-workflow/repo-root'
+      const files = await validatorCoreCandidatePaths()
+      for (const file of files) {
+        if (file === dest) continue
+        try {
+          const target = await fs.resolve(file)
+          const info = await fs.stat(target)
+          if (!info || info.type !== 'file') continue
+          const src = await fs.readText(target)
+          if (!src || src.indexOf('validateBlueprint') < 0) continue
+          await fs.writeText(await fs.resolve(dest), src, undefined, undefined, policy)
+          if (file.indexOf('/scripts/validate-core.cjs') !== -1) {
+            const root = file.slice(0, file.length - '/scripts/validate-core.cjs'.length)
+            if (root) {
+              try { await fs.writeText(await fs.resolve(pointer), root + '\n', undefined, undefined, policy) } catch (e) { /* 指针可选 */ }
+            }
+          }
+          return
+        } catch (e) { /* 尝试下一个候选 */ }
+      }
+    }
+    async function readValidatorCoreViaNode() {
+      if (subprocess === undefined) return null
+      const probe = [
+        "const fs=require('fs');const path=require('path');const os=require('os');",
+        "function tryFile(p){try{if(!p)return false;if(!fs.existsSync(p)||!fs.statSync(p).isFile())return false;const s=fs.readFileSync(p,'utf8');if(s.indexOf('function validateBlueprint')<0)return false;process.stdout.write(s);return true}catch(e){return false}}",
+        "function walk(d){for(let i=0;i<8&&d&&d!=='/';i++){if(tryFile(path.join(d,'scripts','validate-core.cjs')))return true;const n=path.dirname(d);if(n===d)break;d=n}return false}",
+        "const homes=[];if(process.env.DSH_HOME)homes.push(process.env.DSH_HOME);",
+        "try{homes.push(path.join(os.homedir(),'.dsh-workflow-dev'))}catch(e){}",
+        "for(const h of homes){if(tryFile(path.join(h,'visual-workflow','validate-core.cjs')))process.exit(0)}",
+        "const cands=[];try{cands.push(process.cwd())}catch(e){};if(process.env.PWD)cands.push(process.env.PWD);",
+        "for(const c of cands){if(walk(c))process.exit(0)}process.exit(2)",
+      ].join('')
+      const home = await dshHome()
+      const r = await runNode(['-e', probe], { cwd: home || '/' })
+      if (r.ok && r.stdout && r.stdout.indexOf('function validateBlueprint') >= 0) return r.stdout
+      return null
+    }
     function loadValidatorCore() {
-      if (!validatorCorePromise) {
-        validatorCorePromise = (async () => {
-          const repo = repoRoot()
-          if (fs === undefined) return null
-          // 动态会话优先读当前项目；静态/web 模式没有项目路径时，
-          // 读取组合包注入的仓库根，避免编辑器保存被误报为缺少校验内核。
-          const roots = [
-            repo,
-            (typeof __VWF_REPO_ROOT__ === 'string' && __VWF_REPO_ROOT__) ? __VWF_REPO_ROOT__ : null,
-          ].filter(Boolean)
-          for (const root of roots) {
+      if (validatorCorePromise) return validatorCorePromise
+      const pending = (async () => {
+        // 动态会话 / 浏览器保存没有 currentInitiator；部署 cwd 也不是仓库根。
+        // 候选：会话 cwd、注入仓库根、宿主指针、插件 dist、DSH Home 副本；
+        // fs 沙箱读不到仓库时，再经 node 子进程按 DSH cwd 找内核。
+        if (fs !== undefined) {
+          const files = await validatorCoreCandidatePaths()
+          for (const file of files) {
             try {
-              const target = await fs.resolve(root + '/scripts/validate-core.cjs')
+              const target = await fs.resolve(file)
               const info = await fs.stat(target)
               if (!info || info.type !== 'file') continue
               const src = await fs.readText(target)
-              const module = { exports: {} }
-              new Function('module', 'exports', src)(module, module.exports)
-              return module.exports
-            } catch (e) { /* 尝试下一个根 */ }
+              const core = await evalValidatorCore(src)
+              if (core) return core
+            } catch (e) { /* 尝试下一个路径 */ }
           }
-          return null
-        })()
-      }
+        }
+        const spawned = await readValidatorCoreViaNode()
+        if (spawned) return evalValidatorCore(spawned)
+        return null
+      })()
+      validatorCorePromise = pending.then((core) => {
+        if (!core) validatorCorePromise = null
+        return core
+      })
       return validatorCorePromise
     }
 
@@ -1432,19 +1555,22 @@ return {
       return { providers: out }
     })
 
-    // ── 角色库（issue-58：内置/自定义分类 + 生命周期管理）─────────────────────
-    // 模型：内置角色 = 系统正式角色（issue-81 的 12 角色），
-    // 常驻、只读、可查看/选择/基于其创建自定义变体；自定义角色 = 工作区
-    // dsh/roles/ 下不属于内置集合的 *.md（与运行时 profile→<roleDir>/<id>.md
-    // 的消费契约一致：保存即被 wf_run 产出的脚本按原机制读取，无需运行时改造）。
-    // 引用 = 全部工作流（内置模板 + 用户模板）节点 profile 命中该角色 id 的计数，
-    // 删除/重命名前的安全保护以引用数裁决；内容修改则天然全局生效（引用按 id）。
+    // ── 角色库（深模块 RoleLibrary + manifest 数据化）─────────────────────
+    // 模型：内置角色 = 系统正式角色（issue-81 的 12 角色），常驻、只读、可查看/选择/
+    // 基于其创建自定义变体；自定义角色 = 工作区 dsh/roles/ 下不属于内置集合的 *.md
+    // （与运行时 profile→<roleDir>/<id>.md 的消费契约一致：保存即被 wf_run 产出的
+    // 脚本按原机制读取，无需运行时改造）。引用 = 全部工作流（内置模板 + 用户模板）
+    // 节点 profile 命中该角色 id 的计数，删除/重命名前的安全保护以引用数裁决。
+    // issue-81：旧 dispatcher 已退出内置身份，迁为自定义角色（dsh/roles/dispatcher.md
+    // 原位保留，引用它的历史工作流无需任何改动即可继续工作）。
     //
-    // issue-81：旧 `dispatcher` 已退出内置身份，迁为自定义角色。其定义文件保留在
-    // dsh/roles/ 原位，因此引用它的历史工作流无需任何改动即可继续工作。
-    // issue-81 正式 12 角色：通用基础能力 8 个 + 专业能力 4 个。
-    // 顺序即角色库「内置」分组的展示顺序，与产品规格 §8 名单一致。
-    const BUILTIN_ROLES = [
+    // 决策内核 = scripts/role-library.cjs（唯一实现：名称规则 / 来源优先级 / 摘要口径 /
+    // usage 统计 / 只读与回滚裁决）；内置清单事实源 = dsh/roles/builtin-roles.json。
+    // 本段只剩 cordis 胶水：core+manifest 同根成对加载、事实采集适配器（fs/subprocess）、
+    // 效果执行（写/重命名/删除 + 回滚）、RPC 转发。core 不可用时降级为嵌入只读清单
+    // （EMBEDDED_BUILTIN_MANIFEST：机器投影自 manifest，禁止手改；一致性由
+    // tests/role-manifest.test.mjs 保证）。
+    const EMBEDDED_BUILTIN_MANIFEST = [
       // ── 通用基础能力 ──
       { id: 'requirements', name: '需求分析', summary: '需求分析角色：三要素门禁，产出需求基线' },
       { id: 'designer', name: '方案设计', summary: '方案设计角色：实施路径、关键取舍与风险' },
@@ -1460,11 +1586,7 @@ return {
       { id: 'researcher', name: '专家研究', summary: '专家研究角色：按任务书独立取证，含反证' },
       { id: 'synthesizer', name: '综合分析', summary: '综合分析角色：把独立判断整合为可决策的观点地图' },
     ]
-    const BUILTIN_ROLE_IDS = BUILTIN_ROLES.map((r) => r.id)
-    const ROLE_NAME_MAX = 64
-    // 名称唯一性键：NFC 规范化 + 小写（macOS/Windows 默认文件系统对规范化/大小写
-    // 不敏感，未归一化会令等价名称指向同一文件而互相覆盖）。
-    const roleKey = (s) => String(s || '').normalize('NFC').toLowerCase()
+
     // fs.resolve 句柄 → 子进程 argv 可用的绝对路径字符串（真实句柄含 displayPath）
     const pathOf = (h) => (typeof h === 'string') ? h : (h && (h.displayPath || h.targetKey)) || null
     // 只有「确认不存在」（ENOENT 类）才算缺失目录；其余错误按瞬时 I/O 失败 fail-closed
@@ -1475,40 +1597,20 @@ return {
       const p = await rootPaths()
       return p.repo ? p.repo + '/dsh/roles' : 'dsh/roles'
     }
-    // 角色正文摘要：取首个有意义行（跳过 frontmatter 键/标题），截 80 字符；空则回退 fallback。
-    // readRoleFiles 与 getRoleDetail 共用，保证「列表摘要/详情摘要/展示正文」口径一致。
-    const summarizeRole = (content, fallback = '') => {
-      if (typeof content !== 'string') return fallback
-      const firstLine = content.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('---') && !l.startsWith('id:') && !l.startsWith('name:') && !l.startsWith('summary') && !l.startsWith('createdAt') && !l.startsWith('updatedAt') && !l.startsWith('dynamicTemplate') && !l.startsWith('#'))[0]
-      return (firstLine || fallback).slice(0, 80)
-    }
-    // 内置角色打包快照（#129 遗留项 1）：__VWF_REPO_ROOT__/dsh/roles/<id>.md——与运行时
-    // roleRef 编译期内联同源（generate.mjs DEFAULT_ROLES_DIR 即同一目录）。读不到返回 null。
-    async function readBuiltinRoleSnapshot(id) {
-      const roots = [(typeof __VWF_REPO_ROOT__ === 'string' && __VWF_REPO_ROOT__) ? __VWF_REPO_ROOT__ : null].filter(Boolean)
-      for (const root of roots) {
-        try {
-          const target = await fs.resolve(root + '/dsh/roles/' + id + '.md')
-          const info = await fs.stat(target)
-          if (info && info.type === 'file') return String(await fs.readText(target))
-        } catch (e) { /* 尝试下一个根 */ }
-      }
-      return null
-    }
-    // 读取角色目录：返回 { files: Map<id,{summary,content}>, state: ok|missing|error, message }。
-    // fail-closed：读取失败（而非目录缺失）必须阻断后续唯一性校验与变更。
+    // 读取角色目录：返回 { files: Map<id,{content}>, state: ok|missing|error, message }。
+    // 摘要口径在内核（只传原始正文）。fail-closed：读取失败（而非目录缺失）必须阻断
+    // 后续唯一性校验与变更。
     async function readRoleFiles() {
       const out = new Map()
       if (fs === undefined) return { files: out, state: 'error', message: '宿主文件能力不可用' }
       const roleDir = await roleDirPath()
-      // 只有「确认不存在」才归为 missing（可作为空清单放行）；resolve 失败可能是
+      // 只有「确认不存在」（ENOENT）归 missing（可作为空清单放行）；resolve 失败可能是
       // 瞬时路径错误、stat 失败是瞬态读错误——都按 error fail-closed，避免创建/
       // 重命名把失败当空库放行而覆盖既有角色。
       let dir = null
       try {
         dir = await fs.resolve(roleDir)
       } catch (e) {
-        // 只有确认不存在（ENOENT）归 missing；resolve 的瞬时/宿主错误按 error fail-closed
         if (isMissingErr(e)) return { files: out, state: 'missing', message: '角色目录不存在：' + roleDir }
         return { files: out, state: 'error', message: '角色目录解析失败：' + String((e && e.message) || e) }
       }
@@ -1526,195 +1628,30 @@ return {
           .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
         for (const ent of entries) {
           const id = ent.name.replace(/\.md$/i, '')
-          let summary = ''
           let content = null
           try {
             content = String(await fs.readText(await fs.resolve(roleDir + '/' + ent.name)))
-            summary = summarizeRole(content)
-          } catch (e) { /* 单文件读取失败跳过摘要 */ }
-          out.set(id, { summary, content })
+          } catch (e) { /* 单文件读取失败保留 id（防止同名覆盖），正文按缺失处理 */ }
+          out.set(id, { content })
         }
         return { files: out, state: 'ok' }
       } catch (e) {
         return { files: out, state: 'error', message: '角色目录读取失败：' + String((e && e.message) || e) }
       }
     }
-    // 统一角色清单：内置六角色常驻（内容/摘要优先取工作区文件，缺失回退内置元数据），
-    // 自定义 = 角色目录中不属于内置集合的 *.md（按 id 字母序）。
-    // includeContent = true 时携带 content（null 值剔除，lossless-JSON 守卫）。
-    async function listLibraryRoles(includeContent) {
-      const inv = await readRoleFiles()
-      const files = inv.files
-      const roles = []
-      for (const b of BUILTIN_ROLES) {
-        // 内置角色摘要/内容与详情、运行时 roleRef 同序（#129 遗留项 1）：打包快照优先、
-        // 工作区回退——否则旧版 dsh/roles/<id>.md 会以旧版摘要/正文出现在角色列表，
-        // 与详情/执行口径不一致。
-        const snap = await readBuiltinRoleSnapshot(b.id)
-        const f = files.get(b.id)
-        const entry = { id: b.id, name: b.name, summary: snap != null ? summarizeRole(snap, b.summary) : ((f && f.summary) || b.summary), builtin: true }
-        if (includeContent) {
-          const content = snap != null ? snap : (f && f.content != null ? f.content : null)
-          if (content != null) entry.content = content
-        }
-        roles.push(entry)
+    // 内置角色打包快照（#129 遗留项 1）：__VWF_REPO_ROOT__/dsh/roles/<id>.md——与运行时
+    // roleRef 编译期内联同源（generate.mjs DEFAULT_ROLES_DIR 即同一目录）。读不到返回 null。
+    async function readBuiltinRoleSnapshot(id) {
+      const roots = [(typeof __VWF_REPO_ROOT__ === 'string' && __VWF_REPO_ROOT__) ? __VWF_REPO_ROOT__ : null].filter(Boolean)
+      for (const root of roots) {
+        try {
+          const target = await fs.resolve(root + '/dsh/roles/' + id + '.md')
+          const info = await fs.stat(target)
+          if (info && info.type === 'file') return String(await fs.readText(target))
+        } catch (e) { /* 尝试下一个根 */ }
       }
-      // 打包回退（Codex PR#124 第二轮 P1）：产品工作区无 dsh/roles/dispatcher.md 时，
-      // 迁出内置但被 bundleRoles 模板引用的历史角色从打包快照只读回退到自定义分组，
-      // 不写入 .generated。用户编辑时种子到工作区 dsh/roles/。
-      let bundledLegacy = null
-      try { bundledLegacy = await bundledLegacyRoles() } catch (e) { bundledLegacy = new Map() }
-      const customIds = Array.from(files.keys()).filter(id => BUILTIN_ROLE_IDS.indexOf(id) < 0).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
-      const seenCustom = new Set(customIds)
-      for (const id of customIds) {
-        const f = files.get(id)
-        const entry = { id, name: id, summary: f.summary || '', builtin: false }
-        if (includeContent) entry.content = f.content
-        roles.push(entry)
-      }
-      // 打包回退角色排在已落盘自定义角色之后（可见但非首选）
-      const bundledIds = Array.from(bundledLegacy.keys()).filter(id => !seenCustom.has(id)).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
-      for (const id of bundledIds) {
-        const content = bundledLegacy.get(id) || ''
-        const firstLine = content.split('\n').find(l => l.trim()) || ''
-        const entry = { id, name: id, summary: firstLine, builtin: false }
-        if (includeContent) entry.content = content
-        roles.push(entry)
-      }
-      return roles
-    }
-    // 单个角色详情：内置角色定义来源顺序与运行时 roleRef 对齐（#129 遗留项 1）——
-    // 打包快照（__VWF_REPO_ROOT__/dsh/roles，编译期内联同源）→ 工作区 dsh/roles 回退
-    // → 内置元数据合成占位正文。否则工作区一份旧版/本地改过的同名文件会盖过模板自带
-    // 的版本化定义，编辑器展示与执行口径不一致。自定义角色仍以工作区为准（打包只读兜底）。
-    async function getRoleDetail(id) {
-      const inv = await readRoleFiles()
-      const files = inv.files
-      if (BUILTIN_ROLE_IDS.indexOf(id) >= 0) {
-        const meta = BUILTIN_ROLES.find(r => r.id === id)
-        // 内置角色定义来源顺序与运行时 roleRef 对齐（#129 遗留项 1）：打包快照 →
-        // 工作区 dsh/roles 回退 → 元数据占位兜底。否则工作区一份旧版/本地改过的
-        // 同名文件会盖过模板自带的版本化定义，编辑器展示与执行口径不一致。
-        let content = await readBuiltinRoleSnapshot(id)
-        if (content == null) {
-          const f = files.get(id)
-          content = f && f.content
-        }
-        if (content == null) content = '# ' + meta.name + '（' + id + '）\n\n' + meta.summary + '\n\n> 当前工作区未包含该内置角色的完整定义（dsh/roles/' + id + '.md），角色仍可正常选择使用。'
-        // 摘要与展示正文同源（summarizeRole），占位正文回退注册表摘要
-        return { id, name: meta.name, summary: summarizeRole(content, meta.summary), builtin: true, content }
-      }
-      const f = files.get(id)
-      if (f) return { id, name: id, summary: f.summary || '', builtin: false, content: f.content != null ? f.content : '' }
-      // 打包回退（Codex PR#124 第二轮 P1）：工作区无文件时，从打包快照只读回退
-      let bundledLegacy = null
-      try { bundledLegacy = await bundledLegacyRoles() } catch (e) { return null }
-      const content = bundledLegacy.get(id)
-      if (content == null) return null
-      const firstLine = content.split('\n').find(l => l.trim()) || ''
-      return { id, name: id, summary: firstLine, builtin: false, content }
-    }
-    // 引用扫描：全部工作流（内置模板 + 用户模板）+ 可选的开放草稿 DSL。草稿引用按
-    // workflowId 去重替换（打开编辑器编辑既有模板时其持久化版本已被统计，草稿内容
-    // 才是当前真实状态）；新草稿（无 id）以 draft: 前缀键独立计入——未保存但引用该
-    // 角色时禁止删除/重命名（P1：草稿随后保存会引用已删除的角色文件）。
-    async function roleUsage(id, draftDsl) {
-      // strict：内置/用户模板清单或单文件读取失败时抛出（破坏性变更前置：失败 ≠ 零引用）
-      const [builtins, users] = await Promise.all([loadBuiltins(true), loadUserTemplates(true)])
-      const wfRefs = new Map()
-      const add = (workflowId, workflowName, builtin, dsl, draft) => {
-        const nodes = []
-        for (const n of (dsl.nodes || []) || []) {
-          // 与文件名唯一性同一基准（roleKey：NFC + 小写）：大小写/规范化不敏感
-          // 文件系统上 profile 'Analyst' 同样引用 analyst.md 角色文件
-          if (n && typeof n.profile === 'string' && roleKey(n.profile) === roleKey(id)) nodes.push({ id: n.id, label: n.label || n.id })
-        }
-        if (!nodes.length) {
-          // 草稿里已移除全部引用 → 草稿状态取代持久化快照（否则会将「将要保存的
-          // 状态」误判为仍被引用而阻止删除/重命名，直到保存后才解除）
-          if (draft) wfRefs.delete(String(workflowId))
-          return
-        }
-        const ref = { workflowId: String(workflowId), workflowName: String(workflowName), builtin: !!builtin, nodes }
-        if (draft) ref.draft = true
-        wfRefs.set(ref.workflowId, ref)
-      }
-      for (const dsl of builtins.values()) add(dsl.id, dsl.name, true, dsl, false)
-      for (const bp of users.values()) add(bp.id, bp.displayName, false, projectToVwf(bp), false)
-      if (draftDsl && Array.isArray(draftDsl.nodes)) {
-        const draftId = draftDsl.id || ('draft:' + String(draftDsl.name || '未保存草稿'))
-        add(draftId, draftDsl.name || '未保存草稿', false, draftDsl, true)
-      }
-      const refs = Array.from(wfRefs.values())
-      const count = refs.reduce((sum, r) => sum + (r.nodes || []).length, 0)
-      return { count, refs }
-    }
-    // 角色名称校验：非空 / 长度 / 文件系统安全字符 / 首尾点 / Windows 保留设备名；
-    // 唯一性单列（需排除自身）。
-    function validateRoleName(name) {
-      const v = String(name || '').trim()
-      if (!v) return '角色名称不能为空'
-      if (v.length > ROLE_NAME_MAX) return '角色名称过长（最多 ' + ROLE_NAME_MAX + ' 字符）'
-      if (/[\\/:*?"<>|\x00-\x1F\x7F]/.test(v)) return '角色名称包含非法字符'
-      if (/^\./.test(v) || /\.$/.test(v)) return '角色名称不能以点开头或结尾'
-      if (/^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i.test(v)) return '角色名称是系统保留名（如 CON/NUL/AUX），请换一个名称'
       return null
     }
-    // 名称唯一性（NFC 归一 + 大小写不敏感，兼容 macOS/Windows 文件系统）：内置 + 现有自定义
-    // + 打包回退角色（Codex PR#124 第三轮 P2，评论 3889725486）。fail-closed：角色目录读取
-    // 失败（非目录缺失）时抛错，调用方阻断变更。
-    async function roleNameTaken(name, excludeId) {
-      const key = roleKey(name)
-      if (!key) return true
-      for (const b of BUILTIN_ROLES) {
-        const bId = roleKey(b.id)
-        if (excludeId && roleKey(excludeId) === bId) continue
-        if (bId === key) return true
-      }
-      const inv = await readRoleFiles()
-      if (inv.state === 'error') throw new Error('角色库读取失败，无法验证名称唯一性：' + inv.message)
-      for (const id of inv.files.keys()) {
-        const idKey = roleKey(id)
-        if (excludeId && roleKey(excludeId) === idKey) continue
-        if (idKey === key) return true
-      }
-      // 打包回退角色（Codex PR#124 第三轮 P2）：迁移角色经 bundledLegacyRoles 只读回退
-      // 可见时，同名 create 必须返回冲突——否则用户在角色库看到 dispatcher 已列出，
-      // create({name:'dispatcher'}) 却静默成功，绕过唯一性校验创建同名工作区文件。
-      // 打包回退读取失败不影响主校验（已覆盖内置 + 工作区，fail-closed 已在上文处理）。
-      try {
-        const bundled = await bundledLegacyRoles()
-        for (const id of bundled.keys()) {
-          const idKey = roleKey(id)
-          if (excludeId && roleKey(excludeId) === idKey) continue
-          if (idKey === key) return true
-        }
-      } catch (e) { /* 打包回退读取失败不影响主校验链路 */ }
-      return false
-    }
-
-    // 角色列表（节点表单的角色选择器 + 角色管理列表数据源）：内置常驻 + 自定义。
-    registerRpc('vwf.roles', async () => ({ roles: await listLibraryRoles(false) }))
-    // 角色详情（查看内置/编辑自定义前的完整配置）
-    registerRpc('vwf.roles.get', async (a) => {
-      const id = a && a.id
-      const role = id ? await getRoleDetail(id) : null
-      if (!role) return { ok: false, errors: [{ at: '$', message: '角色不存在：' + (id || '') }] }
-      return { ok: true, role }
-    })
-    // 引用统计（删除/修改前的保护提示数据源）：可携带开放草稿 DSL 一并计数
-    registerRpc('vwf.roles.usage', async (a) => {
-      const id = a && a.id
-      if (!id || typeof id !== 'string') return { ok: false, errors: [{ at: '$.id', message: '缺少角色 id' }] }
-      let u
-      try {
-        u = await roleUsage(id, a && a.draftDsl)
-      } catch (e) {
-        return { ok: false, errors: [{ at: '$', message: '引用统计失败：' + String((e && e.message) || e) }] }
-      }
-      return { ok: true, id, count: u.count, refs: u.refs }
-    })
-    // 空白新增 / 基于角色创建：校验名称与内容 → 写入工作区 dsh/roles/<name>.md
     // 打包角色包回退（Codex PR#124 第二轮 P1）：bundleRoles 模板自带 roles/ 快照，
     // 其中可能包含已迁出内置集合的历史自定义角色（如 dispatcher）。产品工作区没有
     // 仓库 dsh/roles/，这类角色必须仍以「自定义」身份可见、可编辑，否则从角色库消失。
@@ -1737,7 +1674,7 @@ return {
           for (const rf of roleEnts || []) {
             if (!rf || rf.type !== 'file' || !rf.name || !rf.name.endsWith('.md')) continue
             const id = rf.name.slice(0, -3)
-            if (!id || BUILTIN_ROLE_IDS.indexOf(id) >= 0 || out.has(id)) continue
+            if (!id || out.has(id)) continue
             try {
               out.set(id, String(await fs.readText(await fs.resolve(spot + '/' + ent.name + '/roles/' + rf.name))))
             } catch (e) { /* 单文件读取失败不影响其余 */ }
@@ -1747,146 +1684,350 @@ return {
       return out
     }
 
-    registerRpc('vwf.roles.create', async (a) => {
-      const name = String((a && a.name) || '').trim()
-      const content = a && typeof a.content === 'string' ? a.content : ''
-      if (fs === undefined) return { ok: false, errors: [{ at: '$', message: '宿主文件能力不可用：无法创建角色' }] }
-      const badName = validateRoleName(name)
-      if (badName) return { ok: false, errors: [{ at: 'name', message: badName }] }
-      if (!content.trim()) return { ok: false, errors: [{ at: 'content', message: '角色配置不能为空' }] }
-      let conflict = false
-      try {
-        conflict = await roleNameTaken(name, null)
-      } catch (e) {
-        return { ok: false, errors: [{ at: '$', message: String((e && e.message) || e) }] }
-      }
-      if (conflict) {
-        return { ok: false, errors: [{ at: 'name', message: '已存在同名角色，请使用其他名称。' }] }
-      }
-      const roleDir = await roleDirPath()
-      try {
-        const target = await fs.resolve(roleDir + '/' + name + '.md')
-        await fs.writeText(target, content + (content.endsWith('\n') ? '' : '\n'), undefined, undefined, writePolicy())
-      } catch (e) {
-        return { ok: false, errors: [{ at: '$', message: '角色文件写入失败：' + String((e && e.message) || e) }] }
-      }
-      const role = await getRoleDetail(name)
-      return { ok: true, role }
-    })
-    // 编辑自定义角色：内容修改全局生效（引用按 id 天然共享）；重命名仅零引用时允许
-    // （引用按 id 字符串，重命名会令所有引用失效——服务端强制，客户端也先提示）。
-    // 仅重命名路径需要 subprocess（删除旧文件）；纯内容编辑只依赖 fs。
-    registerRpc('vwf.roles.update', async (a) => {
-      const id = a && a.id
-      const content = a && typeof a.content === 'string' ? a.content : null
-      const newName = String((a && a.name) || '').trim()
-      if (fs === undefined) return { ok: false, errors: [{ at: '$', message: '宿主文件能力不可用：无法更新角色' }] }
-      if (!id || typeof id !== 'string') return { ok: false, errors: [{ at: '$.id', message: '缺少角色 id' }] }
-      if (BUILTIN_ROLE_IDS.indexOf(id) >= 0) {
-        return { ok: false, errors: [{ at: '$', message: '内置角色只读：' + id + ' 属于系统标准角色，不能修改；可基于其创建自定义角色。' }] }
-      }
-      const inv = await readRoleFiles()
-      if (inv.state === 'error') return { ok: false, errors: [{ at: '$', message: '角色库读取失败：' + inv.message }] }
-      // 存在性判定：工作区有文件，或打包回退可见（Codex PR#124 第二轮 P1）。
-      // 后者代表产品工作区无 dsh/roles/<id>.md 但 bundleRoles 模板自带该角色快照——
-      // 编辑时种子到工作区，.generated 不被改写。
-      let bundledLegacy = null
-      if (!inv.files.has(id)) {
-        try { bundledLegacy = await bundledLegacyRoles() } catch (e) { bundledLegacy = new Map() }
-        if (!bundledLegacy.has(id)) return { ok: false, errors: [{ at: '$', message: '自定义角色不存在：' + id }] }
-      }
-      const target = newName && newName !== id ? newName : id
-      let isRename = target !== id
-      if (isRename) {
-        // 大小写/Unicode 规范化差异（NFC 归一后相同）指向同一文件：拒绝，避免
-        // 写后删把自己的文件删掉（P1）。
-        if (roleKey(target) === roleKey(id)) {
-          return { ok: false, errors: [{ at: 'name', message: '新名称与当前名称仅大小写或写法不同（指向同一文件），请保留原名称或改用不同名称。' }] }
+    // ── core 加载：role-library.cjs + builtin-roles.json 同根成对读取（不混根）────
+    // 信任/新鲜度顺序：动态开发优先当前 repo（最新源码），home 副本仅兜底；正式静态
+    // 优先可信插件 dist，绝不先 eval 任意会话工作区。源码静态测试（无 pluginRoot）
+    // 才允许 repo 根。缓存限定为本次插件激活。
+    let roleLibraryPromise = null
+    function evalRoleLibrary(src) {
+      const module = { exports: {} }
+      try { new Function('module', 'exports', src)(module, module.exports) } catch (e) { return null }
+      const ex = module.exports
+      if (!ex || typeof ex.createRoleLibrary !== 'function') return null
+      return ex
+    }
+    function addRoleAssetPairs(pairs, seen, root) {
+      let dir = root
+      for (let i = 0; i < 8 && dir; i++) {
+        const core = dir + '/scripts/role-library.cjs'
+        if (!seen.has(core)) {
+          seen.add(core)
+          pairs.push({ core: core, manifest: dir + '/dsh/roles/builtin-roles.json' })
         }
-        const badName = validateRoleName(target)
-        if (badName) return { ok: false, errors: [{ at: 'name', message: badName }] }
-        try {
-          if (await roleNameTaken(target, id)) {
-            return { ok: false, errors: [{ at: 'name', message: '已存在同名角色，请使用其他名称。' }] }
+        dir = parentDir(dir)
+      }
+    }
+    async function roleAssetCandidatePairs() {
+      const pairs = []
+      const seen = new Set()
+      function addPair(core, manifest) {
+        if (!core || seen.has(core)) return
+        seen.add(core)
+        pairs.push({ core: core, manifest: manifest })
+      }
+      const pluginRoot = (typeof __VWF_PLUGIN_ROOT__ === 'string' && __VWF_PLUGIN_ROOT__) ? __VWF_PLUGIN_ROOT__ : null
+      // 正式静态：可信 dist 必须第一；不扫描任意会话工作区 CJS。
+      if (!isDynamicHost && pluginRoot) {
+        addPair(pluginRoot + '/dist/role-library.cjs', pluginRoot + '/dist/builtin-roles.json')
+      }
+      // 动态开发：当前 repo 最新源码必须先于可能过期的 home 同步副本。
+      if (isDynamicHost) {
+        addRoleAssetPairs(pairs, seen, injectedRepoRoot())
+        addRoleAssetPairs(pairs, seen, repoRoot())
+      } else if (!pluginRoot) {
+        // 源码静态测试形态（无正式 pluginRoot）
+        addRoleAssetPairs(pairs, seen, repoRoot())
+      }
+      const home = await dshHome()
+      if (home) addPair(home + '/visual-workflow/role-library.cjs', home + '/visual-workflow/builtin-roles.json')
+      if (isDynamicHost) {
+        addRoleAssetPairs(pairs, seen, await homeRepoPointer())
+        if (pluginRoot) addPair(pluginRoot + '/dist/role-library.cjs', pluginRoot + '/dist/builtin-roles.json')
+      }
+      return pairs
+    }
+    function loadRoleLibrary() {
+      if (roleLibraryPromise) return roleLibraryPromise
+      const pending = (async () => {
+        if (fs !== undefined) {
+          const pairs = await roleAssetCandidatePairs()
+          for (const pair of pairs) {
+            try {
+              const coreTarget = await fs.resolve(pair.core)
+              const coreInfo = await fs.stat(coreTarget)
+              if (!coreInfo || coreInfo.type !== 'file') continue
+              const manifestTarget = await fs.resolve(pair.manifest)
+              const manifestInfo = await fs.stat(manifestTarget)
+              if (!manifestInfo || manifestInfo.type !== 'file') continue
+              const coreSrc = await fs.readText(coreTarget)
+              const manifestSrc = await fs.readText(manifestTarget)
+              const mod = evalRoleLibrary(coreSrc)
+              if (!mod) continue
+              // 清单强校验（非法即 loud-fail 抛出）→ 该候选对损坏则尝试下一对
+              return mod.createRoleLibrary(JSON.parse(manifestSrc))
+            } catch (e) { /* 尝试下一个候选对 */ }
           }
-        } catch (e) {
-          return { ok: false, errors: [{ at: '$', message: String((e && e.message) || e) }] }
         }
-        let u
-        try {
-          u = await roleUsage(id, a && a.draftDsl)
-        } catch (e) {
-          return { ok: false, errors: [{ at: '$', message: '引用统计失败：' + String((e && e.message) || e) }] }
-        }
-        if (u.count > 0) {
-          return { ok: false, errors: [{ at: 'name', message: '该角色仍被 ' + u.count + ' 个节点使用，重命名会导致这些引用全部失效；请先解除引用，或使用「基于此角色创建自定义角色」新建变体。' }] }
-        }
-        if (subprocess === undefined) return { ok: false, errors: [{ at: '$', message: '重命名需要子进程服务（删除旧角色文件）；当前宿主不可用，可先编辑内容或新建同名新角色。' }] }
-      }
-      if (content == null || !content.trim()) return { ok: false, errors: [{ at: 'content', message: '角色配置不能为空' }] }
-      const roleDir = await roleDirPath()
-      let newAbs = null
+        // 正式静态模式若可信 dist 无法读取，降级为嵌入只读清单；禁止通过
+        // subprocess 扫描任意 cwd。仅动态开发允许 node 子进程按开发根兜底。
+        return isDynamicHost ? await readRoleLibraryViaNode() : null
+      })()
+      roleLibraryPromise = pending
+      pending.catch(() => { if (roleLibraryPromise === pending) roleLibraryPromise = null })
+      return pending
+    }
+    // fs 沙箱读不到仓库时，经 node 子进程按 DSH home / cwd 找内核与清单（成对返回）。
+    async function readRoleLibraryViaNode() {
+      if (subprocess === undefined) return null
+      const probe = [
+        "const fs=require('fs');const path=require('path');const os=require('os');",
+        "function tryPair(c,m){try{if(!fs.existsSync(c)||!fs.statSync(c).isFile())return false;if(!fs.existsSync(m)||!fs.statSync(m).isFile())return false;const cs=fs.readFileSync(c,'utf8');if(cs.indexOf('createRoleLibrary')<0)return false;const ms=fs.readFileSync(m,'utf8');process.stdout.write(JSON.stringify({core:cs,manifest:ms}));return true}catch(e){return false}}",
+        "function walk(d){for(let i=0;i<8&&d&&d!=='/';i++){if(tryPair(path.join(d,'scripts','role-library.cjs'),path.join(d,'dsh','roles','builtin-roles.json')))return true;const n=path.dirname(d);if(n===d)break;d=n}return false}",
+        "const homes=[];if(process.env.DSH_HOME)homes.push(process.env.DSH_HOME);",
+        "try{homes.push(path.join(os.homedir(),'.dsh-workflow-dev'))}catch(e){}",
+        "for(const h of homes){if(tryPair(path.join(h,'visual-workflow','role-library.cjs'),path.join(h,'visual-workflow','builtin-roles.json')))process.exit(0)}",
+        "const cands=[];try{cands.push(process.cwd())}catch(e){};if(process.env.PWD)cands.push(process.env.PWD);",
+        "for(const c of cands){if(walk(c))process.exit(0)}process.exit(2)",
+      ].join('')
+      const home = await dshHome()
+      const r = await runNode(['-e', probe], { cwd: home || '/' })
+      if (!r.ok || !r.stdout) return null
       try {
-        newAbs = await fs.resolve(roleDir + '/' + target + '.md')
-        await fs.writeText(newAbs, content + (content.endsWith('\n') ? '' : '\n'), undefined, undefined, writePolicy())
-      } catch (e) {
-        return { ok: false, errors: [{ at: '$', message: '角色文件写入失败：' + String((e && e.message) || e) }] }
+        const data = JSON.parse(r.stdout)
+        const mod = evalRoleLibrary(data.core)
+        if (!mod) return null
+        return mod.createRoleLibrary(JSON.parse(data.manifest))
+      } catch (e) { return null }
+    }
+    // 与 apply 时序解耦的异步同步：把 core+manifest 复制到 home/visual-workflow/，
+    // 供无会话 cwd 的浏览器调用经候选根读取（与 syncValidatorCore 同一模式）。
+    async function syncRoleAssets() {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        fs = ctx.get('fs')
+        subprocess = ctx.get('subprocess')
+        if (fs !== undefined) break
+        // 动态会话 vm 沙箱不提供真定时器：无定时器或调用被拦截则放弃重试
+        try {
+          await new Promise((r) => setTimeout(r, 100 * (attempt + 1)))
+        } catch (e) { break }
       }
-      if (isRename) {
+      if (fs === undefined) return
+      const home = await dshHome()
+      if (!home) return
+      const policy = writePolicy()
+      const destCore = home + '/visual-workflow/role-library.cjs'
+      const destManifest = home + '/visual-workflow/builtin-roles.json'
+      const pairs = await roleAssetCandidatePairs()
+      for (const pair of pairs) {
+        if (pair.core === destCore) continue
+        try {
+          const coreTarget = await fs.resolve(pair.core)
+          const coreInfo = await fs.stat(coreTarget)
+          if (!coreInfo || coreInfo.type !== 'file') continue
+          const manifestTarget = await fs.resolve(pair.manifest)
+          const manifestInfo = await fs.stat(manifestTarget)
+          if (!manifestInfo || manifestInfo.type !== 'file') continue
+          const coreSrc = await fs.readText(coreTarget)
+          if (coreSrc.indexOf('createRoleLibrary') < 0) continue
+          const manifestSrc = await fs.readText(manifestTarget)
+          await fs.writeText(await fs.resolve(destCore), coreSrc, undefined, undefined, policy)
+          await fs.writeText(await fs.resolve(destManifest), manifestSrc, undefined, undefined, policy)
+          return
+        } catch (e) { /* 尝试下一个候选对 */ }
+      }
+    }
+
+    // ── 事实采集适配器（fs/subprocess 集中在此；core 永不接触路径/句柄）────
+    // 目录事实：{ state, message, workspace:[{id,content}], bundled:[{id,content}] }
+    async function collectRoleCatalog() {
+      const inv = await readRoleFiles()
+      const workspace = []
+      for (const [id, f] of inv.files) workspace.push({ id: id, content: f.content })
+      let bundledMap = null
+      try { bundledMap = await bundledLegacyRoles() } catch (e) { bundledMap = new Map() }
+      const bundled = []
+      for (const [id, content] of bundledMap) bundled.push({ id: id, content: content })
+      return { state: inv.state, message: inv.message || '', workspace: workspace, bundled: bundled }
+    }
+    async function collectBuiltinBodies() {
+      const bodies = {}
+      for (const r of EMBEDDED_BUILTIN_MANIFEST) {
+        try { bodies[r.id] = await readBuiltinRoleSnapshot(r.id) } catch (e) { bodies[r.id] = null }
+      }
+      return bodies
+    }
+    // 引用事实：正式内置 + 用户模板 + 未删除的历史生成物 + 可选开放草稿。
+    // 同 id 用户覆盖优先；strict 读取失败按 error fail-closed。
+    async function collectWorkflowFacts(draftDsl) {
+      try {
+        const [{ builtins, shipped }, users, removed] = await Promise.all([splitGenerated(true), loadUserTemplates(true), loadRemovedIds()])
+        const mapNodes = (dsl) => ((dsl && dsl.nodes) || []).map((n) => ({ id: n.id, label: n.label, profile: n.profile }))
+        const records = []
+        const seen = new Set()
+        for (const dsl of builtins.values()) {
+          records.push({ workflowId: String(dsl.id), workflowName: String(dsl.name), builtin: true, nodes: mapNodes(dsl) })
+          seen.add(dsl.id)
+        }
+        for (const bp of users.values()) {
+          if (seen.has(bp.id)) continue
+          records.push({ workflowId: String(bp.id), workflowName: String(bp.displayName), builtin: false, nodes: mapNodes(projectToVwf(bp)) })
+          seen.add(bp.id)
+        }
+        for (const dsl of shipped.values()) {
+          if (seen.has(dsl.id) || removed.has(dsl.id)) continue
+          records.push({ workflowId: String(dsl.id), workflowName: String(dsl.name), builtin: false, nodes: mapNodes(dsl) })
+        }
+        const facts = { state: 'ok', records: records }
+        if (draftDsl && Array.isArray(draftDsl.nodes)) {
+          const d = { name: draftDsl.name, nodes: mapNodes(draftDsl) }
+          if (draftDsl.id) d.id = draftDsl.id
+          facts.draft = d
+        }
+        return facts
+      } catch (e) {
+        return { state: 'error', message: String((e && e.message) || e) }
+      }
+    }
+
+    // ── 效果执行适配器（唯一写/删出口）：路径解析、fs 句柄、子进程删除与回滚 ────
+    async function applyRoleEffect(effect) {
+      const roleDir = await roleDirPath()
+      if (effect.kind === 'write') {
+        try {
+          const target = await fs.resolve(roleDir + '/' + effect.id + '.md')
+          await fs.writeText(target, effect.content, undefined, undefined, writePolicy())
+          return { ok: true }
+        } catch (e) {
+          return { ok: false, errors: [{ at: '$', message: '角色文件写入失败：' + String((e && e.message) || e) }] }
+        }
+      }
+      if (effect.kind === 'rename') {
+        let newAbs = null
+        try {
+          newAbs = await fs.resolve(roleDir + '/' + effect.to + '.md')
+          await fs.writeText(newAbs, effect.content, undefined, undefined, writePolicy())
+        } catch (e) {
+          return { ok: false, errors: [{ at: '$', message: '角色文件写入失败：' + String((e && e.message) || e) }] }
+        }
         // 删除旧文件前经 fs 服务解析为绝对路径（避免相对 'dsh/roles' 在子进程 cwd=/ 下
         // 指向错误位置）；删除失败则回滚刚写入的新文件，保持角色库原状。
         let oldAbs = null
-        try { oldAbs = pathOf(await fs.resolve(roleDir + '/' + id + '.md')) } catch (e) { oldAbs = null }
+        try { oldAbs = pathOf(await fs.resolve(roleDir + '/' + effect.from + '.md')) } catch (e) { oldAbs = null }
         const rmOld = oldAbs ? await runNode(['-e', "const fs=require('fs');fs.rmSync(process.argv[1],{recursive:true,force:true})", oldAbs], { cwd: repoRoot() || '/' }) : { ok: false, detail: '旧角色文件路径解析失败' }
         if (!rmOld.ok) {
           const newPath = pathOf(newAbs)
           const rmNew = newPath ? await runNode(['-e', "const fs=require('fs');fs.rmSync(process.argv[1],{recursive:true,force:true})", newPath], { cwd: repoRoot() || '/' }) : null
           return { ok: false, errors: [{ at: '$', message: '旧角色文件删除失败（已回滚新文件' + (rmNew && rmNew.ok ? '' : '，回滚失败，请手动清理 ') + '）：' + rmOld.detail }] }
         }
+        return { ok: true }
       }
-      // 编辑打包回退角色（工作区无文件、定义来自内置模板角色包）时，此处写入
-      // 即完成「种子到自定义角色库」；运行时经 roleRef 的工作区优先链路读到新内容，
-      // .generated 打包快照保持生成产物身份、不被改写（Codex PR#124 第二轮 P1）。
-      const role = await getRoleDetail(target)
-      return { ok: true, role }
+      if (effect.kind === 'remove') {
+        let abs = null
+        try { abs = pathOf(await fs.resolve(roleDir + '/' + effect.id + '.md')) } catch (e) { abs = null }
+        const rm = abs ? await runNode(['-e', "const fs=require('fs');fs.rmSync(process.argv[1],{recursive:true,force:true})", abs], { cwd: repoRoot() || '/' }) : { ok: false, detail: '角色文件路径解析失败' }
+        if (!rm.ok) return { ok: false, errors: [{ at: '$', message: '角色删除失败：' + rm.detail }] }
+        return { ok: true }
+      }
+      return { ok: false, errors: [{ at: '$', message: '未知角色变更意图：' + String(effect && effect.kind) }] }
+    }
+
+    // ── 只读降级（core 不可用：无 fs / 候选全损坏）────────────────────────────
+    // 只保证「内置角色常驻」这一产品契约；写操作在 RPC 层按能力 fail-closed。
+    function embeddedRoleList() {
+      return EMBEDDED_BUILTIN_MANIFEST.map((r) => ({ id: r.id, name: r.name, summary: r.summary, builtin: true }))
+    }
+    function embeddedRoleDetail(id) {
+      let meta = null
+      for (const r of EMBEDDED_BUILTIN_MANIFEST) { if (r.id === id) { meta = r; break } }
+      if (!meta) return null
+      const content = '# ' + meta.name + '（' + meta.id + '）\n\n' + meta.summary + '\n\n> 当前工作区未包含该内置角色的完整定义（dsh/roles/' + meta.id + '.md），角色仍可正常选择使用。'
+      return { id: meta.id, name: meta.name, summary: meta.summary, builtin: true, content: content }
+    }
+
+    // ── RPC 薄壳：采集事实 → core 裁决 → 适配器执行 → 原样返回 ────────────────
+    // 角色列表（节点表单的角色选择器 + 角色管理列表数据源）：内置常驻 + 自定义。
+    registerRpc('vwf.roles', async () => {
+      const lib = await loadRoleLibrary()
+      if (!lib) return { roles: embeddedRoleList() }
+      const facts = { includeContent: false, catalog: await collectRoleCatalog(), builtinBodies: await collectBuiltinBodies() }
+      const r = await lib.execute({ operation: 'list', facts: facts })
+      return { roles: r.roles }
+    })
+    // 角色详情（查看内置/编辑自定义前的完整配置）
+    registerRpc('vwf.roles.get', async (a) => {
+      const id = a && a.id
+      const lib = await loadRoleLibrary()
+      if (!lib) {
+        const role = embeddedRoleDetail(id)
+        if (!role) return { ok: false, errors: [{ at: '$', message: '角色不存在：' + (id || '') }] }
+        return { ok: true, role: role }
+      }
+      const facts = { includeContent: true, catalog: await collectRoleCatalog(), builtinBodies: await collectBuiltinBodies() }
+      return lib.execute({ operation: 'get', id: id, facts: facts })
+    })
+    // 引用统计（删除/修改前的保护提示数据源）：可携带开放草稿 DSL 一并计数
+    registerRpc('vwf.roles.usage', async (a) => {
+      const id = a && a.id
+      if (!id || typeof id !== 'string') return { ok: false, errors: [{ at: '$.id', message: '缺少角色 id' }] }
+      const lib = await loadRoleLibrary()
+      if (!lib) return { ok: false, errors: [{ at: '$', message: '引用统计失败：角色库内核不可用' }] }
+      const facts = { workflows: await collectWorkflowFacts(a && a.draftDsl) }
+      return lib.execute({ operation: 'usage', id: id, facts: facts })
+    })
+    // 权威名称校验（UX 收紧：编辑/保存时即时提示 Host 裁决；客户端不再复制规则）
+    registerRpc('vwf.roles.validate', async (a) => {
+      const lib = await loadRoleLibrary()
+      if (!lib) return { ok: false, errors: [{ at: '$', message: '角色库内核不可用：无法校验名称' }] }
+      const facts = { catalog: await collectRoleCatalog() }
+      return lib.execute({ operation: 'validateName', name: a && a.name, excludeId: a && a.excludeId, facts: facts })
+    })
+    // 空白新增 / 基于角色创建：core 裁决（名称/内容/唯一性）→ 适配器写盘
+    registerRpc('vwf.roles.create', async (a) => {
+      if (fs === undefined) return { ok: false, errors: [{ at: '$', message: '宿主文件能力不可用：无法创建角色' }] }
+      const lib = await loadRoleLibrary()
+      if (!lib) return { ok: false, errors: [{ at: '$', message: '角色库内核不可用：无法创建角色' }] }
+      const facts = {
+        capabilities: { fs: fs !== undefined, subprocess: subprocess !== undefined },
+        catalog: await collectRoleCatalog(),
+      }
+      const r = await lib.execute({ operation: 'change', action: 'create', name: a && a.name, content: a && a.content, facts: facts })
+      if (!r.ok) return r
+      const applied = await applyRoleEffect(r.effect)
+      if (!applied.ok) return applied
+      const detail = await lib.execute({ operation: 'get', id: r.effect.id, facts: { includeContent: true, catalog: await collectRoleCatalog(), builtinBodies: await collectBuiltinBodies() } })
+      return detail
+    })
+    // 编辑自定义角色：内容修改全局生效（引用按 id 天然共享）；重命名仅零引用时允许
+    // （引用按 id 字符串，重命名会令所有引用失效——服务端强制，客户端也先提示）。
+    // 仅重命名路径需要 subprocess（删除旧文件）；纯内容编辑只依赖 fs。
+    // 编辑打包回退角色（工作区无文件、定义来自内置模板角色包）时，写入即完成
+    // 「种子到自定义角色库」；.generated 打包快照不被改写（Codex PR#124 第二轮 P1）。
+    registerRpc('vwf.roles.update', async (a) => {
+      if (fs === undefined) return { ok: false, errors: [{ at: '$', message: '宿主文件能力不可用：无法更新角色' }] }
+      const id = a && a.id
+      const lib = await loadRoleLibrary()
+      if (!lib) return { ok: false, errors: [{ at: '$', message: '角色库内核不可用：无法更新角色' }] }
+      const newName = String((a && a.name) || '').trim()
+      const facts = {
+        capabilities: { fs: fs !== undefined, subprocess: subprocess !== undefined },
+        catalog: await collectRoleCatalog(),
+      }
+      // 仅潜在大改名才采集引用事实（纯内容编辑不触发严格模板读取）
+      if (id && newName && newName !== id) facts.workflows = await collectWorkflowFacts(a && a.draftDsl)
+      const r = await lib.execute({ operation: 'change', action: 'update', id: id, name: a && a.name, content: a && a.content, facts: facts })
+      if (!r.ok) return r
+      const applied = await applyRoleEffect(r.effect)
+      if (!applied.ok) return applied
+      const target = r.effect.kind === 'rename' ? r.effect.to : id
+      const detail = await lib.execute({ operation: 'get', id: target, facts: { includeContent: true, catalog: await collectRoleCatalog(), builtinBodies: await collectBuiltinBodies() } })
+      return detail
     })
     // 删除自定义角色：内置拒绝；存在任意引用 → 阻止并提供引用详情（无强制删除）。
     registerRpc('vwf.roles.remove', async (a) => {
-      const id = a && a.id
       if (fs === undefined || subprocess === undefined) return { ok: false, errors: [{ at: '$', message: '宿主文件能力不可用：无法删除角色' }] }
-      if (!id || typeof id !== 'string') return { ok: false, errors: [{ at: '$.id', message: '缺少角色 id' }] }
-      if (BUILTIN_ROLE_IDS.indexOf(id) >= 0) {
-        return { ok: false, errors: [{ at: '$', message: '内置角色只读：' + id + ' 属于系统标准角色，不能删除' }] }
+      const id = a && a.id
+      const lib = await loadRoleLibrary()
+      if (!lib) return { ok: false, errors: [{ at: '$', message: '角色库内核不可用：无法删除角色' }] }
+      const facts = {
+        capabilities: { fs: fs !== undefined, subprocess: subprocess !== undefined },
+        catalog: await collectRoleCatalog(),
+        workflows: await collectWorkflowFacts(a && a.draftDsl),
       }
-      const inv = await readRoleFiles()
-      if (inv.state === 'error') return { ok: false, errors: [{ at: '$', message: '角色库读取失败：' + inv.message }] }
-      let u
-      try {
-        u = await roleUsage(id, a && a.draftDsl)
-      } catch (e) {
-        return { ok: false, errors: [{ at: '$', message: '引用统计失败，已阻止删除：' + String((e && e.message) || e) }] }
-      }
-      if (u.count > 0) {
-        const draftHint = u.refs.some(r => r.draft) ? '（含未保存草稿的引用）' : ''
-        return { ok: false, errors: [{ at: '$', message: '「' + id + '」仍被 ' + u.count + ' 个节点使用' + draftHint + '。请先将这些节点更换为其他角色，解除全部引用后再删除。' }], usage: { count: u.count, refs: u.refs } }
-      }
-      // 打包回退角色（Codex PR#124 第四轮 P2，评论 3889756925）：工作区无文件、
-      // 定义来自内置模板角色包，只能读取不能删除——删它等于改生成产物。此前在统计
-      // 引用前就返回「自定义角色不存在」，界面上可点删除却必然失败且提示不准确。
-      if (!inv.files.has(id)) {
-        let bundledLegacy = null
-        try { bundledLegacy = await bundledLegacyRoles() } catch (e) { bundledLegacy = new Map() }
-        if (bundledLegacy.has(id)) {
-          return { ok: false, errors: [{ at: '$', message: '「' + id + '」的定义来自内置模板自带的角色包（生成产物），不在自定义角色库中，无法在此删除；如需停用，请在模板中把引用替换为其他角色。' }] }
-        }
-        return { ok: false, errors: [{ at: '$', message: '自定义角色不存在：' + id }] }
-      }
-      const roleDir = await roleDirPath()
-      let abs = null
-      try { abs = pathOf(await fs.resolve(roleDir + '/' + id + '.md')) } catch (e) { abs = null }
-      const rm = abs ? await runNode(['-e', "const fs=require('fs');fs.rmSync(process.argv[1],{recursive:true,force:true})", abs], { cwd: repoRoot() || '/' }) : { ok: false, detail: '角色文件路径解析失败' }
-      if (!rm.ok) return { ok: false, errors: [{ at: '$', message: '角色删除失败：' + rm.detail }] }
-      return { ok: true, id }
+      const r = await lib.execute({ operation: 'change', action: 'remove', id: id, facts: facts })
+      if (!r.ok) return r
+      const applied = await applyRoleEffect(r.effect)
+      if (!applied.ok) return applied
+      return { ok: true, id: id }
     })
 
     // ── 静态 bundle 模式：webServer RPC 路由（动态模式走 harness.handle）────
@@ -2480,6 +2621,8 @@ return {
             const p = await rootPaths()
             return JSON.stringify({
               repoRoot: repoRoot(), knownCwd: knownCwd, dshHome: await dshHome(),
+              injectedRepoRoot: injectedRepoRoot(),
+              validatorCandidates: await validatorCoreCandidatePaths(),
               userDir: p.userDir, skillRoot: p.skillRoot, builtinDir: p.builtinDir, homeBuiltinDir: p.homeBuiltinDir, generatorRoot: p.generatorRoot, generator: p.generator,
               fsAvailable: fs !== undefined, subprocessAvailable: subprocess !== undefined,
               nodePath: await resolveNode(),
@@ -2516,4 +2659,3 @@ return {
     }
   },
 }
-//probe

--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -396,6 +396,7 @@ return {
           if (n.failOn !== undefined) o.failOn = n.failOn
           if (n.output) o.output = n.output
           if (n.manualCheck) o.manualCheck = true
+          if (n.verifyBranch) o.verifyBranch = true
           if (models[n.id]) o.model = models[n.id]
           return o
         }),
@@ -412,12 +413,13 @@ return {
       // 业务规则字段（候选二 Q7，与 generate.mjs projectToVwf 一致）
       if (bp.onMaxRounds !== undefined) out.onMaxRounds = bp.onMaxRounds
       if (bp.heteroCheck) out.heteroCheck = true
+      if (bp.bundleRoles) out.bundleRoles = true
       if (bp.humanDecision !== undefined) out.humanDecision = bp.humanDecision
       return out
     }
     // 逆投影（save 落盘格式：蓝图 JSON；候选二 Q7：业务规则字段 onMaxRounds/
-    // heteroCheck 已在 DSL 中（前端可配置），原样带回蓝图；verifyBranch 节点级
-    // 字段无编辑器 UI、不在 DSL，自然不产生）
+    // heteroCheck 已在 DSL 中（前端可配置），原样带回蓝图；verifyBranch 无编辑器
+    // UI，但 JSON 粘贴/保存必须往返，否则建设蓝图的可信度闸门会在另存后丢失）
     function projectToBlueprint(dsl) {
       const models = {}
       const nodes = (dsl.nodes || []).map((n) => {
@@ -427,6 +429,7 @@ return {
         if (n.failOn !== undefined) o.failOn = n.failOn
         if (n.output) o.output = n.output
         if (n.manualCheck) o.manualCheck = true
+        if (n.verifyBranch) o.verifyBranch = true
         if (n.model && typeof n.model === 'object' && n.model.provider && n.model.model) {
           models[n.id] = { provider: n.model.provider, model: n.model.model }
         }
@@ -452,9 +455,24 @@ return {
       if (dsl.control && dsl.control.maxRounds != null) bp.control = { maxRounds: dsl.control.maxRounds }
       if (dsl.onMaxRounds !== undefined) bp.onMaxRounds = dsl.onMaxRounds
       if (dsl.heteroCheck) bp.heteroCheck = true
+      if (dsl.bundleRoles) bp.bundleRoles = true
       if (dsl.humanDecision !== undefined) bp.humanDecision = dsl.humanDecision
       if (Object.keys(models).length) bp.bindings = { models: models }
       return bp
+    }
+
+    // JSON tab / 保存可能直接贴蓝图落盘格式（displayName、bindings.models）。
+    // 先投影成 DSL，再走 sanitize / 逆投影，避免模型绑定与展示名被丢掉。
+    function ingestToDsl(raw) {
+      if (!raw || typeof raw !== 'object') return raw
+      const hasBindings = !!(raw.bindings && raw.bindings.models && typeof raw.bindings.models === 'object'
+        && Object.keys(raw.bindings.models).length)
+      if (typeof raw.displayName !== 'string' && !hasBindings) return raw
+      if (!Array.isArray(raw.nodes) || !Array.isArray(raw.edges)) return raw
+      return projectToVwf({
+        ...raw,
+        displayName: typeof raw.displayName === 'string' ? raw.displayName : (raw.name || raw.id || ''),
+      })
     }
 
 
@@ -566,6 +584,7 @@ return {
         // lossless-JSON 守卫：所有键都必须有值，sanitized 早退时显式给 null
         return { ok: false, errors: [{ at: '$', message: '校验内核不可用：缺少 scripts/validate-core.cjs（请确认仓库完整）' }], fieldErrors: {}, sanitized: null, warnings: [] }
       }
+      dsl = ingestToDsl(dsl)
       if (!dsl || typeof dsl !== 'object') {
         return { ok: false, errors: [{ at: '$', message: 'dsl 必须是对象' }], fieldErrors: {}, sanitized: null, warnings: [] }
       }

--- a/packages/dsh-visual-workflow/src/host.js
+++ b/packages/dsh-visual-workflow/src/host.js
@@ -19,16 +19,18 @@
 //
 // T-IMP-06（双根加载 + 用户模板落盘闭环，FR-2/FR-3，AC-2/AC-3）：
 //  - 废除硬编码 TEMPLATES（L29-74）→ 目录加载：内置 = <repo>/.generated/<id>/vwf-dsl.json
-//    （生成物，CI 先 npm run generate）+ ~/.dsh/.generated（syncBuiltins 同步，会话无关，
-//    默认工作流这类用户级内置模板在任意项目会话可见）；用户 = ~/.dsh/visual-workflow/templates/<id>.json
-//    （蓝图 JSON，宿主数据根 ~/.dsh 下新建）。
+//    （生成物，CI 先 npm run generate）+ ~/.dsh/.generated（syncBuiltins 同步，会话无关）；
+//    用户 = ~/.dsh/visual-workflow/templates/<id>.json（蓝图 JSON）。
+//  - 历史两套 `default-workflow` / `dev-workflow-2-0` 已迁为 Custom Workflow：仍从
+//    .generated 出现在模板库，但 builtin=false，可保存覆盖、可删除（删除后写
+//    ~/.dsh/visual-workflow/removed/<id> 删除标记，避免生成物再次出现）。
 //  - list 合并双根（builtin 标志 + id 字母序），用户条目 dsl = 蓝图→vwf DSL 投影
-//    （内联 projectToVwf，与 scripts/generate.mjs 行为一致）。
-//  - save：结构+异源校验 → 撞名拒绝（内置只读 / 当前编辑 id ≠ 目标 → 改名提示）→
+//    （内联 projectToVwf，与 scripts/generate.mjs 行为一致）；用户覆盖优先于同 id 生成物。
+//  - save：结构+异源校验 → 撞名拒绝（正式内置只读 / 当前编辑 id ≠ 目标 → 改名提示）→
 //    逆投影蓝图落盘 → spawn 生成器 user 子命令同步自包含 skill 到 ~/.dsh/skills/<id>/
 //    （save 即闭环；生成失败回滚落盘，保持原子）。save 新增参数 currentId。
-//  - remove：仅用户模板可删（删蓝图 + 同步删 skill 目录）；内置拒绝。
-//  - findWorkflow：内置优先、用户目录兜底。
+//  - remove：用户模板与已迁出的历史模板可删（删蓝图 + 同步删 skill 目录）；正式内置拒绝。
+//  - findWorkflow：用户覆盖优先，其次未删除的历史生成物，再次正式内置。
 // T-IMP-07（异源接入，FR-8，AC-8）：save 与 vwf.validate 叠加内联异源硬规则
 //  （有 dev+review 节点 → 缺绑定拒 / 完全同模型拒 / 弱异源警告），与引擎
 //  校验内核 validate-core.cjs 规则 7 行为一致（候选二统一）。
@@ -202,10 +204,11 @@ return {
         builtinDir: repo ? repo + '/.generated' : null,
         // 静态组合包的仓库根（仅 bundle 内注入）；避免首次 RPC 早于同步任务时看不到模板。
         packageBuiltinDir: packageRepo ? packageRepo + '/.generated' : null,
-        // 宿主根内置模板（会话无关）：安装/重装时经 syncBuiltins 同步的标准配置，
-        // 任何会话都能看到（默认工作流这类用户级内置模板）
+        // 宿主根内置模板（会话无关）：安装/重装时经 syncBuiltins 同步的标准配置
         homeBuiltinDir: home ? home + '/.generated' : null,
         userDir: home ? home + '/visual-workflow/templates' : null,
+        // 历史模板迁为自定义后的删除标记：存在则 list/find 不再从 .generated 重新列出该 id
+        removedDir: home ? home + '/visual-workflow/removed' : null,
         // runs 运行记录持久化目录（#40）：<runId>.json 一条一文件
         runsDir: home ? home + '/visual-workflow/runs' : null,
         skillRoot: home ? home + '/skills' : null,
@@ -302,10 +305,16 @@ return {
     // 与 apply 时序解耦的异步同步：不阻塞 apply，失败仅在终端日志留痕
     syncBuiltins().catch((e) => console.log('[vwf] 内置模板同步失败：' + String((e && e.message) || e)))
 
+    // 历史两套正式模板已按目标规格迁为 Custom Workflow，不再占用内置身份。
+    // 生成物仍可出现在模板库（任意项目可见的 default-workflow / 仓库内的
+    // dev-workflow-2-0），但 list 标 builtin=false，允许保存覆盖与删除。
+    const LEGACY_CUSTOM_WORKFLOW_IDS = { 'default-workflow': true, 'dev-workflow-2-0': true }
+    function isLegacyCustomId(id) { return !!LEGACY_CUSTOM_WORKFLOW_IDS[id] }
+
     // 内置根：.generated/<id>/vwf-dsl.json（生成物四件套之一，CI 先 npm run generate）
     // 双根：仓库 .generated（开发期最新）优先，宿主根 ~/.dsh/.generated（syncBuiltins 同步，
-    // 会话无关）补缺失——默认工作流这类用户级内置模板在任意项目会话都可见
-    async function loadBuiltins(strict) {
+    // 会话无关）补缺失。扫描结果再按 id 拆成「正式内置」与「已迁出的历史自定义」。
+    async function loadGeneratedCatalog(strict) {
       const out = new Map()
       if (fs === undefined) {
         if (strict) throw new Error('宿主文件能力不可用：无法扫描内置模板')
@@ -338,6 +347,50 @@ return {
         }
       }
       return out
+    }
+    async function splitGenerated(strict) {
+      const all = await loadGeneratedCatalog(strict)
+      const builtins = new Map()
+      const shipped = new Map()
+      for (const [id, dsl] of all) {
+        if (isLegacyCustomId(id)) shipped.set(id, dsl)
+        else builtins.set(id, dsl)
+      }
+      return { builtins, shipped }
+    }
+    async function loadBuiltins(strict) {
+      return (await splitGenerated(strict)).builtins
+    }
+    async function loadRemovedIds() {
+      const out = new Set()
+      if (fs === undefined) return out
+      const p = await rootPaths()
+      if (!p.removedDir) return out
+      let entries = null
+      try {
+        entries = await fs.listDir(await fs.resolve(p.removedDir))
+      } catch (e) { return out }
+      for (const ent of entries || []) {
+        if (!ent || typeof ent.name !== 'string' || !ent.name) continue
+        out.add(ent.name)
+      }
+      return out
+    }
+    async function markRemoved(id) {
+      if (fs === undefined || !isLegacyCustomId(id)) return
+      const p = await rootPaths()
+      if (!p.removedDir) return
+      try {
+        await fs.writeText(await fs.resolve(p.removedDir + '/' + id), '', undefined, undefined, writePolicy())
+      } catch (e) { /* 删除标记写入失败不阻断删除：用户目录与 skill 已清 */ }
+    }
+    async function clearRemoved(id) {
+      if (!isLegacyCustomId(id)) return
+      const p = await rootPaths()
+      if (!p.removedDir || !p.generatorRoot) return
+      try {
+        await runNode(['-e', "const fs=require('fs');fs.rmSync(process.argv[1],{force:true})", p.removedDir + '/' + id], { cwd: p.generatorRoot })
+      } catch (e) { /* 重建模板时清除删除标记失败不阻断 save */ }
     }
 
     // 用户根：~/.dsh/visual-workflow/templates/<id>.json（蓝图 JSON）
@@ -643,9 +696,10 @@ return {
     async function compileViaPipeline(dsl, opts) {
       const p = await rootPaths()
       if (opts && opts.fromTemplate) {
-        // 磁盘产物优先：仓库 .generated → 宿主根 .generated（用户级内置，syncBuiltins 同步）→ 用户 skill 闭环产物
+        // 磁盘产物优先：用户 skill 闭环产物（保存覆盖后必须盖过同 id 的 .generated）
+        // → 仓库 .generated → 宿主根 .generated（syncBuiltins 同步）
         // bundleRoles 模板在产物目录旁带 roles/ 自包含角色包，命中则随译文返回 roleDir
-        const spots = [p.builtinDir, p.packageBuiltinDir, p.homeBuiltinDir, p.skillRoot]
+        const spots = [p.skillRoot, p.builtinDir, p.packageBuiltinDir, p.homeBuiltinDir]
         for (const spot of spots) {
           if (!spot) continue
           const script = await readTextIfExists(spot + '/' + dsl.id + '/script.mjs')
@@ -689,23 +743,38 @@ return {
       }
     }
 
-    // 双根查找：内置优先（沿用），用户目录兜底（蓝图 → vwf DSL 投影）
+    // 查找：用户覆盖优先 → 未删除的历史生成物 → 正式内置
     async function findWorkflow(id) {
       if (!id || typeof id !== 'string') return null
-      const builtins = await loadBuiltins()
-      if (builtins.has(id)) return builtins.get(id)
       const users = await loadUserTemplates()
       const bp = users.get(id)
-      return bp ? projectToVwf(bp) : null
+      if (bp) return projectToVwf(bp)
+      const removed = await loadRemovedIds()
+      if (removed.has(id)) return null
+      const { builtins, shipped } = await splitGenerated()
+      if (shipped.has(id)) return shipped.get(id)
+      if (builtins.has(id)) return builtins.get(id)
+      return null
     }
-    // 合并双根：builtin 标志 + id 字母序；用户条目 dsl = 蓝图 → vwf DSL 投影
+    // 合并：正式内置 builtin=true；历史生成物与用户模板 builtin=false。
+    // 同 id：用户覆盖优先；已删除标记的历史 id 不再从 .generated 列出。
     async function listWorkflows() {
-      const [builtins, users] = await Promise.all([loadBuiltins(), loadUserTemplates()])
+      const [{ builtins, shipped }, users, removed] = await Promise.all([splitGenerated(), loadUserTemplates(), loadRemovedIds()])
       const out = []
-      for (const dsl of builtins.values()) out.push({ id: dsl.id, name: dsl.name, description: dsl.description || '', builtin: true, dsl: dsl })
+      const seen = new Set()
+      for (const dsl of builtins.values()) {
+        out.push({ id: dsl.id, name: dsl.name, description: dsl.description || '', builtin: true, dsl: dsl })
+        seen.add(dsl.id)
+      }
       for (const bp of users.values()) {
+        if (seen.has(bp.id)) continue
         const dsl = projectToVwf(bp)
         out.push({ id: bp.id, name: bp.displayName, description: bp.description || '', builtin: false, dsl: dsl })
+        seen.add(bp.id)
+      }
+      for (const dsl of shipped.values()) {
+        if (seen.has(dsl.id) || removed.has(dsl.id)) continue
+        out.push({ id: dsl.id, name: dsl.name, description: dsl.description || '', builtin: false, dsl: dsl })
       }
       out.sort((a, b) => (a.builtin === b.builtin ? (a.id < b.id ? -1 : a.id > b.id ? 1 : 0) : a.builtin ? -1 : 1))
       return out
@@ -1175,6 +1244,7 @@ return {
         } catch (e) {}
         return { ok: false, errors: [{ at: '$', message: '蓝图校验/技能生成失败（save 已回滚）：' + gen.detail }] }
       }
+      await clearRemoved(id)
       return { ok: true, id: id, dsl: v.sanitized, warnings: v.warnings || [] }
     })
     registerRpc('vwf.workflows.remove', async (a) => {
@@ -1195,12 +1265,18 @@ return {
         const info = await fs.stat(target)
         existed = !!info
       } catch (e) { existed = false }
-      if (!existed) return { ok: false, errors: [{ at: '$.id', message: '用户模板不存在：' + id }] }
+      const shipped = isLegacyCustomId(id)
+      if (!existed && !shipped) return { ok: false, errors: [{ at: '$.id', message: '用户模板不存在：' + id }] }
+      const removed = await loadRemovedIds()
+      if (!existed && shipped && removed.has(id)) return { ok: false, errors: [{ at: '$.id', message: '用户模板不存在：' + id }] }
       // 删蓝图 + 同步删 ~/.dsh/skills/<id>/（fs 服务无删除能力，经子进程 rm）
-      const rm = await runNode(['-e', "const fs=require('fs');fs.rmSync(process.argv[1],{recursive:true,force:true})", file], { cwd: p.generatorRoot })
-      if (!rm.ok) return { ok: false, errors: [{ at: '$', message: '模板删除失败：' + rm.detail }] }
+      if (existed) {
+        const rm = await runNode(['-e', "const fs=require('fs');fs.rmSync(process.argv[1],{recursive:true,force:true})", file], { cwd: p.generatorRoot })
+        if (!rm.ok) return { ok: false, errors: [{ at: '$', message: '模板删除失败：' + rm.detail }] }
+      }
       const skillDir = p.skillRoot + '/' + id
       await runNode(['-e', "const fs=require('fs');fs.rmSync(process.argv[1],{recursive:true,force:true})", skillDir], { cwd: p.generatorRoot })
+      await markRemoved(id)
       return { ok: true, id: id }
     })
     registerRpc('vwf.validate', async (a) => {

--- a/packages/dsh-visual-workflow/tests/client.smoke.mjs
+++ b/packages/dsh-visual-workflow/tests/client.smoke.mjs
@@ -1133,6 +1133,69 @@ test('角色库：自定义角色「基于此创建」克隆 + usage 失败时�
   })
 })
 
+test('粘贴蓝图 JSON：模型投影、唯一入口徽标、主链从左到右', async () => {
+  const blueprint = {
+    id: 'construction-full-feature',
+    displayName: '完整功能开发',
+    entry: 'requirements',
+    bindings: {
+      models: {
+        requirements: { provider: 'kimi-coding', model: 'k3' },
+        design: { provider: 'deepseek-official', model: 'deepseek-v4-pro' },
+        dev: { provider: 'deepseek-official', model: 'deepseek-v4-pro' },
+      },
+    },
+    nodes: [
+      { id: 'requirements', label: '需求分析', profile: 'requirements', goal: 'g' },
+      { id: 'design', label: '方案设计', profile: 'designer', goal: 'g' },
+      { id: 'dev', label: '开发', profile: 'dev', goal: 'g' },
+    ],
+    edges: [
+      { from: 'requirements', to: 'design', on: 'success' },
+      { from: 'design', to: 'dev', outcome: 'READY' },
+      { from: 'design', to: 'requirements', outcome: 'RETURN_REQUIREMENTS', countRound: false },
+      { from: 'dev', to: 'design', outcome: 'RETURN_DESIGN', countRound: false },
+      { from: 'dev', to: '$end', outcome: 'BLOCKED' },
+    ],
+  }
+  await act(async () => {
+    const jsonTab = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'JSON')
+    jsonTab.click()
+    await flush()
+    const textarea = container.querySelector('textarea.vwf-json-edit')
+    const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLTextAreaElement.prototype, 'value').set
+    setter.call(textarea, JSON.stringify(blueprint, null, 2))
+    textarea.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+    await flush()
+    const canvasTab = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '画布')
+    canvasTab.click()
+    await flush()
+  })
+  const nameInput = Array.from(container.querySelectorAll('input.vwf-input')).find((el) => el.getAttribute('placeholder') === '模板名称' || el.value === '完整功能开发')
+  assert.ok(nameInput, '模板名称从 displayName 摄入')
+  assert.equal(nameInput.value, '完整功能开发')
+  const xOf = (id) => {
+    const g = container.querySelector('g[data-node-id="' + id + '"]')
+    const match = /translate\(([-\d.]+),([-\d.]+)\)/.exec(g.getAttribute('transform'))
+    return Number(match[1])
+  }
+  assert.ok(xOf('requirements') < xOf('design'), '需求在设计左侧')
+  assert.ok(xOf('design') < xOf('dev'), '设计在开发左侧')
+  const badges = Array.from(container.querySelectorAll('.vwf-entry-badge-text')).map((el) => {
+    const g = el.closest('g[data-node-id]')
+    return g && g.getAttribute('data-node-id')
+  }).filter(Boolean)
+  assert.deepEqual(badges, ['requirements'], '只有需求分析带入口徽标，开发不得并列入口')
+  await act(async () => {
+    container.querySelector('g[data-node-id="requirements"]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }))
+    await flush()
+  })
+  const selects = Array.from(container.querySelectorAll('.vwf-inspector select.vwf-select'))
+  const values = selects.map((s) => s.value)
+  assert.ok(values.includes('kimi-coding'), '节点 provider 从 bindings.models 投影：' + JSON.stringify(values))
+  assert.ok(values.includes('k3'), '节点 model 从 bindings.models 投影：' + JSON.stringify(values))
+})
+
 test('清理：卸载冒烟测试根节点', async () => {
   await act(async () => {
     root.unmount()

--- a/packages/dsh-visual-workflow/tests/client.smoke.mjs
+++ b/packages/dsh-visual-workflow/tests/client.smoke.mjs
@@ -92,6 +92,22 @@ function makeRuntime() {
         if (idx >= 0) roleState.roles.splice(idx, 1)
         return { ok: true, id: args.id }
       }
+      // 权威名称校验（与 scripts/role-library.cjs 规则一致的最小镜像）：
+      // 非空/长度/非法字符/首尾点/Windows 保留名 + 唯一性（excludeId 排除自身）
+      case 'vwf.roles.validate': {
+        const name = String((args && args.name) || '').trim()
+        const badName = !name ? '角色名称不能为空'
+          : name.length > 64 ? '角色名称过长（最多 64 字符）'
+          : /[\\/:*?"<>|\x00-\x1F\x7F]/.test(name) ? '角色名称包含非法字符'
+          : /^\./.test(name) || /\.$/.test(name) ? '角色名称不能以点开头或结尾'
+          : /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i.test(name) ? '角色名称是系统保留名（如 CON/NUL/AUX），请换一个名称'
+          : null
+        if (badName) return { ok: false, errors: [{ at: 'name', message: badName }] }
+        const key = (s) => String(s || '').normalize('NFC').toLowerCase()
+        const dup = roleState.roles.some(r => key(r.id) === key(name) && r.id !== args.excludeId)
+        if (dup) return { ok: false, errors: [{ at: 'name', message: '已存在同名角色，请使用其他名称。' }] }
+        return { ok: true }
+      }
       case 'vwf.roles.usage': {
         if (state.failUsage === 'resolved') return { ok: false, errors: [{ at: '$', message: '引用统计服务不可用' }] }
         if (state.failUsage) return Promise.reject(new Error('引用统计服务不可用'))
@@ -1131,6 +1147,85 @@ test('角色库：自定义角色「基于此创建」克隆 + usage 失败时�
     freshRoot.unmount()
     fresh.remove()
   })
+})
+
+test('角色库 UX 收紧：首尾点/Windows 保留名保存时被 Host 权威校验拦截（此前客户端漏检）', async () => {
+  const fresh = document.createElement('div')
+  document.body.appendChild(fresh)
+  const freshRoot = createRoot(fresh)
+  await act(async () => {
+    freshRoot.render(React.createElement(Page))
+    await flush()
+  })
+  await act(async () => { byText(fresh, '编辑').click(); await flush() })
+  const roleZone = fresh.querySelector('.vwf-role-zone')
+  await act(async () => {
+    Array.from(roleZone.querySelectorAll('button')).find(b => b.textContent.includes('管理角色')).click()
+    await flush()
+  })
+  const mgr = fresh.querySelector('.vwf-role-mgr')
+  await act(async () => { byText(mgr, '新增角色').click(); await flush() })
+  const nameInput = mgr.querySelector('input.vwf-input')
+  const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, 'value').set
+  const before = roleState.roles.length
+  for (const badName of ['.foo', 'foo.', 'CON', 'com1']) {
+    await act(async () => {
+      setter.call(nameInput, badName)
+      nameInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+      const ta = mgr.querySelector('textarea')
+      const taSetter = Object.getOwnPropertyDescriptor(dom.window.HTMLTextAreaElement.prototype, 'value').set
+      taSetter.call(ta, '正文\n')
+      ta.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+      await flush()
+      byText(mgr, '保存角色').click()
+      await flush()
+      await flush()
+    })
+    assert.ok(mgr.querySelector('input.vwf-input'), `非法名称 ${badName} 保存被拦截（表单保持打开）`)
+    assert.ok(byText(mgr, '保留名') || byText(mgr, '以点开头或结尾'), `非法名称 ${badName} 展示 Host 裁决文案`)
+  }
+  assert.equal(roleState.roles.length, before, '四个非法名称均未落库')
+  // 失焦即时提示：合法名称失焦后再次输入非法名，失焦即提示（无需点保存）
+  // 注：React onBlur 委托监听 focusout（冒泡），而非不冒泡的 blur 事件
+  await act(async () => {
+    setter.call(nameInput, '.bad')
+    nameInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+    nameInput.dispatchEvent(new dom.window.Event('focusout', { bubbles: true }))
+    await flush()
+    await flush()
+  })
+  assert.ok(byText(mgr, '以点开头或结尾'), '失焦即展示 Host 校验错误')
+  await act(async () => { freshRoot.unmount(); fresh.remove() })
+})
+
+test('角色库删除 fail-closed：usage 返回 ok:false 时不弹出删除确认、角色不删除', async () => {
+  const fresh = document.createElement('div')
+  document.body.appendChild(fresh)
+  const freshRoot = createRoot(fresh)
+  await act(async () => {
+    freshRoot.render(React.createElement(Page))
+    await flush()
+  })
+  await act(async () => { byText(fresh, '编辑').click(); await flush() })
+  const roleZone = fresh.querySelector('.vwf-role-zone')
+  await act(async () => {
+    Array.from(roleZone.querySelectorAll('button')).find(b => b.textContent.includes('管理角色')).click()
+    await flush()
+  })
+  const mgr = fresh.querySelector('.vwf-role-mgr')
+  // 用零引用的 dispatcher 行：usage 服务故障（ok:false 解析）时点删除
+  state.failUsage = 'resolved'
+  const row = Array.from(mgr.querySelectorAll('.vwf-role-row')).find(r => byText(r, 'dispatcher'))
+  await act(async () => {
+    Array.from(row.querySelectorAll('button')).find(b => b.textContent === '删除').click()
+    await flush()
+    await flush()
+  })
+  assert.ok(!byText(mgr, '确认删除') && !mgr.querySelector('.vwf-dialog-mask'), 'usage ok:false 时不得进入删除确认')
+  assert.ok(byText(mgr, '引用统计失败'), '展示引用统计失败原因')
+  assert.ok(roleState.roles.some(r => r.id === 'dispatcher'), '角色未被删除')
+  state.failUsage = false
+  await act(async () => { freshRoot.unmount(); fresh.remove() })
 })
 
 test('粘贴蓝图 JSON：模型投影、唯一入口徽标、主链从左到右', async () => {

--- a/packages/dsh-visual-workflow/tests/dist-fresh.test.mjs
+++ b/packages/dsh-visual-workflow/tests/dist-fresh.test.mjs
@@ -10,6 +10,8 @@ const here = dirname(fileURLToPath(import.meta.url))
 const pkgRoot = join(here, '..')
 const HOST = join(pkgRoot, 'src', 'host.js')
 const CLIENT = join(pkgRoot, 'src', 'client.js')
+const ROLE_LIBRARY = join(pkgRoot, '..', '..', 'scripts', 'role-library.cjs')
+const ROLE_MANIFEST = join(pkgRoot, '..', '..', 'dsh', 'roles', 'builtin-roles.json')
 const STAMP = join(pkgRoot, 'dist', '.src-stamp.json')
 const DIST_HOST = join(pkgRoot, 'dist', 'host-entry.mjs')
 const PKG = join(pkgRoot, 'package.json')
@@ -18,11 +20,13 @@ function sha256(file) {
   return createHash('sha256').update(readFileSync(file)).digest('hex')
 }
 
-test('T2：dist/.src-stamp.json 与 src/host.js + src/client.js 哈希一致', () => {
+test('T2：dist/.src-stamp.json 与 src/host.js + src/client.js + 角色库内核/清单哈希一致', () => {
   assert.ok(existsSync(STAMP), '缺少 dist/.src-stamp.json：请运行 npm run build')
   const stamp = JSON.parse(readFileSync(STAMP, 'utf8'))
   assert.equal(stamp.host, sha256(HOST), 'host.js 已变更但 dist 未重建')
   assert.equal(stamp.client, sha256(CLIENT), 'client.js 已变更但 dist 未重建')
+  assert.equal(stamp.roleLibrary, sha256(ROLE_LIBRARY), 'scripts/role-library.cjs 已变更但 dist 未重建')
+  assert.equal(stamp.roleManifest, sha256(ROLE_MANIFEST), 'dsh/roles/builtin-roles.json 已变更但 dist 未重建')
 })
 
 test('T2：重建后的 dist 含双模式守卫，不再无条件调用 harness.handle', () => {

--- a/packages/dsh-visual-workflow/tests/helpers/fake-services.mjs
+++ b/packages/dsh-visual-workflow/tests/helpers/fake-services.mjs
@@ -63,7 +63,11 @@ export function makeSubprocess({ failPattern = null, fs = null, compileScript = 
       let exitCode = 0
       let stdout = ''
       let stderr = ''
-      if (argvStr.includes('.homedir')) {
+      if (argvStr.includes('validate-core.cjs') && fs) {
+        const key = [...fs._files.keys()].find((k) => k.endsWith('/validate-core.cjs'))
+        if (key) stdout = fs._files.get(key)
+        else exitCode = 2
+      } else if (argvStr.includes('.homedir')) {
         stdout = DSH_HOME
       } else if (argvStr.includes('generate.mjs') && argvStr.includes(' compile ')) {
         stdout = JSON.stringify({ ok: true, script: compileScript, meta: { name: 'mock', description: 'mock', phases: [] } })

--- a/packages/dsh-visual-workflow/tests/helpers/load-host.mjs
+++ b/packages/dsh-visual-workflow/tests/helpers/load-host.mjs
@@ -5,16 +5,34 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
-import { makeFs, makeSubprocess, sandboxPolicy } from './fake-services.mjs'
+import { makeFs, makeSubprocess, sandboxPolicy, HOME, DSH_HOME, REPO } from './fake-services.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const src = readFileSync(join(here, '..', '..', 'src', 'host.js'), 'utf8')
+// 角色库内核种子（role-library.cjs + manifest）：默认注入 home 对与 repo 对两个候选根——
+// 有 subprocess 时 dshHome 探针解析到假 HOME（home 对优先命中）；无 subprocess 时回落
+// 真实 HOME，repo 对兜底。readRoleFiles 只收 .md，manifest 的 .json 种子不影响角色目录语义。
+const roleCoreSrc = readFileSync(join(here, '..', '..', '..', '..', 'scripts', 'role-library.cjs'), 'utf8')
+const roleManifestSrc = readFileSync(join(here, '..', '..', '..', '..', 'dsh', 'roles', 'builtin-roles.json'), 'utf8')
+export const ROLE_CORE_SEED = {
+  [HOME + '/.dsh/visual-workflow/role-library.cjs']: roleCoreSrc,
+  [HOME + '/.dsh/visual-workflow/builtin-roles.json']: roleManifestSrc,
+  [REPO + '/scripts/role-library.cjs']: roleCoreSrc,
+  [REPO + '/dsh/roles/builtin-roles.json']: roleManifestSrc,
+}
 
 export function loadHost(overrides = {}) {
   const handlers = new Map()
   const definedTools = []
   const events = new Map()
-  const svc = { fs: makeFs({}), subprocess: makeSubprocess({}), sandboxPolicy, ...overrides }
+  // 测试必须显式注入假 process：当前 DSH 会话自身可能携带真实 DSH_HOME，若让
+  // host.js 读取全局 process.env 会把测试写入开发/产品真实 Home。形态与动态 loader 相同。
+  const { processValue = { env: { DSH_HOME, HOME }, cwd: () => REPO }, ...serviceOverrides } = overrides
+  const svc = { fs: makeFs({}), subprocess: makeSubprocess({}), sandboxPolicy, ...serviceOverrides }
+  // 默认注入角色库内核种子（显式缺省时可通过 roleCoreSeed:false 关闭）
+  if (overrides.roleCoreSeed !== false && svc.fs && svc.fs._files) {
+    for (const [k, v] of Object.entries(ROLE_CORE_SEED)) if (!svc.fs._files.has(k)) svc.fs._files.set(k, v)
+  }
   const ctx = {
     get: (name) => (svc[name] === undefined ? undefined : svc[name]),
     on: (name, fn) => { events.set(name, fn) },
@@ -24,9 +42,9 @@ export function loadHost(overrides = {}) {
     defineTool: (tool) => { definedTools.push(tool); return tool },
     registerTool: () => {},
   }
-  const pluginRoot = overrides.pluginRoot ?? null
-  const fn = new Function('ctx', 'harness', '__VWF_PLUGIN_ROOT__', `${src}`)
-  const plugin = fn(ctx, harness, pluginRoot)
+  const pluginRoot = serviceOverrides.pluginRoot ?? null
+  const fn = new Function('ctx', 'harness', '__VWF_PLUGIN_ROOT__', 'process', `${src}`)
+  const plugin = fn(ctx, harness, pluginRoot, processValue)
   plugin.apply(ctx)
   return { handlers, definedTools, events, ctx }
 }
@@ -39,7 +57,8 @@ export function loadStaticHost(overrides = {}) {
   const defaultWebServer = {
     register(route, label) { registered.push({ route, label }) },
   }
-  const svc = { fs: makeFs({}), subprocess: makeSubprocess({}), sandboxPolicy, ...overrides }
+  const { processValue = { env: { DSH_HOME, HOME }, cwd: () => REPO }, ...serviceOverrides } = overrides
+  const svc = { fs: makeFs({}), subprocess: makeSubprocess({}), sandboxPolicy, ...serviceOverrides }
   const ctx = {
     get: (name) => {
       if (name === 'webServer' && svc.webServer === undefined) return defaultWebServer
@@ -48,8 +67,9 @@ export function loadStaticHost(overrides = {}) {
     on: (name, fn) => { events.set(name, fn) },
     effect: (fn) => { fn(); return () => {} },
   }
-  const fn = new Function('ctx', `${src}`)
-  const plugin = fn(ctx)
+  const pluginRoot = serviceOverrides.pluginRoot ?? null
+  const fn = new Function('ctx', 'process', '__VWF_PLUGIN_ROOT__', `${src}`)
+  const plugin = fn(ctx, processValue, pluginRoot)
   plugin.apply(ctx)
   return { registered, definedTools, events, ctx }
 }

--- a/packages/dsh-visual-workflow/tests/host.test.mjs
+++ b/packages/dsh-visual-workflow/tests/host.test.mjs
@@ -1838,3 +1838,20 @@ test('#93 DSH_HOME：home 探测优先读取 process.env.DSH_HOME', async () => 
   assert.ok(probe, 'dshHome 探测必须读取 DSH_HOME，不能无条件 os.homedir()+/.dsh：' + JSON.stringify(sub._calls.slice(0, 3)))
 })
 
+test('粘贴蓝图 JSON：displayName / bindings.models 摄入 DSL，回退 outcome 不吞入口', async () => {
+  const { handlers, fs } = env()
+  const bp = JSON.parse(readFileSync(join(here, '..', '..', '..', 'scripts', 'test', 'fixtures', 'construction-rollback-mini.json'), 'utf8'))
+  const v = await call(handlers, 'vwf.validate', { dsl: bp })
+  assert.equal(v.ok, true, JSON.stringify(v.errors))
+  assert.equal(v.sanitized.name, '完整功能开发', 'displayName 投影为模板名称')
+  assert.equal(v.sanitized.entry, 'requirements', '唯一入口仍是 requirements')
+  assert.equal(v.sanitized.nodes.find((n) => n.id === 'requirements').model.provider, 'kimi-coding')
+  assert.equal(v.sanitized.nodes.find((n) => n.id === 'dev').model.model, 'deepseek-v4-pro')
+  const saved = await call(handlers, 'vwf.workflows.save', { dsl: bp })
+  assert.equal(saved.ok, true, JSON.stringify(saved.errors))
+  const disk = JSON.parse(fs._files.get(USER_DIR + '/construction-rollback-mini.json'))
+  assert.equal(disk.displayName, '完整功能开发')
+  assert.equal(disk.nodes.find((n) => n.id === 'review').verifyBranch, true, 'verifyBranch 保存往返')
+  assert.equal(disk.bindings.models.requirements.provider, 'kimi-coding')
+})
+

--- a/packages/dsh-visual-workflow/tests/host.test.mjs
+++ b/packages/dsh-visual-workflow/tests/host.test.mjs
@@ -10,7 +10,7 @@ const here = dirname(fileURLToPath(import.meta.url))
 const realGenerated = join(here, '..', '..', '..', '.generated', 'dev-workflow-2-0', 'vwf-dsl.json')
 
 // ── 共享假服务（helpers/fake-services.mjs）与共享加载器（helpers/load-host.mjs）──
-import { loadHost } from './helpers/load-host.mjs'
+import { loadHost, ROLE_CORE_SEED } from './helpers/load-host.mjs'
 import { REPO, SESSION_REPO, HOME, DSH_HOME, USER_DIR, SKILL_ROOT, makeFs, makeSubprocess, sandboxPolicy } from './helpers/fake-services.mjs'
 
 const call = async (handlers, method, args) => handlers.get(method)(args)
@@ -858,7 +858,7 @@ test('角色库 create：落盘 dsh/roles/<name>.md；与内置/自定义重名�
   assert.equal(noContent.errors[0].at, 'content')
 })
 
-test('角色库 usage：已迁出内置的历史模板不再计入内置引用（仅用户模板）', async () => {
+test('角色库 usage：跨历史模板 + 用户模板统计节点引用', async () => {
   const fs = makeFs({
     [REPO + '/.generated/dev-workflow-2-0/vwf-dsl.json']: JSON.stringify({
       id: 'dev-workflow-2-0', name: '内置流', entry: 'a',
@@ -880,10 +880,11 @@ test('角色库 usage：已迁出内置的历史模板不再计入内置引用�
   const { handlers } = loadHost({ fs, subprocess: sub, sandboxPolicy })
   const u = await call(handlers, 'vwf.roles.usage', { id: '需求分析师' })
   assert.equal(u.ok, true)
-  assert.equal(u.count, 1, '历史模板迁出内置后仅统计用户模板（引用回归由角色库深模块阶段纳入）')
-  assert.equal(u.refs.length, 1, '按工作流分组')
-  assert.equal(u.refs[0].workflowId, 'wf-a')
-  assert.equal(u.refs[0].builtin, false)
+  assert.equal(u.count, 3, '历史模板 2 + 用户模板 1')
+  assert.equal(u.refs.length, 2, '按工作流分组')
+  const shippedRef = u.refs.find(x => x.workflowId === 'dev-workflow-2-0')
+  assert.equal(shippedRef.builtin, false, '历史模板引用不再标内置')
+  assert.equal(shippedRef.nodes.length, 2)
 })
 
 test('角色库 update：内容修改全局生效；被引用角色重命名阻止；零引用重命名放行；内置拒绝', async () => {
@@ -1238,6 +1239,163 @@ test('静态组合包：项目路径不可用时仍从包内加载校验内核',
   } finally {
     if (previous === undefined) delete globalThis.__VWF_REPO_ROOT__
     else globalThis.__VWF_REPO_ROOT__ = previous
+  }
+})
+
+test('动态插件：浏览器保存（无会话 cwd）从宿主 visual-workflow 副本加载校验内核', async () => {
+  // 客户端 RPC 没有 currentInitiator；sandboxPolicy.workspaceRoot 是 DSH 部署 cwd，
+  // 不是工作流仓库。动态模式也没有 bundle 注入的 __VWF_REPO_ROOT__。
+  const previousRoot = globalThis.__VWF_REPO_ROOT__
+  const previousAlias = globalThis.__VWF_REPO__
+  delete globalThis.__VWF_REPO_ROOT__
+  delete globalThis.__VWF_REPO__
+  try {
+    const fs = makeFs({
+      [DSH_HOME + '/visual-workflow/validate-core.cjs']: validatorCoreSrc,
+    })
+    const { handlers } = loadHost({
+      fs,
+      subprocess: makeSubprocess({ fs }),
+      sandboxPolicy: { workspaceRoot: SESSION_REPO, resolve: () => ({ mode: 'danger-full-access', workspaceRoot: SESSION_REPO }) },
+    })
+    const v = await call(handlers, 'vwf.validate', { dsl: baseDsl() })
+    assert.equal(v.ok, true, JSON.stringify(v.errors))
+    assert.notEqual(
+      v.errors && v.errors[0] && v.errors[0].message,
+      '校验内核不可用：缺少 scripts/validate-core.cjs（请确认仓库完整）',
+    )
+  } finally {
+    if (previousRoot === undefined) delete globalThis.__VWF_REPO_ROOT__
+    else globalThis.__VWF_REPO_ROOT__ = previousRoot
+    if (previousAlias === undefined) delete globalThis.__VWF_REPO__
+    else globalThis.__VWF_REPO__ = previousAlias
+  }
+})
+
+test('动态插件：fs 读不到仓库时经子进程从 Home 副本加载校验内核', async () => {
+  const previousRoot = globalThis.__VWF_REPO_ROOT__
+  const previousAlias = globalThis.__VWF_REPO__
+  delete globalThis.__VWF_REPO_ROOT__
+  delete globalThis.__VWF_REPO__
+  try {
+    const hostFs = makeFs({})
+    const kernelFs = makeFs({
+      [DSH_HOME + '/visual-workflow/validate-core.cjs']: validatorCoreSrc,
+    })
+    const { handlers } = loadHost({
+      fs: hostFs,
+      subprocess: makeSubprocess({ fs: kernelFs }),
+      sandboxPolicy: { workspaceRoot: '', resolve: () => ({ mode: 'danger-full-access', workspaceRoot: '' }) },
+    })
+    const v = await call(handlers, 'vwf.validate', { dsl: baseDsl() })
+    assert.equal(v.ok, true, JSON.stringify(v.errors))
+  } finally {
+    if (previousRoot === undefined) delete globalThis.__VWF_REPO_ROOT__
+    else globalThis.__VWF_REPO_ROOT__ = previousRoot
+    if (previousAlias === undefined) delete globalThis.__VWF_REPO__
+    else globalThis.__VWF_REPO__ = previousAlias
+  }
+})
+
+test('动态插件：workspaceRoot 在仓库子目录时向上查找校验内核', async () => {
+  const previousRoot = globalThis.__VWF_REPO_ROOT__
+  const previousAlias = globalThis.__VWF_REPO__
+  delete globalThis.__VWF_REPO_ROOT__
+  delete globalThis.__VWF_REPO__
+  try {
+    const nested = REPO + '/packages/dsh-visual-workflow'
+    const fs = makeFs({ [REPO + '/scripts/validate-core.cjs']: validatorCoreSrc })
+    const { handlers } = loadHost({
+      fs,
+      subprocess: makeSubprocess({ fs }),
+      sandboxPolicy: { workspaceRoot: nested, resolve: () => ({ mode: 'danger-full-access', workspaceRoot: nested }) },
+    })
+    const v = await call(handlers, 'vwf.validate', { dsl: baseDsl() })
+    assert.equal(v.ok, true, JSON.stringify(v.errors))
+  } finally {
+    if (previousRoot === undefined) delete globalThis.__VWF_REPO_ROOT__
+    else globalThis.__VWF_REPO_ROOT__ = previousRoot
+    if (previousAlias === undefined) delete globalThis.__VWF_REPO__
+    else globalThis.__VWF_REPO__ = previousAlias
+  }
+})
+
+test('动态插件：历史 loader 的 __VWF_REPO__ 别名可加载校验内核', async () => {
+  const previousRoot = globalThis.__VWF_REPO_ROOT__
+  const previousAlias = globalThis.__VWF_REPO__
+  delete globalThis.__VWF_REPO_ROOT__
+  globalThis.__VWF_REPO__ = REPO
+  try {
+    const fs = makeFs({ [REPO + '/scripts/validate-core.cjs']: validatorCoreSrc })
+    const { handlers } = loadHost({
+      fs,
+      subprocess: makeSubprocess({ fs }),
+      sandboxPolicy: { workspaceRoot: '', resolve: () => ({ mode: 'danger-full-access', workspaceRoot: '' }) },
+    })
+    const v = await call(handlers, 'vwf.validate', { dsl: baseDsl() })
+    assert.equal(v.ok, true, JSON.stringify(v.errors))
+  } finally {
+    if (previousRoot === undefined) delete globalThis.__VWF_REPO_ROOT__
+    else globalThis.__VWF_REPO_ROOT__ = previousRoot
+    if (previousAlias === undefined) delete globalThis.__VWF_REPO__
+    else globalThis.__VWF_REPO__ = previousAlias
+  }
+})
+
+test('动态插件：从插件 dist/validate-core.cjs 加载校验内核', async () => {
+  const previousRoot = globalThis.__VWF_REPO_ROOT__
+  const previousAlias = globalThis.__VWF_REPO__
+  delete globalThis.__VWF_REPO_ROOT__
+  delete globalThis.__VWF_REPO__
+  try {
+    const PLUGIN = '/plugin/pkg'
+    const fs = makeFs({
+      [PLUGIN + '/dist/validate-core.cjs']: validatorCoreSrc,
+    })
+    const { handlers } = loadHost({
+      fs,
+      subprocess: makeSubprocess({ fs }),
+      pluginRoot: PLUGIN,
+      sandboxPolicy: { workspaceRoot: '', resolve: () => ({ mode: 'danger-full-access', workspaceRoot: '' }) },
+    })
+    const v = await call(handlers, 'vwf.validate', { dsl: baseDsl() })
+    assert.equal(v.ok, true, JSON.stringify(v.errors))
+  } finally {
+    if (previousRoot === undefined) delete globalThis.__VWF_REPO_ROOT__
+    else globalThis.__VWF_REPO_ROOT__ = previousRoot
+    if (previousAlias === undefined) delete globalThis.__VWF_REPO__
+    else globalThis.__VWF_REPO__ = previousAlias
+  }
+})
+
+test('动态插件：repo-root 指针让浏览器保存使用仓库生成器', async () => {
+  const previousRoot = globalThis.__VWF_REPO_ROOT__
+  const previousAlias = globalThis.__VWF_REPO__
+  delete globalThis.__VWF_REPO_ROOT__
+  delete globalThis.__VWF_REPO__
+  try {
+    const fs = makeFs({
+      [DSH_HOME + '/visual-workflow/repo-root']: REPO + '\n',
+      [DSH_HOME + '/visual-workflow/validate-core.cjs']: validatorCoreSrc,
+      [REPO + '/scripts/validate-core.cjs']: validatorCoreSrc,
+    })
+    const sub = makeSubprocess({ fs })
+    const { handlers } = loadHost({
+      fs,
+      subprocess: sub,
+      sandboxPolicy: { workspaceRoot: SESSION_REPO, resolve: () => ({ mode: 'danger-full-access', workspaceRoot: SESSION_REPO }) },
+    })
+    const saved = await call(handlers, 'vwf.workflows.save', { dsl: baseDsl({ id: 'browser-save' }) })
+    assert.equal(saved.ok, true, JSON.stringify(saved.errors))
+    assert.ok(
+      sub._calls.some((argv) => argv[1] === REPO + '/scripts/generate.mjs'),
+      JSON.stringify(sub._calls),
+    )
+  } finally {
+    if (previousRoot === undefined) delete globalThis.__VWF_REPO_ROOT__
+    else globalThis.__VWF_REPO_ROOT__ = previousRoot
+    if (previousAlias === undefined) delete globalThis.__VWF_REPO__
+    else globalThis.__VWF_REPO__ = previousAlias
   }
 })
 
@@ -1872,13 +2030,6 @@ test('#93 正式路径：vwf.script 未部署包装脚本时 allocate 不阻断�
   assert.equal(s.workspaceArgs, null)
 })
 
-test('#93 DSH_HOME：home 探测优先读取 process.env.DSH_HOME', async () => {
-  const { handlers, sub } = env()
-  await call(handlers, 'vwf.workflows.list')
-  const probe = sub._calls.find((c) => c.join(' ').includes('process.env.DSH_HOME') && c.join(' ').includes('.homedir'))
-  assert.ok(probe, 'dshHome 探测必须读取 DSH_HOME，不能无条件 os.homedir()+/.dsh：' + JSON.stringify(sub._calls.slice(0, 3)))
-})
-
 test('粘贴蓝图 JSON：displayName / bindings.models 摄入 DSL，回退 outcome 不吞入口', async () => {
   const { handlers, fs } = env()
   const bp = JSON.parse(readFileSync(join(here, '..', '..', '..', 'scripts', 'test', 'fixtures', 'construction-rollback-mini.json'), 'utf8'))
@@ -1894,5 +2045,31 @@ test('粘贴蓝图 JSON：displayName / bindings.models 摄入 DSL，回退 outc
   assert.equal(disk.displayName, '完整功能开发')
   assert.equal(disk.nodes.find((n) => n.id === 'review').verifyBranch, true, 'verifyBranch 保存往返')
   assert.equal(disk.bindings.models.requirements.provider, 'kimi-coding')
+})
+
+test('角色库 core 加载：动态模式优先 repo 最新成对资产，不被 home 旧清单覆盖', async () => {
+  const seed = { ...ROLE_CORE_SEED }
+  const homeManifestPath = DSH_HOME + '/visual-workflow/builtin-roles.json'
+  const stale = JSON.parse(seed[homeManifestPath])
+  stale.builtins.find((r) => r.id === 'dev').name = 'HOME 旧开发名'
+  seed[homeManifestPath] = JSON.stringify(stale)
+  // repo 候选保持当前 manifest（dev.name = 开发）
+  const fs = makeFs(seed)
+  const sub = makeSubprocess({ fs })
+  const { handlers } = loadHost({ fs, subprocess: sub, sandboxPolicy })
+  const r = await call(handlers, 'vwf.roles')
+  assert.equal(r.roles.find((x) => x.id === 'dev').name, '开发', '动态模式必须优先 repo 当前清单')
+})
+
+test('#93 DSH_HOME：明确 process.env.DSH_HOME 直接优先，不能被成功 probe fallback 覆盖', async () => {
+  const injected = '/tmp/vwf-explicit-dev-home'
+  const processValue = { env: { DSH_HOME: injected, HOME: '/tmp' }, cwd: () => REPO }
+  const { definedTools, sub } = env({ extra: { processValue, agents: { currentInitiator: () => null, requireInitiator: () => ({}) } } })
+  const debug = definedTools.find((t) => t.name === 'vwf_debug')
+  assert.ok(debug, 'agents 存在时应注册 vwf_debug')
+  const paths = JSON.parse(await debug.execute({ op: 'paths' }))
+  assert.equal(paths.dshHome, injected, '明确注入的 DSH_HOME 必须直接胜出')
+  const probe = sub._calls.find((c) => c.join(' ').includes('process.env.DSH_HOME') && c.join(' ').includes('.homedir'))
+  assert.equal(probe, undefined, '明确 DSH_HOME 存在时不应再执行可能回落产品 ~/.dsh 的 probe')
 })
 

--- a/packages/dsh-visual-workflow/tests/host.test.mjs
+++ b/packages/dsh-visual-workflow/tests/host.test.mjs
@@ -26,6 +26,21 @@ const MINIMAL_BUILTIN = JSON.stringify({
     { from: 'closeout', to: '$end', on: 'success' },
   ],
 }, null, 2) + '\n'
+const OFFICIAL_BUILTIN = JSON.stringify({
+  id: 'official-builtin', name: '正式内置样例', description: '仍占内置身份', entry: 'dispatch',
+  control: { maxRounds: 9 },
+  nodes: [
+    { id: 'dispatch', profile: 'dispatcher', label: '调度', goal: 'g', model: { provider: 'p1', model: 'm1' } },
+  ],
+  edges: [
+    { from: 'dispatch', to: '$end', on: 'success' },
+  ],
+}, null, 2) + '\n'
+const REMOVED_DIR = DSH_HOME + '/visual-workflow/removed'
+
+function plantOfficialBuiltin(fs) {
+  fs._files.set(REPO + '/.generated/official-builtin/vwf-dsl.json', OFFICIAL_BUILTIN)
+}
 
 // 统一校验内核（候选二 T-IMP-13）：宿主经 fs 读源码求值——测试假 fs 需种入真实内核
 const validatorCoreSrc = readFileSync(join(here, '..', '..', '..', 'scripts', 'validate-core.cjs'), 'utf8')
@@ -95,16 +110,16 @@ function heteroDsl(devModel, reviewModel, overrides = {}) {
 // T-IMP-06 · 双根加载
 // ═══════════════════════════════════════════════════════════════════════════
 
-test('AC-2：内置模板从 .generated/ 目录加载（host.js 无硬编码模板）', async () => {
+test('AC-2：历史模板从 .generated/ 目录加载为自定义（host.js 无硬编码模板）', async () => {
   const { handlers, sub } = env()
   const list = await call(handlers, 'vwf.workflows.list')
-  const builtin = list.find(w => w.id === 'dev-workflow-2-0')
-  assert.ok(builtin, '列表包含内置模板')
-  assert.equal(builtin.builtin, true)
-  const v = await call(handlers, 'vwf.validate', { dsl: builtin.dsl })
+  const shipped = list.find(w => w.id === 'dev-workflow-2-0')
+  assert.ok(shipped, '列表包含历史模板')
+  assert.equal(shipped.builtin, false, 'dev-workflow-2-0 已迁为自定义，无内置标签')
+  const v = await call(handlers, 'vwf.validate', { dsl: shipped.dsl })
   assert.equal(v.ok, true, JSON.stringify(v.errors))
   // T-IMP-12：vwf.compile 已删除；vwf.script 走统一编译器管道（CLI compile）
-  const s = await call(handlers, 'vwf.script', { dsl: builtin.dsl })
+  const s = await call(handlers, 'vwf.script', { dsl: shipped.dsl })
   assert.equal(s.ok, true, JSON.stringify(s.errors))
   const compileCall = sub._calls.find(c => c.join(' ').includes('generate.mjs') && c.join(' ').includes(' compile '))
   assert.ok(compileCall, 'vwf.script 经 CLI compile 取统一译文')
@@ -123,9 +138,9 @@ test('内置根优先取发起 agent 会话 cwd（agentless 兜底 sandboxPolicy
     agents: { currentInitiator: () => ({ session: { header: { cwd: SESSION_REPO } } }) },
   })
   const list = await call(handlers, 'vwf.workflows.list')
-  const builtin = list.find(w => w.id === 'dev-workflow-2-0')
-  assert.ok(builtin && builtin.builtin === true, '内置模板从会话 cwd 的 .generated/ 加载')
-  assert.equal(builtin.name, '开发工作流 2.0')
+  const shipped = list.find(w => w.id === 'dev-workflow-2-0')
+  assert.ok(shipped && shipped.builtin === false, '历史模板从会话 cwd 的 .generated/ 加载为自定义')
+  assert.equal(shipped.name, '开发工作流 2.0')
   // 无 agents 时兜底 sandboxPolicy.workspaceRoot（env() 默认路径覆盖）
 })
 
@@ -158,11 +173,11 @@ test('apply 无 initiator（浏览器审批激活）→ 后续模型调用实时
   // 模型发起调用（有 initiator）：实时解析会话 cwd → 内置根出现
   initiator = { session: { header: { cwd: SESSION_REPO } } }
   list = await call(handlers, 'vwf.workflows.list')
-  assert.ok(list.some(w => w.id === 'dev-workflow-2-0' && w.builtin === true), '实时 initiator 生效')
+  assert.ok(list.some(w => w.id === 'dev-workflow-2-0' && w.builtin === false), '实时 initiator 生效')
   // initiator 再次消失（客户端 RPC）：knownCwd 兜底仍能解析
   initiator = null
   list = await call(handlers, 'vwf.workflows.list')
-  assert.ok(list.some(w => w.id === 'dev-workflow-2-0' && w.builtin === true), 'knownCwd 历史兜底生效')
+  assert.ok(list.some(w => w.id === 'dev-workflow-2-0' && w.builtin === false), 'knownCwd 历史兜底生效')
 })
 
 test('真实生成物 .generated/dev-workflow-2-0/vwf-dsl.json 校验通过（编译已并入统一管道）', async (t) => {
@@ -215,11 +230,11 @@ test('save 蓝图级校验失败（生成器 exit 1）→ 回滚落盘并回传�
   assert.ok(!list.some(w => w.id === 't1'))
 })
 
-test('撞名：内置只读 / 同名用户拒绝提示改名 / currentId 更新自身允许', async () => {
-  const { handlers } = env()
+test('撞名：正式内置只读 / 同名用户拒绝提示改名 / currentId 更新自身允许', async () => {
+  const { handlers, fs } = env()
+  plantOfficialBuiltin(fs)
   await call(handlers, 'vwf.workflows.save', { dsl: baseDsl() })
-  // 内置只读
-  const toBuiltin = await call(handlers, 'vwf.workflows.save', { dsl: baseDsl({ id: 'dev-workflow-2-0', name: '开发工作流 2.0' }) })
+  const toBuiltin = await call(handlers, 'vwf.workflows.save', { dsl: baseDsl({ id: 'official-builtin', name: '正式内置样例' }) })
   assert.equal(toBuiltin.ok, false)
   assert.ok(toBuiltin.errors.some(e => e.message.includes('内置模板只读')), JSON.stringify(toBuiltin.errors))
   // 同名用户：无 currentId → 拒绝
@@ -236,27 +251,54 @@ test('撞名：内置只读 / 同名用户拒绝提示改名 / currentId 更新�
   assert.equal(list.find(w => w.id === 't1').description, 'v2', '更新覆盖生效')
 })
 
-test('remove：仅用户模板可删（蓝图+skill 同步删）；内置/不存在拒绝', async () => {
+test('remove：用户模板可删（蓝图+skill 同步删）；正式内置/不存在拒绝；历史模板可删且不再列出', async () => {
   const { handlers, fs, sub } = env()
+  plantOfficialBuiltin(fs)
   await call(handlers, 'vwf.workflows.save', { dsl: baseDsl() })
-  const rmBuiltin = await call(handlers, 'vwf.workflows.remove', { id: 'dev-workflow-2-0' })
+  const rmBuiltin = await call(handlers, 'vwf.workflows.remove', { id: 'official-builtin' })
   assert.equal(rmBuiltin.ok, false)
   assert.ok(rmBuiltin.errors.some(e => e.message.includes('内置模板只读')))
   const rmMissing = await call(handlers, 'vwf.workflows.remove', { id: 'nope' })
   assert.equal(rmMissing.ok, false)
   assert.ok(rmMissing.errors.some(e => e.message.includes('不存在')))
+  const rmShipped = await call(handlers, 'vwf.workflows.remove', { id: 'dev-workflow-2-0' })
+  assert.equal(rmShipped.ok, true)
+  assert.ok(fs._files.has(REMOVED_DIR + '/dev-workflow-2-0'), '删除标记已写入')
+  assert.ok(!(await call(handlers, 'vwf.workflows.list')).some(w => w.id === 'dev-workflow-2-0'), '历史模板删除后不再列出')
   const ok = await call(handlers, 'vwf.workflows.remove', { id: 't1' })
   assert.equal(ok.ok, true)
   assert.ok(!fs._files.has(USER_DIR + '/t1.json'), '蓝图已删')
   const rmCalls = sub._calls.filter(c => c.join(' ').includes('rmSync')).map(c => c.join(' '))
   assert.ok(rmCalls.some(s => s.includes(USER_DIR + '/t1.json')), '蓝图 rm 调用')
   assert.ok(rmCalls.some(s => s.includes(SKILL_ROOT + '/t1')), 'skill 目录 rm 调用')
+  assert.ok(rmCalls.some(s => s.includes(SKILL_ROOT + '/dev-workflow-2-0')), '历史模板同步删 skill')
   // 所有子进程 spawn 必须移除宿主注入的 NODE_OPTIONS（WorkBuddy safe-delete 钩子拦截 rmSync）
   const rmSpecs = sub._specs.filter(s => s.argv.join(' ').includes('rmSync'))
   assert.ok(rmSpecs.length >= 1, 'rmSync spawn 调用存在')
   assert.ok(rmSpecs.every(s => s.env && s.env.NODE_OPTIONS === undefined), 'NODE_OPTIONS 已移除（tombstone）')
   const list = await call(handlers, 'vwf.workflows.list')
   assert.ok(!list.some(w => w.id === 't1'))
+})
+
+test('历史模板迁为自定义：可保存覆盖用户目录；删除后 save 可重建', async () => {
+  const { handlers, fs } = env()
+  const list = await call(handlers, 'vwf.workflows.list')
+  const shipped = list.find(w => w.id === 'dev-workflow-2-0')
+  assert.ok(shipped && shipped.builtin === false)
+  const saved = await call(handlers, 'vwf.workflows.save', { dsl: baseDsl({ id: 'dev-workflow-2-0', name: '开发工作流 2.0', description: '用户覆盖' }), currentId: 'dev-workflow-2-0' })
+  assert.equal(saved.ok, true, JSON.stringify(saved.errors))
+  assert.ok(fs._files.has(USER_DIR + '/dev-workflow-2-0.json'), '覆盖落盘用户目录')
+  const overlay = (await call(handlers, 'vwf.workflows.list')).filter(w => w.id === 'dev-workflow-2-0')
+  assert.equal(overlay.length, 1, '用户覆盖与生成物不重复列出')
+  assert.equal(overlay[0].builtin, false)
+  assert.equal(overlay[0].description, '用户覆盖')
+  const rm = await call(handlers, 'vwf.workflows.remove', { id: 'dev-workflow-2-0' })
+  assert.equal(rm.ok, true)
+  assert.ok(!(await call(handlers, 'vwf.workflows.list')).some(w => w.id === 'dev-workflow-2-0'))
+  const restored = await call(handlers, 'vwf.workflows.save', { dsl: baseDsl({ id: 'dev-workflow-2-0', name: '开发工作流 2.0' }) })
+  assert.equal(restored.ok, true, JSON.stringify(restored.errors))
+  const again = (await call(handlers, 'vwf.workflows.list')).find(w => w.id === 'dev-workflow-2-0')
+  assert.ok(again && again.builtin === false, '重建后仍为自定义')
 })
 
 test('findWorkflow：内置优先、用户兜底（经 wf_run 未知模板错误消息验证合并列表）', async () => {
@@ -816,7 +858,7 @@ test('角色库 create：落盘 dsh/roles/<name>.md；与内置/自定义重名�
   assert.equal(noContent.errors[0].at, 'content')
 })
 
-test('角色库 usage：跨内置模板 + 用户模板统计节点引用', async () => {
+test('角色库 usage：已迁出内置的历史模板不再计入内置引用（仅用户模板）', async () => {
   const fs = makeFs({
     [REPO + '/.generated/dev-workflow-2-0/vwf-dsl.json']: JSON.stringify({
       id: 'dev-workflow-2-0', name: '内置流', entry: 'a',
@@ -838,11 +880,10 @@ test('角色库 usage：跨内置模板 + 用户模板统计节点引用', async
   const { handlers } = loadHost({ fs, subprocess: sub, sandboxPolicy })
   const u = await call(handlers, 'vwf.roles.usage', { id: '需求分析师' })
   assert.equal(u.ok, true)
-  assert.equal(u.count, 3, '内置模板 2 + 用户模板 1')
-  assert.equal(u.refs.length, 2, '按工作流分组')
-  const builtinRef = u.refs.find(x => x.builtin)
-  assert.equal(builtinRef.workflowId, 'dev-workflow-2-0')
-  assert.equal(builtinRef.nodes.length, 2)
+  assert.equal(u.count, 1, '历史模板迁出内置后仅统计用户模板（引用回归由角色库深模块阶段纳入）')
+  assert.equal(u.refs.length, 1, '按工作流分组')
+  assert.equal(u.refs[0].workflowId, 'wf-a')
+  assert.equal(u.refs[0].builtin, false)
 })
 
 test('角色库 update：内容修改全局生效；被引用角色重命名阻止；零引用重命名放行；内置拒绝', async () => {
@@ -1149,7 +1190,7 @@ test('内置双根：仓库 .generated 为空时从 ~/.dsh/.generated 加载（h
   const { handlers } = loadHost({ fs, subprocess: sub, sandboxPolicy })
   const list = await call(handlers, 'vwf.workflows.list')
   const w = list.find(x => x.id === 'default-workflow')
-  assert.ok(w && w.builtin === true, '宿主根内置模板可见')
+  assert.ok(w && w.builtin === false, '宿主根历史模板可见且为自定义')
   assert.equal(w.name, '默认工作流')
 })
 

--- a/packages/dsh-visual-workflow/tests/role-manifest.test.mjs
+++ b/packages/dsh-visual-workflow/tests/role-manifest.test.mjs
@@ -1,0 +1,104 @@
+// 内置角色清单 manifest 契约测试（角色库深化 P1）
+// seam：dsh/roles/builtin-roles.json 数据文件本身。
+// 期望值来源 = 产品规格 §8 的 12 角色名单 + host.js 当前注册表（独立事实源，非从被测物推导）。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(here, '..', '..', '..')
+const MANIFEST = join(repoRoot, 'dsh', 'roles', 'builtin-roles.json')
+const ROLES_DIR = join(repoRoot, 'dsh', 'roles')
+
+// 规格 §8 的权威名单（通用 8 + 专业 4，顺序即展示顺序）
+const EXPECTED = [
+  { id: 'requirements', name: '需求分析', summary: '需求分析角色：三要素门禁，产出需求基线' },
+  { id: 'designer', name: '方案设计', summary: '方案设计角色：实施路径、关键取舍与风险' },
+  { id: 'dev', name: '开发', summary: '开发角色：测试驱动施工，满足质量闸门' },
+  { id: 'review', name: '审核', summary: '审核角色：规范与需求符合性、代码质量双轴审查' },
+  { id: 'test', name: '测试', summary: '测试角色：运行态验证，证据驱动判定' },
+  { id: 'evaluator', name: '评估', summary: '评估角色：按节点评价契约独立评估，场景差异由节点表达' },
+  { id: 'accept', name: '验收助手', summary: '验收助手角色：对照验收标准最终核验并等待人工签字' },
+  { id: 'closeout', name: '收口', summary: '收口角色：一致性收口与交接产物汇总' },
+  { id: 'diagnose', name: '缺陷诊断', summary: '缺陷诊断角色：先取证后结论，收敛到根因' },
+  { id: 'orchestrator', name: '探索统筹', summary: '探索统筹角色：设计研究方案与专家任务书' },
+  { id: 'researcher', name: '专家研究', summary: '专家研究角色：按任务书独立取证，含反证' },
+  { id: 'synthesizer', name: '综合分析', summary: '综合分析角色：把独立判断整合为可决策的观点地图' },
+]
+
+function loadManifest() {
+  assert.ok(existsSync(MANIFEST), '缺少 dsh/roles/builtin-roles.json')
+  return JSON.parse(readFileSync(MANIFEST, 'utf8'))
+}
+
+test('manifest：可解析 JSON 且 schemaVersion=1', () => {
+  const m = loadManifest()
+  assert.equal(m.schemaVersion, 1, 'manifest 必须声明 schemaVersion: 1')
+  assert.ok(Array.isArray(m.builtins), 'manifest.builtins 必须是数组')
+})
+
+test('manifest：12 个内置角色按规格 §8 精确顺序与文案', () => {
+  const m = loadManifest()
+  assert.equal(m.builtins.length, EXPECTED.length, `内置角色必须恰好 ${EXPECTED.length} 个（规格 §8）`)
+  for (let i = 0; i < EXPECTED.length; i++) {
+    const got = m.builtins[i]
+    const want = EXPECTED[i]
+    assert.equal(got.id, want.id, `第 ${i} 位角色 id 漂移`)
+    assert.equal(got.name, want.name, `${want.id} 中文名漂移`)
+    assert.equal(got.summary, want.summary, `${want.id} 摘要漂移`)
+  }
+})
+
+test('manifest：结构不变量（id 稳定英文、中文名非空、definition 不穿越、全部只读）', () => {
+  const m = loadManifest()
+  const seen = new Set()
+  for (const r of m.builtins) {
+    assert.match(r.id, /^[a-z][a-z0-9-]*$/, `机器 ID 必须为稳定英文：${r.id}`)
+    const key = r.id.normalize('NFC').toLowerCase()
+    assert.ok(!seen.has(key), `id 归一化后冲突：${r.id}`)
+    seen.add(key)
+    assert.ok(r.name && String(r.name).trim().length > 0, `中文名不得为空：${r.id}`)
+    assert.ok(r.summary && String(r.summary).trim().length > 0, `摘要不得为空：${r.id}`)
+    assert.equal(r.definition, 'dsh/roles/' + r.id + '.md', `definition 必须严格等于 dsh/roles/<id>.md：${r.id}`)
+    assert.equal(r.builtin, true, `内置角色必须 builtin:true：${r.id}`)
+    assert.equal(r.readonly, true, `内置角色必须 readonly:true：${r.id}`)
+  }
+})
+
+test('manifest：12 个内置角色的定义文件全部存在', () => {
+  const m = loadManifest()
+  for (const r of m.builtins) {
+    assert.ok(existsSync(join(ROLES_DIR, r.id + '.md')), `缺少角色定义文件：dsh/roles/${r.id}.md`)
+  }
+})
+
+test('manifest：dispatcher 登记为兼容角色（builtin:false），且不与内置冲突', () => {
+  const m = loadManifest()
+  const builtinIds = new Set(m.builtins.map((r) => r.id))
+  assert.ok(!builtinIds.has('dispatcher'), 'dispatcher 不得出现在 builtins（issue-81 已迁出）')
+  const compat = Array.isArray(m.compatibilityRoles) ? m.compatibilityRoles : []
+  const dp = compat.find((r) => r.id === 'dispatcher')
+  assert.ok(dp, 'dispatcher 必须登记在 compatibilityRoles（历史引用兼容）')
+  assert.equal(dp.builtin, false, 'dispatcher 身份必须是自定义')
+  for (const r of compat) {
+    assert.ok(!builtinIds.has(r.id), `兼容角色不得与内置冲突：${r.id}`)
+  }
+})
+
+test('嵌入降级清单 EMBEDDED_BUILTIN_MANIFEST 与 manifest 逐字段一致（无 fs 降级数据闸）', () => {
+  // host.js 无 fs / core 不可用时以嵌入清单兜底「内置角色常驻」。该清单是 manifest 的
+  // 机器投影（禁止手改），本测试是两份数据的一致性闸。
+  const m = loadManifest()
+  const hostSrc = readFileSync(join(repoRoot, 'packages', 'dsh-visual-workflow', 'src', 'host.js'), 'utf8')
+  const block = /const EMBEDDED_BUILTIN_MANIFEST = \[([\s\S]*?)\n\s*\]/.exec(hostSrc)
+  assert.ok(block, 'host.js 必须含 EMBEDDED_BUILTIN_MANIFEST 嵌入清单')
+  const embedded = new Function('return [' + block[1] + ']')()
+  assert.equal(embedded.length, m.builtins.length, '嵌入清单与 manifest 数量漂移')
+  for (let i = 0; i < m.builtins.length; i++) {
+    assert.equal(embedded[i].id, m.builtins[i].id, `第 ${i} 位 id 漂移`)
+    assert.equal(embedded[i].name, m.builtins[i].name, `第 ${i} 位 name 漂移`)
+    assert.equal(embedded[i].summary, m.builtins[i].summary, `第 ${i} 位 summary 漂移`)
+  }
+})

--- a/packages/dsh-visual-workflow/tests/static-bundle.test.mjs
+++ b/packages/dsh-visual-workflow/tests/static-bundle.test.mjs
@@ -9,15 +9,49 @@ import { pathToFileURL } from 'node:url'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { loadStaticHost, loadHost } from './helpers/load-host.mjs'
-import { makeFs, makeSubprocess, sandboxPolicy } from './helpers/fake-services.mjs'
+import { REPO, makeFs, makeSubprocess, sandboxPolicy } from './helpers/fake-services.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const distEntry = join(here, '..', 'dist', 'host-entry.mjs')
 const distClient = join(here, '..', 'dist', 'client.js')
 
+function invokeStaticRpc(route, method, payload = {}) {
+  return new Promise((resolve, reject) => {
+    const listeners = {}
+    const req = { method: 'POST', on(name, fn) { listeners[name] = fn } }
+    const res = {
+      writeHead() {},
+      end(text) {
+        try { resolve(JSON.parse(text).result) } catch (e) { reject(e) }
+      },
+    }
+    route.handler(req, res)
+    if (listeners.data) listeners.data(JSON.stringify({ type: 'client-request', rpcId: 'test-rpc', method, payload }))
+    if (listeners.end) listeners.end()
+  })
+}
+
 test('T3：静态 bundle dist 含 formal-artifacts.cjs（#69 正式安装路径）', () => {
   const formalDist = join(here, '..', 'dist', 'formal-artifacts.cjs')
   assert.ok(existsSync(formalDist), 'dist/formal-artifacts.cjs 必须存在（build 时从 scripts/ 复制）')
+})
+
+test('静态 bundle dist 含 validate-core.cjs（浏览器保存无仓库 cwd 时的内核副本）', () => {
+  const kernelDist = join(here, '..', 'dist', 'validate-core.cjs')
+  assert.ok(existsSync(kernelDist), 'dist/validate-core.cjs 必须存在（build 时从 scripts/ 复制）')
+})
+
+test('静态 bundle dist 含 role-library.cjs + builtin-roles.json 且内核可加载（角色库正式安装路径）', () => {
+  const coreDist = join(here, '..', 'dist', 'role-library.cjs')
+  const manifestDist = join(here, '..', 'dist', 'builtin-roles.json')
+  assert.ok(existsSync(coreDist), 'dist/role-library.cjs 必须存在（build 时从 scripts/ 复制）')
+  assert.ok(existsSync(manifestDist), 'dist/builtin-roles.json 必须存在（build 时从 dsh/roles/ 复制）')
+  // 从 dist 路径真实加载内核（与 host.js 静态候选根 __VWF_PLUGIN_ROOT__/dist 同形态）
+  const module = { exports: {} }
+  new Function('module', 'exports', readFileSync(coreDist, 'utf8'))(module, module.exports)
+  assert.equal(typeof module.exports.createRoleLibrary, 'function', 'dist 内核必须导出 createRoleLibrary')
+  const lib = module.exports.createRoleLibrary(JSON.parse(readFileSync(manifestDist, 'utf8')))
+  assert.equal(lib.describe().builtinIds.length, 12, 'dist 清单必须含 12 个内置角色')
 })
 
 test('T3：静态客户端 bundle 注册 dsh-visual-workflow 到网页模块加载器', () => {
@@ -58,6 +92,26 @@ test('T3：动态 Host 仍走 harness.handle（回归：双模式互不抢占）
   })()
   assert.ok(handlers.has('vwf.workflows.list'), '动态模式 RPC 仍经 harness.handle 注册')
   assert.equal(registered, undefined, '动态加载器不暴露 webServer 注册面')
+})
+
+test('角色库 core 加载：正式静态模式优先可信 pluginRoot/dist，不读取 repo 旧清单', async () => {
+  const repoRoot = join(here, '..', '..', '..')
+  const coreSrc = readFileSync(join(repoRoot, 'scripts', 'role-library.cjs'), 'utf8')
+  const base = JSON.parse(readFileSync(join(repoRoot, 'dsh', 'roles', 'builtin-roles.json'), 'utf8'))
+  const trusted = JSON.parse(JSON.stringify(base))
+  trusted.builtins.find((r) => r.id === 'dev').name = 'DIST 可信开发名'
+  const untrusted = JSON.parse(JSON.stringify(base))
+  untrusted.builtins.find((r) => r.id === 'dev').name = 'REPO 旧开发名'
+  const pluginRoot = '/pkg'
+  const fs = makeFs({
+    [pluginRoot + '/dist/role-library.cjs']: coreSrc,
+    [pluginRoot + '/dist/builtin-roles.json']: JSON.stringify(trusted),
+    [REPO + '/scripts/role-library.cjs']: coreSrc,
+    [REPO + '/dsh/roles/builtin-roles.json']: JSON.stringify(untrusted),
+  })
+  const loaded = loadStaticHost({ fs, subprocess: makeSubprocess({ fs }), sandboxPolicy, pluginRoot })
+  const result = await invokeStaticRpc(loaded.registered[0].route, 'vwf.roles')
+  assert.equal(result.roles.find((r) => r.id === 'dev').name, 'DIST 可信开发名', '静态模式必须优先可信 dist')
 })
 
 test('T3：静态 bundle dist/host-entry.mjs 在无 harness 时 apply() 走 webServer', async (t) => {

--- a/scripts/dev-plugin.mjs
+++ b/scripts/dev-plugin.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto'
 import {
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -156,10 +157,18 @@ function discoverDevDsh() {
 function sourceVersion() {
   const host = readFileSync(join(pluginRoot, 'src', 'host.js'))
   const client = readFileSync(join(pluginRoot, 'src', 'client.js'))
+  // 角色库深化后运行时行为还由内核与清单决定：改它们不改 host/client 时
+  // 联合版本必须变化，否则动态注入后 cordis_inspect_self 核对会漏掉内核漂移
+  const roleLibrary = readFileSync(join(repoRoot, 'scripts', 'role-library.cjs'))
+  const roleManifest = readFileSync(join(repoRoot, 'dsh', 'roles', 'builtin-roles.json'))
   const hash = createHash('sha256')
     .update(host)
     .update('\0')
     .update(client)
+    .update('\0')
+    .update(roleLibrary)
+    .update('\0')
+    .update(roleManifest)
     .digest('hex')
     .slice(0, 12)
   return `vwf-dev-${hash}`
@@ -194,7 +203,7 @@ console.log(
     running ? `运行中（PID ${pid}，${active.urls.join(', ')}）` : '未运行'
   }`,
 )
-console.log(`- 当前联合版本：${version}（host + client）`)
+console.log(`- 当前联合版本：${version}（host + client + role-library + role-manifest）`)
 
 if (formalBundleInstalled) {
   fail(
@@ -202,6 +211,36 @@ if (formalBundleInstalled) {
       `请先通过公开命令清理开发 Profile；脚本不会自动修改 ${profilePackage}。`,
   )
 }
+
+function syncDevKernelAssets() {
+  try {
+    const kernelSrc = join(repoRoot, 'scripts', 'validate-core.cjs')
+    const roleLibrarySrc = join(repoRoot, 'scripts', 'role-library.cjs')
+    const roleManifestSrc = join(repoRoot, 'dsh', 'roles', 'builtin-roles.json')
+    const assetDir = join(devHome, 'visual-workflow')
+    mkdirSync(assetDir, { recursive: true })
+    writeFileSync(join(assetDir, 'repo-root'), `${repoRoot}\n`)
+    if (!existsSync(kernelSrc)) {
+      fail(`缺少校验内核：${kernelSrc}`)
+    }
+    copyFileSync(kernelSrc, join(assetDir, 'validate-core.cjs'))
+    // 角色库内核 + 内置清单（RoleLibrary 深化）：候选根成对加载需要 home 副本
+    if (!existsSync(roleLibrarySrc)) {
+      fail(`缺少角色库内核：${roleLibrarySrc}`)
+    }
+    if (!existsSync(roleManifestSrc)) {
+      fail(`缺少内置角色清单：${roleManifestSrc}`)
+    }
+    copyFileSync(roleLibrarySrc, join(assetDir, 'role-library.cjs'))
+    copyFileSync(roleManifestSrc, join(assetDir, 'builtin-roles.json'))
+  } catch (e) {
+    // sync 是可选便利（浏览器侧候选根兜底）；写 dev home 被沙箱/权限拒绝时
+    // 不应让状态检查整体崩溃——插件运行时仍可从仓库根候选路径加载内核。
+    console.warn(`⚠️ 内核资产同步到开发 Home 失败（不影响仓库根加载）：${String((e && e.message) || e)}`)
+  }
+}
+
+syncDevKernelAssets()
 
 function printSyncGuide() {
   console.log(`

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -8,26 +8,34 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 // 统一校验内核（候选二 T-IMP-13，CJS 单文件——引擎 import / 宿主 vm eval 双形态）
 import validatorCore from './validate-core.cjs';
+// 角色库内核（候选二深化）：内置角色清单唯一事实源 = dsh/roles/builtin-roles.json；
+// 正文安全读取与「被引用角色文件打包」共享内核实现（含自定义角色——dispatcher 等）。
+import roleLibrary from './role-library.cjs';
+
+const { buildSnapshot, readRoleFileSafe, collectReferencedRoleFiles } = roleLibrary;
 
 const { validateBlueprint, COND_RE, HUMAN_DECISION_ID, HD_CONTROL_RESULTS, HD_PACKAGE_REQUIRED, HD_UNKNOWN, HD_EVENT_RECORD_KIND, HD_EVENT_TRIGGER } = validatorCore;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_TPL_DIR = path.join(__dirname, '..', 'templates');
 const DEFAULT_OUT_DIR = path.join(__dirname, '..', '.generated');
+const DEFAULT_MANIFEST_PATH = path.join(__dirname, '..', 'dsh', 'roles', 'builtin-roles.json');
 
-// ---------- 内置角色清单（单一来源 = 宿主注册表 host.js BUILTIN_ROLES）----------
+// ---------- 内置角色清单（单一事实源 = dsh/roles/builtin-roles.json）----------
 // 生成脚本需区分「内置角色」与「自定义角色」：内置角色只读、以打包快照为准（Codex
-// PR#124 第四轮 P1，评论 3889756922），自定义角色以工作区 dsh/roles 为准。此处不在
-// 本文件复制名单，改注册表即生效；解析失败 loud-fail，避免静默退化成全部走工作区。
-export function loadBuiltinRoleIds(hostSrc) {
-  const src = hostSrc === undefined
-    ? fs.readFileSync(path.join(__dirname, '..', 'packages', 'dsh-visual-workflow', 'src', 'host.js'), 'utf8')
-    : hostSrc;
-  const block = /const BUILTIN_ROLES = \[([\s\S]*?)\n\s*\]/.exec(src);
-  if (!block) throw new Error('内置角色清单解析失败：未在 host.js 找到 BUILTIN_ROLES 数组');
-  const ids = Array.from(block[1].matchAll(/\{\s*id:\s*'([^']+)'/g)).map((m) => m[1]);
-  if (!ids.length) throw new Error('内置角色清单解析失败：BUILTIN_ROLES 中未解析到任何 id');
-  return ids;
+// PR#124 第四轮 P1，评论 3889756922），自定义角色以工作区 dsh/roles 为准。清单读
+// manifest 并强校验（schema/顺序不变量/dispatcher 不得为内置），解析失败 loud-fail，
+// 禁止静默退化成全部走工作区。不再反向解析 host.js 源码（旧 regex 缝已拆）。
+export function loadBuiltinRoleIds(manifestPath = DEFAULT_MANIFEST_PATH) {
+  try {
+    // 统一走 RoleLibrary 的同步构建投影：保持 compileBlueprint 同步，避免第二套
+    // manifest 解析/校验实现。buildSnapshot 同时验证 12 个角色正文可读取性投影。
+    return buildSnapshot({ manifestPath, rolesDir: DEFAULT_ROLES_DIR, io: fs }).builtinIds;
+  } catch (e) {
+    const message = String((e && e.message) || e)
+    if (message.includes('内置角色清单解析失败')) throw e
+    throw new Error('内置角色清单解析失败：' + message)
+  }
 }
 let _builtinRoleIdsCache = null;
 function builtinRoleIdsCached() {
@@ -40,15 +48,9 @@ function builtinRoleIdsCached() {
 // 打包角色包即可拿到角色定义；stale 产物缺 ROLE_DEFS 时 roleRef 安全回退到读文件路径。
 // 仅收录内置角色（ids 即内置清单）；角色文件缺失/非法 id 时跳过，保留读路径回退。
 // rolesDir 默认 <repo>/dsh/roles（与 collectBuiltinRoles 同源，编译期内联 = 打包快照）。
-// 角色文件安全读取（与 collectBuiltinRoles 共享）：标识只允许中英文/数字/下划线/短横线，
-// 且解析后路径必须仍在角色源目录内（路径穿越防护）；文件缺失/非法返回 null。
-function readRoleFileSafe(rolesDir, id, io) {
-  if (!/^[\w一-龥-]+$/.test(id)) return null
-  const file = path.join(rolesDir, id + '.md')
-  const rel = path.relative(rolesDir, file)
-  if (rel.startsWith('..') || path.isAbsolute(rel)) return null
-  try { return io.readFileSync(file, 'utf8') } catch (e) { return null }
-}
+// 角色文件安全读取（readRoleFileSafe 共享自 role-library.cjs，Codex PR#124 第四轮 P1，
+// 评论 3889756923）：标识只允许中英文/数字/下划线/短横线，且解析后路径必须仍在角色源
+// 目录内（路径穿越防护）；文件缺失/非法返回 null。
 export function loadBuiltinRoleDefs(ids, rolesDir = DEFAULT_ROLES_DIR, io = fs) {
   const out = {};
   for (const id of ids) {
@@ -135,7 +137,7 @@ export function compileBlueprint(bp, opts = {}) {
   const folds = foldableNodes(bp);
   const hetero = bp.heteroCheck && models.dev && models.review;
   const autoReschedule = bp.onMaxRounds === 'auto-reschedule';
-  // 内置角色清单：opts 注入优先（测试用），否则读宿主注册表并缓存
+  // 内置角色清单：opts 注入优先（测试用），否则读 manifest 并缓存
   const builtinRoleIds = opts.builtinRoleIds || builtinRoleIdsCached();
   // 内置角色正文（#129 遗留项 2）：临时/未保存图编译自包含——正文内联进 ROLE_DEFS。
   // 只内联蓝图实际引用到的内置角色（Codex PR#130 P1，评论 3900290054）：全部 12 个
@@ -165,7 +167,7 @@ export function compileBlueprint(bp, opts = {}) {
     'const EDGES = ' + JSON.stringify(bp.edges),
     'const MODELS = ' + JSON.stringify(models),
     'const FOLDS = ' + JSON.stringify(folds),
-    // 内置角色清单（单一来源 = 宿主注册表）：roleRef 据此决定内置/自定义读取优先级
+    // 内置角色清单（单一事实源 = dsh/roles/builtin-roles.json）：roleRef 据此决定内置/自定义读取优先级
     'const BUILTIN_ROLE_IDS = ' + JSON.stringify(builtinRoleIds),
     // 内置角色正文（#129 遗留项 2）：编译期内联，临时编译自包含；缺失时 roleRef 走读路径回退
     'const ROLE_DEFS = ' + JSON.stringify(builtinRoleDefs),
@@ -824,22 +826,12 @@ export function generateUserSkill(bp) {
 // 一起写到 roles/ 子目录，compileViaPipeline 命中即带出 roleDir，运行时自包含。
 // 角色源缺失或某角色文件不存在时静默跳过——可能是自定义角色（运行时按工作区 dsh/roles 解析）。
 const DEFAULT_ROLES_DIR = path.join(__dirname, '..', 'dsh', 'roles')
+// 注意命名误导（保留导出名以兼容既有调用与测试）：本函数打包的是「蓝图引用且角色
+// 文件存在」的全部角色，**包含自定义角色**（如已迁出内置的 dispatcher）——绝不能误
+// 改为仅过滤内置，否则用户 skill 的历史自定义角色自包含行为会回归。语义实现已收敛进
+// role-library.cjs 的 collectReferencedRoleFiles（单一实现）。
 export function collectBuiltinRoles(bp, rolesDir = DEFAULT_ROLES_DIR, io = fs) {
-  const out = new Map()
-  if (!bp || !Array.isArray(bp.nodes)) return out
-  const profiles = new Set()
-  for (const n of bp.nodes) {
-    if (n && typeof n.profile === 'string' && n.profile) profiles.add(n.profile)
-  }
-  for (const profile of profiles) {
-    // 安全读取（readRoleFileSafe 共享，Codex PR#124 第四轮 P1，评论 3889756923）：
-    // profile 此前只校验非空，'../../AGENTS' 之类会被拼出 roles/ 目录之外的路径，
-    // 随 skill 写到暂存目录外。角色标识只允许中英文/数字/下划线/短横线且路径必须在
-    // 角色源目录内；文件缺失/非法返回 null → 跳过（自定义角色运行时按工作区 dsh/roles 解析）。
-    const content = readRoleFileSafe(rolesDir, profile, io)
-    if (content != null) out.set('roles/' + profile + '.md', content)
-  }
-  return out
+  return collectReferencedRoleFiles(bp, rolesDir, io)
 }
 
 // ---------- 用户 skill 原子写盘（候选四 T-IMP-14） ----------

--- a/scripts/role-library.cjs
+++ b/scripts/role-library.cjs
@@ -1,0 +1,437 @@
+'use strict'
+// ─────────────────────────────────────────────────────────────────────────────
+// 角色库内核（Role Library Core）——唯一决策模块
+//
+// 深度设计：外部只有两类入口，内部隐藏名称规则、来源优先级、摘要口径、引用统计、
+// 只读裁决与重命名回滚决策。
+//   1. createRoleLibrary(manifest) → { describe(), execute(request) }——运行时深模块。
+//      execute 只接受闭合命令联合（manifest/list/get/usage/validateName/change），
+//      事实（facts）由调用方（Host 适配器）采集注入，模块不触碰 fs/subprocess/路径。
+//      决策以意图（effect）返回：{kind:'write'|'rename'|'remove', ...}，由 Host 执行。
+//   2. buildSnapshot(opts) → 同步构建期投影（生成器用）：清单 + 内置角色正文。
+//      保持 compileBlueprint 同步，不引入顶层 await。
+//
+// 单一事实源：dsh/roles/builtin-roles.json（内置清单）；dsh/roles/<id>.md（角色正文）。
+// 删除本模块后，名称规则 / 来源优先级 / usage 统计 / 只读与回滚裁决会重新散落回
+// Host、Generator、Client 三处——这正是它存在的理由（删除测试）。
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ROLE_NAME_MAX = 64
+// 名称唯一性键：NFC 规范化 + 小写（macOS/Windows 默认文件系统对规范化/大小写不敏感）。
+function roleKey(s) {
+  return String(s || '').normalize('NFC').toLowerCase()
+}
+const ILLEGAL_NAME_CHARS = /[\\/:*?"<>|\x00-\x1F\x7F]/
+const WINDOWS_RESERVED = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i
+
+// 角色名称校验：非空 / 长度 / 文件系统安全字符 / 首尾点 / Windows 保留设备名。
+// 返回错误文案（与线上 RPC 逐字一致）或 null。
+function validateRoleName(name) {
+  const v = String(name || '').trim()
+  if (!v) return '角色名称不能为空'
+  if (v.length > ROLE_NAME_MAX) return '角色名称过长（最多 ' + ROLE_NAME_MAX + ' 字符）'
+  if (ILLEGAL_NAME_CHARS.test(v)) return '角色名称包含非法字符'
+  if (/^\./.test(v) || /\.$/.test(v)) return '角色名称不能以点开头或结尾'
+  if (WINDOWS_RESERVED.test(v)) return '角色名称是系统保留名（如 CON/NUL/AUX），请换一个名称'
+  return null
+}
+
+// 角色正文摘要：取首个有意义行（跳过 frontmatter 键/标题），截 80 字符；空则回退 fallback。
+function summarizeRole(content, fallback) {
+  if (typeof content !== 'string') return fallback || ''
+  const skip = /^---|^id:|^name:|^summary|^createdAt|^updatedAt|^dynamicTemplate|^#/
+  const firstLine = content.split('\n').map((l) => l.trim()).filter((l) => l && !skip.test(l))[0]
+  return (firstLine || fallback || '').slice(0, 80)
+}
+
+// 打包回退角色的摘要口径：取首个非空行（注意：不做 trim——与线上行为逐字一致）。
+function bundledFirstLine(content) {
+  return String(content || '').split('\n').find((l) => l.trim()) || ''
+}
+
+function placeholderContent(meta) {
+  return '# ' + meta.name + '（' + meta.id + '）\n\n' + meta.summary + '\n\n> 当前工作区未包含该内置角色的完整定义（dsh/roles/' + meta.id + '.md），角色仍可正常选择使用。'
+}
+
+// ── manifest 校验（加载即 loud-fail；不得静默退化为「全是自定义」）─────────────────
+function validateManifest(m) {
+  if (!m || typeof m !== 'object') throw new Error('内置角色清单解析失败：manifest 不是对象')
+  if (!Array.isArray(m.builtins)) throw new Error('内置角色清单解析失败：缺少 builtins 数组')
+  if (!m.builtins.length) throw new Error('内置角色清单解析失败：builtins 为空')
+  if (m.schemaVersion !== 1) throw new Error('内置角色清单解析失败：schemaVersion 必须为 1')
+  const seen = new Set()
+  for (const r of m.builtins) {
+    if (!r || typeof r !== 'object') throw new Error('内置角色清单解析失败：存在非对象条目')
+    if (!/^[a-z][a-z0-9-]*$/.test(String(r.id || ''))) throw new Error('内置角色清单解析失败：非法 id：' + r.id)
+    const key = roleKey(r.id)
+    if (seen.has(key)) throw new Error('内置角色清单解析失败：id 归一化后冲突：' + r.id)
+    seen.add(key)
+    if (!r.name || !String(r.name).trim()) throw new Error('内置角色清单解析失败：中文名为空：' + r.id)
+    if (!r.summary || !String(r.summary).trim()) throw new Error('内置角色清单解析失败：摘要为空：' + r.id)
+    if (r.definition !== 'dsh/roles/' + r.id + '.md') throw new Error('内置角色清单解析失败：definition 路径非法：' + r.id)
+    if (r.builtin !== true || r.readonly !== true) throw new Error('内置角色清单解析失败：内置角色必须 builtin/readonly：' + r.id)
+  }
+  if (seen.has('dispatcher')) throw new Error('内置角色清单解析失败：dispatcher 不得为内置（issue-81 已迁出）')
+  const compat = Array.isArray(m.compatibilityRoles) ? m.compatibilityRoles : []
+  for (const r of compat) {
+    if (!r || typeof r !== 'object' || !r.id) throw new Error('内置角色清单解析失败：兼容角色条目非法')
+    if (seen.has(roleKey(r.id))) throw new Error('内置角色清单解析失败：兼容角色与内置冲突：' + r.id)
+    if (r.builtin !== false) throw new Error('内置角色清单解析失败：兼容角色必须 builtin:false：' + r.id)
+  }
+  return m
+}
+
+// ── 事实（facts）规范化：Host 适配器注入的目录事实 → 模块内部快照 ──────────────────
+// catalog = { state:'ok'|'missing'|'error', message?, workspace:[{id,summary,content}], bundled:[{id,content}] }
+// workspace 缺失/失败时按空目录参与只读读取（list/get）；写操作在 change 中单独裁决 fail-closed。
+function catalogSnapshot(catalog) {
+  const c = catalog && typeof catalog === 'object' ? catalog : { state: 'error', message: '角色库事实缺失' }
+  return {
+    state: c.state === 'ok' || c.state === 'missing' ? c.state : 'error',
+    message: typeof c.message === 'string' ? c.message : '',
+    workspace: Array.isArray(c.workspace) ? c.workspace : [],
+    bundled: Array.isArray(c.bundled) ? c.bundled : [],
+  }
+}
+
+// ── 深模块本体 ─────────────────────────────────────────────────────────────────
+function createRoleLibrary(rawManifest) {
+  const manifest = validateManifest(rawManifest)
+  // 冻结：清单是模块私有只读事实源
+  const builtins = manifest.builtins.map((r) => Object.freeze({ id: r.id, name: r.name, summary: r.summary, definition: r.definition, builtin: true, readonly: true }))
+  const builtinIds = builtins.map((r) => r.id)
+  const builtinKeySet = new Set(builtins.map((r) => roleKey(r.id)))
+  const byId = new Map(builtins.map((r) => [r.id, r]))
+
+  function describe() {
+    return { builtinIds: builtinIds.slice(), roles: builtins.map((r) => ({ id: r.id, name: r.name, summary: r.summary })) }
+  }
+
+  function isBuiltin(id) {
+    return byId.has(id)
+  }
+
+  // 名称唯一性：内置 + 工作区自定义 + 打包回退；目录读取失败 fail-closed。
+  // 返回 { taken:true } | { taken:false } | { error:'…' }
+  function nameTaken(catalog, name, excludeId) {
+    const key = roleKey(name)
+    if (!key) return { taken: true }
+    const cat = catalogSnapshot(catalog)
+    if (cat.state === 'error') return { error: '角色库读取失败，无法验证名称唯一性：' + cat.message }
+    const excl = excludeId ? roleKey(excludeId) : null
+    for (const id of builtinIds) {
+      if (excl && excl === roleKey(id)) continue
+      if (roleKey(id) === key) return { taken: true }
+    }
+    for (const r of cat.workspace) {
+      if (!r || typeof r.id !== 'string') continue
+      if (excl && excl === roleKey(r.id)) continue
+      if (roleKey(r.id) === key) return { taken: true }
+    }
+    for (const r of cat.bundled) {
+      if (!r || typeof r.id !== 'string') continue
+      if (excl && excl === roleKey(r.id)) continue
+      if (roleKey(r.id) === key) return { taken: true }
+    }
+    return { taken: false }
+  }
+
+  // 统一角色清单：内置（清单顺序）→ 工作区自定义（id 序）→ 打包回退（id 序，排最后）。
+  // 内置正文来源：打包快照 > 工作区同名文件 > 清单摘要兜底。
+  function list(facts) {
+    const cat = catalogSnapshot(facts && facts.catalog)
+    const bodies = (facts && facts.builtinBodies) || {}
+    const wsById = new Map()
+    for (const r of cat.workspace) {
+      if (r && typeof r.id === 'string') wsById.set(r.id, r)
+    }
+    const includeContent = !!(facts && facts.includeContent)
+    const roles = []
+    for (const meta of builtins) {
+      const snap = typeof bodies[meta.id] === 'string' ? bodies[meta.id] : null
+      const f = wsById.get(meta.id)
+      const wsSummary = f && f.content != null ? summarizeRole(f.content, '') : ''
+      const entry = { id: meta.id, name: meta.name, summary: snap != null ? summarizeRole(snap, meta.summary) : (wsSummary || meta.summary), builtin: true }
+      if (includeContent) {
+        const content = snap != null ? snap : (f && f.content != null ? f.content : null)
+        if (content != null) entry.content = content
+      }
+      roles.push(entry)
+    }
+    const customIds = cat.workspace.map((r) => r.id).filter((id) => typeof id === 'string' && !builtinKeySet.has(roleKey(id)))
+    customIds.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    const seenCustom = new Set(customIds)
+    for (const id of customIds) {
+      const f = wsById.get(id)
+      // 摘要口径收归内核：适配器只传原始正文，摘要由 summarizeRole 统一计算
+      const entry = { id, name: id, summary: summarizeRole(f && f.content, ''), builtin: false }
+      if (includeContent && f) entry.content = f.content
+      roles.push(entry)
+    }
+    const bundledIds = cat.bundled.map((r) => r.id).filter((id) => typeof id === 'string' && !builtinKeySet.has(roleKey(id)) && !seenCustom.has(id))
+    bundledIds.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    for (const id of bundledIds) {
+      const b = cat.bundled.find((r) => r.id === id)
+      const content = (b && typeof b.content === 'string') ? b.content : ''
+      const entry = { id, name: id, summary: bundledFirstLine(content), builtin: false }
+      if (includeContent) entry.content = content
+      roles.push(entry)
+    }
+    return roles
+  }
+
+  // 单个角色详情：内置（快照 → 工作区 → 占位）→ 工作区自定义 → 打包回退 → null。
+  function get(facts, id) {
+    const cat = catalogSnapshot(facts && facts.catalog)
+    const bodies = (facts && facts.builtinBodies) || {}
+    const wsById = new Map()
+    for (const r of cat.workspace) {
+      if (r && typeof r.id === 'string') wsById.set(r.id, r)
+    }
+    if (isBuiltin(id)) {
+      const meta = byId.get(id)
+      let content = typeof bodies[id] === 'string' ? bodies[id] : null
+      if (content == null) {
+        const f = wsById.get(id)
+        content = f && f.content != null ? f.content : null
+      }
+      if (content == null) content = placeholderContent(meta)
+      return { id, name: meta.name, summary: summarizeRole(content, meta.summary), builtin: true, content }
+    }
+    const f = wsById.get(id)
+    if (f) return { id, name: id, summary: summarizeRole(f.content, ''), builtin: false, content: f.content != null ? f.content : '' }
+    const b = cat.bundled.find((r) => r.id === id)
+    if (b && typeof b.content === 'string') {
+      return { id, name: id, summary: bundledFirstLine(b.content), builtin: false, content: b.content }
+    }
+    return null
+  }
+
+  // 引用统计：全部工作流 + 可选开放草稿；草稿取代同 id 持久化版本；profile 按 roleKey 匹配。
+  // workflows 事实 = { state:'ok'|'error', message?, records:[{workflowId,workflowName,builtin,nodes:[{id,label,profile}]}], draft? }
+  function usage(facts, id) {
+    const wf = (facts && facts.workflows) || { state: 'error', message: '引用事实缺失' }
+    if (wf.state === 'error') return { error: wf.message || '引用统计失败' }
+    const target = roleKey(id)
+    const wfRefs = new Map()
+    const add = (rec) => {
+      const nodes = []
+      for (const n of rec.nodes || []) {
+        if (n && typeof n.profile === 'string' && roleKey(n.profile) === target) nodes.push({ id: n.id, label: n.label || n.id })
+      }
+      if (!nodes.length) {
+        // 草稿里已移除全部引用 → 草稿状态取代持久化快照
+        if (rec.draft) wfRefs.delete(String(rec.workflowId))
+        return
+      }
+      const ref = { workflowId: String(rec.workflowId), workflowName: String(rec.workflowName), builtin: !!rec.builtin, nodes }
+      if (rec.draft) ref.draft = true
+      wfRefs.set(ref.workflowId, ref)
+    }
+    for (const rec of wf.records || []) add(rec)
+    if (wf.draft) {
+      // 草稿键：有 id 取代同 id 持久化版本；无 id 以 draft: 前缀独立计入（与线上语义一致）
+      const draftId = wf.draft.id || ('draft:' + String(wf.draft.name || '未保存草稿'))
+      add({ workflowId: draftId, workflowName: wf.draft.name || '未保存草稿', builtin: false, nodes: wf.draft.nodes, draft: true })
+    }
+    const refs = Array.from(wfRefs.values())
+    const count = refs.reduce((sum, r) => sum + (r.nodes || []).length, 0)
+    return { count, refs }
+  }
+
+  // 变更裁决（commit）：返回 { ok:true, effect } 或 { ok:false, errors, usage? }。
+  // 检查顺序与线上 RPC 逐字一致；effect 由 Host 适配器执行（写/重命名/删除）。
+  function change(request) {
+    const facts = request.facts || {}
+    const caps = facts.capabilities || {}
+    const cat = catalogSnapshot(facts.catalog)
+    const action = request.action
+    const id = typeof request.id === 'string' ? request.id : ''
+    const content = typeof request.content === 'string' ? request.content : null
+
+    if (action === 'create') {
+      if (!caps.fs) return { ok: false, errors: [{ at: '$', message: '宿主文件能力不可用：无法创建角色' }] }
+      const name = String(request.name || '').trim()
+      const badName = validateRoleName(name)
+      if (badName) return { ok: false, errors: [{ at: 'name', message: badName }] }
+      if (content == null || !content.trim()) return { ok: false, errors: [{ at: 'content', message: '角色配置不能为空' }] }
+      const dup = nameTaken(facts.catalog, name, null)
+      if (dup.error) return { ok: false, errors: [{ at: '$', message: dup.error }] }
+      if (dup.taken) return { ok: false, errors: [{ at: 'name', message: '已存在同名角色，请使用其他名称。' }] }
+      return { ok: true, effect: { kind: 'write', id: name, content: content + (content.endsWith('\n') ? '' : '\n') } }
+    }
+
+    if (action === 'update') {
+      if (!caps.fs) return { ok: false, errors: [{ at: '$', message: '宿主文件能力不可用：无法更新角色' }] }
+      if (!id) return { ok: false, errors: [{ at: '$.id', message: '缺少角色 id' }] }
+      if (isBuiltin(id)) return { ok: false, errors: [{ at: '$', message: '内置角色只读：' + id + ' 属于系统标准角色，不能修改；可基于其创建自定义角色。' }] }
+      if (cat.state === 'error') return { ok: false, errors: [{ at: '$', message: '角色库读取失败：' + cat.message }] }
+      const inWorkspace = cat.workspace.some((r) => r && r.id === id)
+      const inBundled = cat.bundled.some((r) => r && r.id === id)
+      if (!inWorkspace && !inBundled) return { ok: false, errors: [{ at: '$', message: '自定义角色不存在：' + id }] }
+      const newName = String(request.name || '').trim()
+      const target = newName && newName !== id ? newName : id
+      const isRename = target !== id
+      if (isRename) {
+        // 仅大小写/规范化差异指向同一文件：拒绝，避免写后删把自己删掉
+        if (roleKey(target) === roleKey(id)) {
+          return { ok: false, errors: [{ at: 'name', message: '新名称与当前名称仅大小写或写法不同（指向同一文件），请保留原名称或改用不同名称。' }] }
+        }
+        const badName = validateRoleName(target)
+        if (badName) return { ok: false, errors: [{ at: 'name', message: badName }] }
+        const dup = nameTaken(facts.catalog, target, id)
+        if (dup.error) return { ok: false, errors: [{ at: '$', message: dup.error }] }
+        if (dup.taken) return { ok: false, errors: [{ at: 'name', message: '已存在同名角色，请使用其他名称。' }] }
+        const u = usage(facts, id)
+        if (u.error) return { ok: false, errors: [{ at: '$', message: '引用统计失败：' + u.error }] }
+        if (u.count > 0) {
+          return { ok: false, errors: [{ at: 'name', message: '该角色仍被 ' + u.count + ' 个节点使用，重命名会导致这些引用全部失效；请先解除引用，或使用「基于此角色创建自定义角色」新建变体。' }] }
+        }
+        if (!caps.subprocess) return { ok: false, errors: [{ at: '$', message: '重命名需要子进程服务（删除旧角色文件）；当前宿主不可用，可先编辑内容或新建同名新角色。' }] }
+      }
+      if (content == null || !content.trim()) return { ok: false, errors: [{ at: 'content', message: '角色配置不能为空' }] }
+      const normalized = content + (content.endsWith('\n') ? '' : '\n')
+      if (isRename) return { ok: true, effect: { kind: 'rename', from: id, to: target, content: normalized } }
+      return { ok: true, effect: { kind: 'write', id: id, content: normalized } }
+    }
+
+    if (action === 'remove') {
+      if (!caps.fs || !caps.subprocess) return { ok: false, errors: [{ at: '$', message: '宿主文件能力不可用：无法删除角色' }] }
+      if (!id) return { ok: false, errors: [{ at: '$.id', message: '缺少角色 id' }] }
+      if (isBuiltin(id)) return { ok: false, errors: [{ at: '$', message: '内置角色只读：' + id + ' 属于系统标准角色，不能删除' }] }
+      if (cat.state === 'error') return { ok: false, errors: [{ at: '$', message: '角色库读取失败：' + cat.message }] }
+      const u = usage(facts, id)
+      if (u.error) return { ok: false, errors: [{ at: '$', message: '引用统计失败，已阻止删除：' + u.error }] }
+      if (u.count > 0) {
+        const draftHint = u.refs.some((r) => r.draft) ? '（含未保存草稿的引用）' : ''
+        return {
+          ok: false,
+          errors: [{ at: '$', message: '「' + id + '」仍被 ' + u.count + ' 个节点使用' + draftHint + '。请先将这些节点更换为其他角色，解除全部引用后再删除。' }],
+          usage: { count: u.count, refs: u.refs },
+        }
+      }
+      const inWorkspace = cat.workspace.some((r) => r && r.id === id)
+      if (!inWorkspace) {
+        if (inBundledOf(cat, id)) {
+          return { ok: false, errors: [{ at: '$', message: '「' + id + '」的定义来自内置模板自带的角色包（生成产物），不在自定义角色库中，无法在此删除；如需停用，请在模板中把引用替换为其他角色。' }] }
+        }
+        return { ok: false, errors: [{ at: '$', message: '自定义角色不存在：' + id }] }
+      }
+      return { ok: true, effect: { kind: 'remove', id: id } }
+    }
+
+    return { ok: false, errors: [{ at: '$', message: '未知角色变更动作：' + String(action) }] }
+  }
+
+  function inBundledOf(cat, id) {
+    return cat.bundled.some((r) => r && r.id === id)
+  }
+
+  // 统一入口：闭合命令联合。始终返回 Promise（Host 可 await）。
+  async function execute(request) {
+    const op = request && request.operation
+    const facts = (request && request.facts) || {}
+    switch (op) {
+      case 'manifest':
+        return { ok: true, manifest: { schemaVersion: manifest.schemaVersion, builtins: describe().roles, compatibilityRoles: manifest.compatibilityRoles || [] } }
+      case 'list':
+        return { ok: true, roles: list(facts) }
+      case 'get': {
+        const id = request.id
+        const role = typeof id === 'string' && id ? get(facts, id) : null
+        if (!role) return { ok: false, errors: [{ at: '$', message: '角色不存在：' + (id || '') }] }
+        return { ok: true, role }
+      }
+      case 'usage': {
+        const id = request.id
+        if (!id || typeof id !== 'string') return { ok: false, errors: [{ at: '$.id', message: '缺少角色 id' }] }
+        const u = usage(facts, id)
+        if (u.error) return { ok: false, errors: [{ at: '$', message: '引用统计失败：' + u.error }] }
+        return { ok: true, id, count: u.count, refs: u.refs }
+      }
+      case 'validateName': {
+        const name = String(request.name || '').trim()
+        const badName = validateRoleName(name)
+        if (badName) return { ok: false, errors: [{ at: 'name', message: badName }] }
+        const dup = nameTaken(facts.catalog, name, request.excludeId || null)
+        if (dup.error) return { ok: false, errors: [{ at: '$', message: dup.error }] }
+        if (dup.taken) return { ok: false, errors: [{ at: 'name', message: '已存在同名角色，请使用其他名称。' }] }
+        return { ok: true }
+      }
+      case 'change':
+        return change(request)
+      default:
+        return { ok: false, errors: [{ at: '$', message: '未知角色库操作：' + String(op) }] }
+    }
+  }
+
+  return Object.freeze({ describe, execute })
+}
+
+// ── 构建期投影（生成器同步入口）────────────────────────────────────────────────
+// 角色文件安全读取：标识只允许中英文/数字/下划线/短横线，且解析后路径必须在角色源目录内。
+function readRoleFileSafe(rolesDir, id, io) {
+  if (!/^[\w一-龥-]+$/.test(String(id || ''))) return null
+  const file = joinPath(rolesDir, id + '.md')
+  const rel = relativePath(rolesDir, file)
+  if (rel.startsWith('..') || isAbsolutePath(rel)) return null
+  try { return io.readFileSync(file, 'utf8') } catch (e) { return null }
+}
+
+// 极简 path 工具（本模块禁止 require；只需 posix 风格的拼接/相对/绝对判定，
+// rolesDir 由调用方以绝对路径传入——生成器与测试都以 node:path 解析后传入）。
+function joinPath(a, b) {
+  return String(a).replace(/[\\/]+$/, '') + '/' + b
+}
+function isAbsolutePath(p) {
+  return /^([A-Za-z]:[\\/]|\/|\\\\)/.test(p)
+}
+function relativePath(from, to) {
+  const f = String(from).replace(/[\\/]+$/, '') + '/'
+  return String(to).startsWith(f) ? String(to).slice(f.length) : '..' + '/' + to
+}
+
+// 打包蓝图中引用的角色文件（**包含自定义角色**：dispatcher 等历史角色必须随 skill
+// 自包含——名称沿用历史误导名 collectBuiltinRoles 的调用契约，语义 = referenced+existing）。
+function collectReferencedRoleFiles(bp, rolesDir, io) {
+  const out = new Map()
+  if (!bp || !Array.isArray(bp.nodes)) return out
+  const profiles = new Set()
+  for (const n of bp.nodes) {
+    if (n && typeof n.profile === 'string' && n.profile) profiles.add(n.profile)
+  }
+  for (const profile of profiles) {
+    const content = readRoleFileSafe(rolesDir, profile, io)
+    if (content != null) out.set('roles/' + profile + '.md', content)
+  }
+  return out
+}
+
+// 同步快照：清单 + 内置角色正文（生成器编译期内联）。manifest/角色目录读取失败 loud-fail
+// 由调用方决定（生成器直接抛错；此处返回结构化结果）。
+function buildSnapshot(opts) {
+  const o = opts || {}
+  const io = o.io
+  if (!io || typeof io.readFileSync !== 'function') throw new Error('buildSnapshot 需要同步 io.readFileSync')
+  const manifestText = io.readFileSync(o.manifestPath, 'utf8')
+  const manifest = validateManifest(JSON.parse(manifestText))
+  const builtinIds = manifest.builtins.map((r) => r.id)
+  const roleDefs = {}
+  for (const id of builtinIds) {
+    const content = readRoleFileSafe(o.rolesDir, id, io)
+    if (content != null) roleDefs[id] = content
+  }
+  return { manifest, builtinIds, roleDefs }
+}
+
+module.exports = {
+  createRoleLibrary,
+  validateManifest,
+  buildSnapshot,
+  readRoleFileSafe,
+  collectReferencedRoleFiles,
+  // 工具导出仅供测试与生成器复用（不构成业务接缝）
+  roleKey,
+  validateRoleName,
+  summarizeRole,
+}

--- a/scripts/test/dev-plugin.test.mjs
+++ b/scripts/test/dev-plugin.test.mjs
@@ -11,7 +11,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawn, spawnSync } from 'node:child_process'
 import test from 'node:test'
@@ -329,6 +329,31 @@ fi
         process.kill(fakePid, 'SIGTERM')
       }
     }
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('status 把校验内核与仓库指针同步到开发 Home', () => {
+  const root = mkdtempSync(join(tmpdir(), 'vwf-dev-plugin-kernel-'))
+  try {
+    const devHome = join(root, 'dev-home')
+    const productHome = join(root, 'product-home')
+    const result = spawnSync(process.execPath, [scriptPath, 'status'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        VWF_DEV_DSH_HOME: devHome,
+        VWF_PRODUCT_DSH_HOME: productHome,
+        DSH_HOME: undefined,
+      },
+    })
+    assert.equal(result.status, 0, result.stderr)
+    const kernel = join(devHome, 'visual-workflow', 'validate-core.cjs')
+    const pointer = join(devHome, 'visual-workflow', 'repo-root')
+    assert.equal(existsSync(kernel), true, '应复制 scripts/validate-core.cjs')
+    assert.match(readFileSync(kernel, 'utf8'), /validateBlueprint/)
+    assert.equal(readFileSync(pointer, 'utf8').trim(), dirname(dirname(scriptPath)))
+  } finally {
     rmSync(root, { recursive: true, force: true })
   }
 })

--- a/scripts/test/fixtures/construction-rollback-mini.json
+++ b/scripts/test/fixtures/construction-rollback-mini.json
@@ -1,0 +1,101 @@
+{
+  "id": "construction-rollback-mini",
+  "displayName": "完整功能开发",
+  "description": "需求→设计→开发，回退 outcome 指向入口。",
+  "entry": "requirements",
+  "control": { "maxRounds": 3 },
+  "heteroCheck": true,
+  "bindings": {
+    "models": {
+      "requirements": { "provider": "kimi-coding", "model": "k3" },
+      "design": { "provider": "deepseek-official", "model": "deepseek-v4-pro" },
+      "dev": { "provider": "deepseek-official", "model": "deepseek-v4-pro" },
+      "review": { "provider": "kimi-coding", "model": "k3" }
+    }
+  },
+  "nodes": [
+    {
+      "id": "requirements",
+      "label": "需求分析",
+      "profile": "requirements",
+      "goal": "形成需求基线",
+      "manualCheck": true,
+      "output": {
+        "schema": {
+          "type": "object",
+          "properties": { "complete": { "type": "boolean" } },
+          "required": ["complete"],
+          "additionalProperties": false
+        },
+        "successCondition": "$.complete == true"
+      }
+    },
+    {
+      "id": "design",
+      "label": "方案设计",
+      "profile": "designer",
+      "goal": "形成方案",
+      "output": {
+        "outcomePath": "$.route",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "route": { "type": "string", "enum": ["READY", "RETURN_REQUIREMENTS", "BLOCKED"] }
+          },
+          "required": ["route"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "dev",
+      "label": "开发",
+      "profile": "dev",
+      "goal": "完成实现",
+      "output": {
+        "outcomePath": "$.route",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "route": { "type": "string", "enum": ["READY", "RETURN_DESIGN", "BLOCKED"] }
+          },
+          "required": ["route"],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "id": "review",
+      "label": "独立审核",
+      "profile": "review",
+      "goal": "独立审核",
+      "verifyBranch": true,
+      "output": {
+        "outcomePath": "$.route",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "route": { "type": "string", "enum": ["APPROVE", "RETURN_DEV", "BLOCKED"] },
+            "verified_branch": { "type": "string" },
+            "verified_head": { "type": "string" }
+          },
+          "required": ["route", "verified_branch", "verified_head"],
+          "additionalProperties": false
+        }
+      }
+    }
+  ],
+  "edges": [
+    { "from": "requirements", "to": "design", "on": "success" },
+    { "from": "requirements", "to": "$end", "on": "failure" },
+    { "from": "design", "to": "dev", "outcome": "READY" },
+    { "from": "design", "to": "requirements", "outcome": "RETURN_REQUIREMENTS", "countRound": false },
+    { "from": "design", "to": "$end", "outcome": "BLOCKED" },
+    { "from": "dev", "to": "review", "outcome": "READY" },
+    { "from": "dev", "to": "design", "outcome": "RETURN_DESIGN", "countRound": false },
+    { "from": "dev", "to": "$end", "outcome": "BLOCKED" },
+    { "from": "review", "to": "$end", "outcome": "APPROVE" },
+    { "from": "review", "to": "dev", "outcome": "RETURN_DEV", "countRound": true },
+    { "from": "review", "to": "$end", "outcome": "BLOCKED" }
+  ]
+}

--- a/scripts/test/generate.test.mjs
+++ b/scripts/test/generate.test.mjs
@@ -319,13 +319,22 @@ test('S6 内联仅限蓝图引用内置角色：最小图产物 < 宿主 64KB st
   assert.ok(Buffer.byteLength(resp12, 'utf8') < 1024 * 1024, '12 角色全用图的 JSON 响应 < 编译路径 1MB 捕获上限（host.js runNode maxBytes）')
 })
 
-test('S4 内置角色清单：单一来源为宿主注册表，解析失败 loud-fail', () => {
+test('S4 内置角色清单：单一事实源为 manifest（dsh/roles/builtin-roles.json），解析失败 loud-fail', () => {
   const ids = loadBuiltinRoleIds()
   assert.ok(ids.length >= 12, `内置角色不少于 12 个（实际 ${ids.length}）`)
   assert.ok(ids.includes('requirements') && ids.includes('synthesizer'), '含新增角色')
   assert.ok(!ids.includes('dispatcher'), 'dispatcher 已迁出内置')
-  assert.throws(() => loadBuiltinRoleIds('const BUILTIN_ROLES = []'), /解析失败/, '空清单应报错')
-  assert.throws(() => loadBuiltinRoleIds(''), /解析失败/, '找不到数组应报错')
+  // 来源证明：不再反向解析 host.js 源码——传入任何字符串都被当作 manifest 路径处理
+  assert.throws(() => loadBuiltinRoleIds('const BUILTIN_ROLES = []'), /解析失败/, '非路径输入按 manifest 读取失败报错')
+  assert.throws(() => loadBuiltinRoleIds(''), /解析失败/, '空路径报错')
+  // 损坏 manifest loud-fail（写入临时文件验证 fail-closed，不退化为空清单）
+  const tmp = path.join(tmpdir(), 'vwf-bad-manifest-' + process.pid + '.json')
+  fs.writeFileSync(tmp, '{"schemaVersion":1,"builtins":[]}', 'utf8')
+  try {
+    assert.throws(() => loadBuiltinRoleIds(tmp), /解析失败/, '空清单 manifest 应报错')
+  } finally {
+    fs.unlinkSync(tmp)
+  }
 })
 
 test('S7 #93：编译脚本注入 workspace 默认 args 与 SOURCE cwd', () => {

--- a/scripts/test/role-library.test.mjs
+++ b/scripts/test/role-library.test.mjs
@@ -1,0 +1,339 @@
+// 角色库内核（scripts/role-library.cjs）直测
+// seam = 模块接口（createRoleLibrary().execute / buildSnapshot），不穿 Host/RPC/fs。
+// 期望值来源 = 线上 host.js 角色 RPC 的既有行为（characterization）+ 产品规格 §8。
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import roleLibrary from '../role-library.cjs'
+
+const { createRoleLibrary, validateManifest, buildSnapshot, readRoleFileSafe, collectReferencedRoleFiles } = roleLibrary
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(here, '..', '..')
+const manifest = JSON.parse(readFileSync(join(repoRoot, 'dsh', 'roles', 'builtin-roles.json'), 'utf8'))
+
+function lib() {
+  return createRoleLibrary(manifest)
+}
+
+// 目录事实构造器
+function catalog({ workspace = [], bundled = [], state = 'ok', message = '' } = {}) {
+  return { state, message, workspace, bundled }
+}
+
+// ── manifest 校验（loud-fail）────────────────────────────────────────────
+test('validateManifest：合法清单通过', () => {
+  assert.equal(validateManifest(manifest).schemaVersion, 1)
+})
+
+test('validateManifest：非法清单一律抛错（fail-closed）', () => {
+  assert.throws(() => validateManifest(null), /不是对象/)
+  assert.throws(() => validateManifest({}), /builtins/)
+  assert.throws(() => validateManifest({ schemaVersion: 2, builtins: manifest.builtins }), /schemaVersion/)
+  assert.throws(() => validateManifest({ schemaVersion: 1, builtins: [] }), /为空/)
+  const bad = JSON.parse(JSON.stringify(manifest))
+  bad.builtins[0].id = 'BAD ID'
+  assert.throws(() => validateManifest(bad), /非法 id/)
+  const dup = JSON.parse(JSON.stringify(manifest))
+  dup.builtins.push({ ...dup.builtins[0] })
+  assert.throws(() => validateManifest(dup), /冲突/)
+  const noName = JSON.parse(JSON.stringify(manifest))
+  noName.builtins[1].name = '  '
+  assert.throws(() => validateManifest(noName), /中文名为空/)
+  const badDef = JSON.parse(JSON.stringify(manifest))
+  badDef.builtins[2].definition = '../escape.md'
+  assert.throws(() => validateManifest(badDef), /definition/)
+  const dpIn = JSON.parse(JSON.stringify(manifest))
+  dpIn.builtins.push({ id: 'dispatcher', name: 'x', summary: 'y', definition: 'dsh/roles/dispatcher.md', builtin: true, readonly: true })
+  assert.throws(() => validateManifest(dpIn), /dispatcher 不得为内置/)
+})
+
+// ── list ─────────────────────────────────────────────────────────────────
+test('list：无目录事实时 12 内置常驻、按清单顺序、带 manifest 摘要', async () => {
+  const r = await lib().execute({ operation: 'list', facts: { catalog: catalog({ state: 'missing' }) } })
+  assert.equal(r.ok, true)
+  assert.equal(r.roles.length, 12)
+  assert.deepEqual(r.roles.map((x) => x.id), manifest.builtins.map((b) => b.id))
+  assert.ok(r.roles.every((x) => x.builtin === true))
+  assert.equal(r.roles.find((x) => x.id === 'dev').summary, manifest.builtins.find((b) => b.id === 'dev').summary)
+})
+
+test('list：内置在前、工作区自定义按 id 序居中、打包回退排最后且不重复', async () => {
+  const facts = {
+    catalog: catalog({
+      workspace: [
+        { id: 'zzz-custom', content: 'z 摘要\nz 正文' },
+        { id: 'dev', content: '工作区旧 dev 摘要\n工作区旧正文' }, // 与内置同 id → 不进入自定义分组
+        { id: 'aaa-custom', content: 'a 摘要\na 正文' },
+      ],
+      bundled: [{ id: 'dispatcher', content: '调度首行\n其余' }],
+    }),
+  }
+  const r = await lib().execute({ operation: 'list', facts })
+  const ids = r.roles.map((x) => x.id)
+  assert.equal(ids.indexOf('aaa-custom') < ids.indexOf('zzz-custom'), true, '自定义按 id 升序')
+  assert.equal(ids.filter((x) => x === 'dev').length, 1, '内置 id 不重复出现在自定义分组')
+  assert.equal(ids.indexOf('dispatcher'), ids.length - 1, '打包回退排最后')
+  const dp = r.roles[r.roles.length - 1]
+  assert.equal(dp.builtin, false)
+  assert.equal(dp.summary, '调度首行', '打包回退摘要取首个非空行')
+  // 内置摘要：无快照时从工作区文件正文计算（dev 有工作区文件）
+  assert.equal(r.roles.find((x) => x.id === 'dev').summary, '工作区旧 dev 摘要')
+})
+
+test('list：内置摘要优先取打包快照（与工作区旧文件脱钩）', async () => {
+  const facts = {
+    catalog: catalog({ workspace: [{ id: 'dev', content: '工作区旧摘要\n旧正文' }] }),
+    builtinBodies: { dev: '打包快照首行\n\n正文' },
+  }
+  const r = await lib().execute({ operation: 'list', facts })
+  assert.equal(r.roles.find((x) => x.id === 'dev').summary, '打包快照首行')
+})
+
+// ── get ──────────────────────────────────────────────────────────────────
+test('get：内置详情来源优先级 快照 > 工作区 > 占位', async () => {
+  const l = lib()
+  // 占位兜底
+  let r = await l.execute({ operation: 'get', id: 'dev', facts: { catalog: catalog({ state: 'missing' }) } })
+  assert.equal(r.ok, true)
+  assert.match(r.role.content, /当前工作区未包含该内置角色的完整定义/)
+  assert.equal(r.role.name, '开发')
+  // 工作区回退
+  r = await l.execute({ operation: 'get', id: 'dev', facts: { catalog: catalog({ workspace: [{ id: 'dev', summary: '', content: '工作区正文\n' }] }) } })
+  assert.equal(r.role.content, '工作区正文\n')
+  // 快照优先
+  r = await l.execute({
+    operation: 'get', id: 'dev',
+    facts: { catalog: catalog({ workspace: [{ id: 'dev', summary: '', content: '工作区正文\n' }] }), builtinBodies: { dev: '打包快照正文\n' } },
+  })
+  assert.equal(r.role.content, '打包快照正文\n')
+})
+
+test('get：自定义读工作区；打包回退只读可见；未知 id 报「角色不存在」', async () => {
+  const l = lib()
+  let r = await l.execute({ operation: 'get', id: 'my-role', facts: { catalog: catalog({ workspace: [{ id: 'my-role', content: 'c\n' }] }) } })
+  assert.deepEqual({ id: r.role.id, builtin: r.role.builtin, content: r.role.content }, { id: 'my-role', builtin: false, content: 'c\n' })
+  r = await l.execute({ operation: 'get', id: 'dispatcher', facts: { catalog: catalog({ bundled: [{ id: 'dispatcher', content: '调度正文\n' }] }) } })
+  assert.equal(r.role.builtin, false)
+  assert.equal(r.role.content, '调度正文\n')
+  r = await l.execute({ operation: 'get', id: 'ghost', facts: { catalog: catalog() } })
+  assert.equal(r.ok, false)
+  assert.match(r.errors[0].message, /角色不存在：ghost/)
+})
+
+// ── usage ────────────────────────────────────────────────────────────────
+function wf(id, name, builtin, profiles) {
+  return { workflowId: id, workflowName: name, builtin, nodes: profiles.map((p, i) => ({ id: 'n' + i, label: 'N' + i, profile: p })) }
+}
+
+test('usage：跨内置+用户模板统计；profile 大小写/规范化不敏感', async () => {
+  const facts = {
+    workflows: {
+      state: 'ok',
+      records: [
+        wf('builtin-wf', '内置流', true, ['dev', 'review']),
+        wf('user-wf', '用户流', false, ['Dev', 'dev']),
+      ],
+    },
+  }
+  const r = await lib().execute({ operation: 'usage', id: 'dev', facts })
+  assert.equal(r.ok, true)
+  assert.equal(r.count, 3, '大小写不敏感匹配：dev + Dev + dev')
+  assert.equal(r.refs.length, 2)
+  assert.equal(r.refs[0].builtin, true)
+})
+
+test('usage：草稿取代同 id 持久化版本；无 id 草稿独立计入；失败 fail-closed', async () => {
+  const l = lib()
+  // 草稿移除全部引用 → 持久化版本被取代（零引用）
+  let r = await l.execute({
+    operation: 'usage', id: 'dev',
+    facts: {
+      workflows: {
+        state: 'ok',
+        records: [wf('wf-a', 'A', false, ['dev'])],
+        draft: { id: 'wf-a', name: 'A', nodes: [{ id: 'n0', label: 'N0', profile: 'review' }] },
+      },
+    },
+  })
+  assert.equal(r.count, 0, '草稿无引用时持久化引用被取代')
+  // 无 id 草稿独立计入
+  r = await l.execute({
+    operation: 'usage', id: 'dev',
+    facts: {
+      workflows: {
+        state: 'ok',
+        records: [],
+        draft: { name: '未命名', nodes: [{ id: 'n0', label: 'N0', profile: 'dev' }] },
+      },
+    },
+  })
+  assert.equal(r.count, 1)
+  assert.equal(r.refs[0].draft, true)
+  // 事实读取失败 fail-closed
+  r = await l.execute({ operation: 'usage', id: 'dev', facts: { workflows: { state: 'error', message: '模板读取失败' } } })
+  assert.equal(r.ok, false)
+  assert.match(r.errors[0].message, /引用统计失败：模板读取失败/)
+})
+
+// ── validateName ─────────────────────────────────────────────────────────
+test('validateName：完整规则集（含首尾点与 Windows 保留名）+ 唯一性', async () => {
+  const l = lib()
+  const facts = { catalog: catalog({ workspace: [{ id: 'taken', content: 'x' }], bundled: [{ id: 'dispatcher', content: 'x' }] }) }
+  const bad = async (name, re) => {
+    const r = await l.execute({ operation: 'validateName', name, facts })
+    assert.equal(r.ok, false, `应拒绝：${JSON.stringify(name)}`)
+    assert.match(r.errors[0].message, re)
+    assert.equal(r.errors[0].at, 'name')
+  }
+  await bad('', /不能为空/)
+  await bad('a'.repeat(65), /最多 64/)
+  await bad('a/b', /非法字符/)
+  await bad('.foo', /以点开头或结尾/)
+  await bad('foo.', /以点开头或结尾/)
+  await bad('CON', /系统保留名/)
+  await bad('com1', /系统保留名/)
+  await bad('dev', /已存在同名角色/)
+  await bad('Taken', /已存在同名角色/)       // 大小写不敏感
+  await bad('dispatcher', /已存在同名角色/)  // 打包回退角色计入唯一性
+  const ok = await l.execute({ operation: 'validateName', name: '新角色', facts })
+  assert.equal(ok.ok, true)
+  // excludeId 排除自身（重命名场景）
+  const self = await l.execute({ operation: 'validateName', name: 'taken', excludeId: 'taken', facts })
+  assert.equal(self.ok, true)
+})
+
+// ── change / create ──────────────────────────────────────────────────────
+test('change create：能力/名称/内容/唯一性检查顺序与线上一致，成功产出 write 意图', async () => {
+  const l = lib()
+  const facts = (c) => ({ capabilities: { fs: true, subprocess: true }, catalog: c || catalog() })
+  // 无 fs 能力
+  let r = await l.execute({ operation: 'change', action: 'create', name: 'x', content: 'y', facts: { capabilities: { fs: false } } })
+  assert.match(r.errors[0].message, /宿主文件能力不可用：无法创建角色/)
+  // 名称先于内容
+  r = await l.execute({ operation: 'change', action: 'create', name: 'a/b', content: '', facts: facts() })
+  assert.equal(r.errors[0].at, 'name')
+  assert.match(r.errors[0].message, /非法字符/)
+  // 内容为空
+  r = await l.execute({ operation: 'change', action: 'create', name: 'x', content: '  ', facts: facts() })
+  assert.match(r.errors[0].message, /角色配置不能为空/)
+  // 目录读取失败 fail-closed
+  r = await l.execute({ operation: 'change', action: 'create', name: 'x', content: 'y', facts: facts(catalog({ state: 'error', message: 'IO 故障' })) })
+  assert.match(r.errors[0].message, /角色库读取失败，无法验证名称唯一性：IO 故障/)
+  // 重名
+  r = await l.execute({ operation: 'change', action: 'create', name: 'dev', content: 'y', facts: facts() })
+  assert.match(r.errors[0].message, /已存在同名角色/)
+  // 成功：尾部补换行
+  r = await l.execute({ operation: 'change', action: 'create', name: '新角色', content: '正文', facts: facts() })
+  assert.equal(r.ok, true)
+  assert.deepEqual(r.effect, { kind: 'write', id: '新角色', content: '正文\n' })
+})
+
+// ── change / update ──────────────────────────────────────────────────────
+test('change update：只读/存在性/重命名保护顺序与线上一致', async () => {
+  const l = lib()
+  const ws = catalog({ workspace: [{ id: 'my-role', summary: '', content: '旧\n' }] })
+  const caps = { fs: true, subprocess: true }
+  const noUsage = { state: 'ok', records: [] }
+  // 内置只读
+  let r = await l.execute({ operation: 'change', action: 'update', id: 'dev', name: 'dev', content: 'x', facts: { capabilities: caps, catalog: ws, workflows: noUsage } })
+  assert.match(r.errors[0].message, /内置角色只读/)
+  // 目录错误 fail-closed
+  r = await l.execute({ operation: 'change', action: 'update', id: 'my-role', name: 'my-role', content: 'x', facts: { capabilities: caps, catalog: catalog({ state: 'error', message: 'IO' }), workflows: noUsage } })
+  assert.match(r.errors[0].message, /角色库读取失败：IO/)
+  // 不存在（既不在工作区也不在打包回退）
+  r = await l.execute({ operation: 'change', action: 'update', id: 'ghost', name: 'ghost', content: 'x', facts: { capabilities: caps, catalog: ws, workflows: noUsage } })
+  assert.match(r.errors[0].message, /自定义角色不存在：ghost/)
+  // 打包回退角色可编辑（种子到工作区）
+  r = await l.execute({ operation: 'change', action: 'update', id: 'dispatcher', name: 'dispatcher', content: '新内容', facts: { capabilities: caps, catalog: catalog({ bundled: [{ id: 'dispatcher', content: '旧\n' }] }), workflows: noUsage } })
+  assert.equal(r.ok, true)
+  assert.deepEqual(r.effect, { kind: 'write', id: 'dispatcher', content: '新内容\n' })
+  // 仅写法差异重命名拒绝
+  r = await l.execute({ operation: 'change', action: 'update', id: 'my-role', name: 'My-Role', content: 'x', facts: { capabilities: caps, catalog: ws, workflows: noUsage } })
+  assert.match(r.errors[0].message, /仅大小写或写法不同/)
+  // 重命名有引用阻止
+  const usedWf = { state: 'ok', records: [wf('wf-a', 'A', false, ['my-role'])] }
+  r = await l.execute({ operation: 'change', action: 'update', id: 'my-role', name: 'new-role', content: 'x', facts: { capabilities: caps, catalog: ws, workflows: usedWf } })
+  assert.equal(r.errors[0].at, 'name')
+  assert.match(r.errors[0].message, /重命名会导致这些引用全部失效/)
+  // 重命名需 subprocess
+  r = await l.execute({ operation: 'change', action: 'update', id: 'my-role', name: 'new-role', content: 'x', facts: { capabilities: { fs: true, subprocess: false }, catalog: ws, workflows: noUsage } })
+  assert.match(r.errors[0].message, /重命名需要子进程服务/)
+  // 纯内容编辑无需 subprocess、无需 usage 事实
+  r = await l.execute({ operation: 'change', action: 'update', id: 'my-role', name: 'my-role', content: '新正文', facts: { capabilities: { fs: true, subprocess: false }, catalog: ws } })
+  assert.equal(r.ok, true)
+  assert.deepEqual(r.effect, { kind: 'write', id: 'my-role', content: '新正文\n' })
+  // 零引用重命名产出 rename 意图
+  r = await l.execute({ operation: 'change', action: 'update', id: 'my-role', name: 'new-role', content: '新正文', facts: { capabilities: caps, catalog: ws, workflows: noUsage } })
+  assert.deepEqual(r.effect, { kind: 'rename', from: 'my-role', to: 'new-role', content: '新正文\n' })
+})
+
+// ── change / remove ──────────────────────────────────────────────────────
+test('change remove：只读/引用阻止（含草稿提示）/打包回退不可删/成功意图', async () => {
+  const l = lib()
+  const caps = { fs: true, subprocess: true }
+  const ws = catalog({ workspace: [{ id: 'my-role', summary: '', content: 'x' }] })
+  // 能力缺失
+  let r = await l.execute({ operation: 'change', action: 'remove', id: 'my-role', facts: { capabilities: { fs: true, subprocess: false }, catalog: ws, workflows: { state: 'ok', records: [] } } })
+  assert.match(r.errors[0].message, /宿主文件能力不可用：无法删除角色/)
+  // 内置只读
+  r = await l.execute({ operation: 'change', action: 'remove', id: 'dev', facts: { capabilities: caps, catalog: ws, workflows: { state: 'ok', records: [] } } })
+  assert.match(r.errors[0].message, /内置角色只读/)
+  // 引用统计失败 fail-closed（文案带「已阻止删除」）
+  r = await l.execute({ operation: 'change', action: 'remove', id: 'my-role', facts: { capabilities: caps, catalog: ws, workflows: { state: 'error', message: 'IO' } } })
+  assert.match(r.errors[0].message, /引用统计失败，已阻止删除：IO/)
+  // 有引用阻止并携带 usage（草稿加提示）
+  r = await l.execute({
+    operation: 'change', action: 'remove', id: 'my-role',
+    facts: {
+      capabilities: caps, catalog: ws,
+      workflows: { state: 'ok', records: [wf('wf-a', 'A', false, ['my-role'])], draft: { name: '草稿', nodes: [{ id: 'n0', label: 'N0', profile: 'my-role' }] } },
+    },
+  })
+  assert.equal(r.ok, false)
+  assert.match(r.errors[0].message, /仍被 2 个节点使用（含未保存草稿的引用）/)
+  assert.equal(r.usage.count, 2)
+  // 打包回退角色不可删除
+  r = await l.execute({ operation: 'change', action: 'remove', id: 'dispatcher', facts: { capabilities: caps, catalog: catalog({ bundled: [{ id: 'dispatcher', content: 'x' }] }), workflows: { state: 'ok', records: [] } } })
+  assert.match(r.errors[0].message, /定义来自内置模板自带的角色包/)
+  // 不存在
+  r = await l.execute({ operation: 'change', action: 'remove', id: 'ghost', facts: { capabilities: caps, catalog: ws, workflows: { state: 'ok', records: [] } } })
+  assert.match(r.errors[0].message, /自定义角色不存在：ghost/)
+  // 成功
+  r = await l.execute({ operation: 'change', action: 'remove', id: 'my-role', facts: { capabilities: caps, catalog: ws, workflows: { state: 'ok', records: [] } } })
+  assert.deepEqual(r.effect, { kind: 'remove', id: 'my-role' })
+})
+
+test('execute：未知操作 fail-closed', async () => {
+  const r = await lib().execute({ operation: 'nope', facts: {} })
+  assert.equal(r.ok, false)
+  assert.match(r.errors[0].message, /未知角色库操作/)
+})
+
+// ── 构建期投影（生成器同步入口）────────────────────────────────────────────
+test('buildSnapshot：清单 + 内置角色正文同步读取；非法路径注入被拒绝', () => {
+  const files = new Map()
+  files.set(join(repoRoot, 'dsh', 'roles', 'builtin-roles.json'), JSON.stringify(manifest))
+  for (const b of manifest.builtins) files.set(join(repoRoot, 'dsh', 'roles', b.id + '.md'), '# ' + b.name + '\n正文')
+  const io = { readFileSync: (p) => { if (!files.has(p)) { const e = new Error('ENOENT'); throw e } return files.get(p) } }
+  const snap = buildSnapshot({ manifestPath: join(repoRoot, 'dsh', 'roles', 'builtin-roles.json'), rolesDir: join(repoRoot, 'dsh', 'roles'), io })
+  assert.deepEqual(snap.builtinIds, manifest.builtins.map((b) => b.id))
+  assert.equal(snap.roleDefs.dev, '# 开发\n正文')
+  assert.equal(Object.keys(snap.roleDefs).length, 12)
+})
+
+test('readRoleFileSafe：路径穿越返回 null，不读目录外文件', () => {
+  const io = { readFileSync: () => { throw new Error('不应被读取') } }
+  assert.equal(readRoleFileSafe('/roles', '../../etc/passwd', io), null)
+  assert.equal(readRoleFileSafe('/roles', 'bad id!', io), null)
+})
+
+test('collectReferencedRoleFiles：打包被引用且文件存在的角色（含自定义 dispatcher）', () => {
+  const io = { readFileSync: (p) => (p.endsWith('dispatcher.md') ? '调度正文' : (p.endsWith('dev.md') ? '开发正文' : (() => { throw new Error('ENOENT') })())) }
+  const bp = { nodes: [{ profile: 'dev' }, { profile: 'dispatcher' }, { profile: 'ghost' }] }
+  const out = collectReferencedRoleFiles(bp, '/roles', io)
+  assert.deepEqual(Array.from(out.keys()).sort(), ['roles/dev.md', 'roles/dispatcher.md'])
+  assert.equal(out.get('roles/dispatcher.md'), '调度正文', '自定义角色随 skill 自包含（不得过滤为仅内置）')
+})

--- a/scripts/test/validate-outcome-routing.test.mjs
+++ b/scripts/test/validate-outcome-routing.test.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import validatorCore from '../validate-core.cjs'
 
-const { validateBlueprint } = validatorCore
+const { validateBlueprint, deriveEntryCandidates } = validatorCore
 const here = path.dirname(fileURLToPath(import.meta.url))
 const good = JSON.parse(readFileSync(path.join(here, '../../templates/dev-workflow-2-0.json'), 'utf8'))
 const defaultWf = JSON.parse(readFileSync(path.join(here, '../../templates/default-workflow.json'), 'utf8'))
@@ -312,4 +312,11 @@ test('#126 同一 outcome 取值两条出边拒绝', () => {
   const b = clone(outcomeGood)
   b.edges.push({ from: 'evaluate', to: 'execute', outcome: 'PASS' })
   expectReject(b, 'PASS', 'dup-outcome')
+})
+
+test('回退 outcome 不计入入口入边：建设主链唯一入口仍是 requirements', () => {
+  const bp = JSON.parse(readFileSync(path.join(here, 'fixtures/construction-rollback-mini.json'), 'utf8'))
+  const cands = deriveEntryCandidates(bp.nodes, bp.edges)
+  assert.deepEqual(cands, ['requirements'], 'RETURN_* 不得把入口节点算成有入边：' + JSON.stringify(cands))
+  expectOk(bp, 'construction-rollback-mini')
 })

--- a/scripts/validate-core.cjs
+++ b/scripts/validate-core.cjs
@@ -62,6 +62,14 @@ function isStructuralEdge(e) {
   return !!(e && (e.on === 'success' || hasOutcomeField(e)))
 }
 
+// 回退边不计入入口入边（契约：failure/technical 本就不是结构边；新模式回退走
+// outcome + countRound，自环也视为回退）。未标 countRound 的前向 outcome 仍是结构入边。
+function isRollbackEdge(e) {
+  if (!isStructuralEdge(e)) return false
+  if (e.from === e.to) return true
+  return e.countRound !== undefined
+}
+
 function hasOutcomePath(n) {
   return !!(n && n.output && typeof n.output.outcomePath === 'string' && n.output.outcomePath.trim())
 }
@@ -216,7 +224,7 @@ function deriveEntryCandidates(nodes, edges) {
   nodes.forEach((n) => { if (n && n.id) ids[n.id] = true })
   const incoming = {}
   edges.forEach((e) => {
-    if (!isStructuralEdge(e)) return
+    if (!isStructuralEdge(e) || isRollbackEdge(e)) return
     if (!e.to || e.to === '$end' || e.to === HUMAN_DECISION_ID || !ids[e.to]) return
     const fromOk = ids[e.from] || e.from === HUMAN_DECISION_ID
     if (!fromOk) return

--- a/templates/default-workflow.json
+++ b/templates/default-workflow.json
@@ -1,7 +1,7 @@
 {
   "id": "default-workflow",
   "displayName": "默认工作流",
-  "description": "内置默认工作流（用户级）：issue 三要素门禁 → 开发 →（分流）测试/直审 → 审核 → 人工验收 → 收口，打回上限 9 轮；角色自包含分发，任意项目可用",
+  "description": "默认工作流（用户级）：issue 三要素门禁 → 开发 →（分流）测试/直审 → 审核 → 人工验收 → 收口，打回上限 9 轮；角色自包含分发，任意项目可用",
   "entry": "dispatch",
   "control": {
     "maxRounds": 9


### PR DESCRIPTION
## 主题与提交（一个 PR · 三个主题 commit，按依赖顺序）

1. `6d950dc` **feat(workflow): 蓝图 JSON 粘贴导入** — 编辑器 JSON 页签/保存直接接受蓝图落盘格式：`displayName`/`bindings.models` 摄入 DSL、`verifyBranch`/`bundleRoles` 保存往返、回退 outcome（`countRound`/自环）不再吞入口（校验内核 `deriveEntryCandidates` 与客户端拓扑/布局同构）。含构造蓝图夹具 `construction-rollback-mini`。
2. `463d5ad` **feat(workflow): 历史模板迁为自定义** — `default-workflow`/`dev-workflow-2-0` 不再占内置身份：list 标 `builtin=false`、可保存覆盖与删除；删除写 `removed/` 标记避免生成物复现；用户覆盖优先于同 id 生成物；删除后 save 可重建。
3. `d92b74b` **feat(visual-workflow): 角色库深化** — 内置角色清单数据化（`dsh/roles/builtin-roles.json`，12 内置 + dispatcher 迁出），决策逻辑收敛进 `scripts/role-library.cjs` 深模块（名称规则/来源优先级/摘要/引用统计/CRUD 裁决）；host 只留适配器与 7 个 RPC 薄壳；客户端权威校验走 `vwf.roles.validate`（即时非法名提示、删除 fail-closed）；validate-core/role-library 内核资产按信任序加载并同步开发 Home。

## 影响
- 用户：粘贴构造蓝图 JSON 不再丢展示名/模型绑定，回退边不再误标入口；两套历史模板可编辑/删除；角色命名非法字符/保留名输入即提示。
- 蓝图/生成结果：`templates/default-workflow.json` 描述文案更新（迁自定义措辞），`npm run generate` 已重跑。

## 已运行校验
`npm test`（引擎 312）、`npm run validate`（含包测试 155 + 蓝图/生成一致性）、`npm run release:verify` 全部通过；每个中间 commit 亦逐次跑过测试与 validate（A1 引擎 294/包 142；A2 引擎 294/包 143）。

## 编辑器改动
角色库管理 UI 与 JSON 导入路径有改动；开发 DSH 动态插件验证截图在验收阶段补充。