### PR TITLE
feat(visual-workflow): 画布两级序号排版

### DIFF
--- a/packages/dsh-visual-workflow/src/client.js
+++ b/packages/dsh-visual-workflow/src/client.js
@@ -490,6 +490,8 @@ return {
 .vwf-node-card { fill:var(--dsw-alias-bg-layer-2, #242424); stroke:var(--dsw-alias-border-l2, #333); stroke-width:1; }
 .vwf-node-kind { fill:var(--dsw-alias-label-tertiary, #8a8a8a); font-size:10px; letter-spacing:.14em; text-transform:uppercase; }
 .vwf-node-label { fill:var(--dsw-alias-label-primary, #e8e8e8); font-size:13px; font-weight:500; }
+.vwf-node-seq { fill:var(--dsw-alias-brand-text, var(--dsw-alias-brand-primary, #4d9fff)); font-size:11px; font-weight:700; font-variant-numeric:tabular-nums; }
+.vwf-node-seq-badge { fill:var(--dsw-alias-bg-layer-1, #1e1e1e); stroke:var(--dsw-alias-brand-primary, #4d9fff); stroke-width:1; }
 .vwf-handle { fill:var(--dsw-alias-label-tertiary, #8a8a8a); stroke:var(--dsw-alias-bg-layer-2, #242424); stroke-width:2; }
 /* 节点左右连接把手（拖出/落入连线的源与目标指示）：默认隐藏，节点悬停时显示，
    避免没有对应边的节点右侧出现无意义灰点（验收反馈）。 */
@@ -524,6 +526,7 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
     const MARGIN_Y = 64
     const CANVAS_PAD = 24
     const END_NODE = '$end'
+    const HUMAN_DECISION_ID = '$human-decision'
     const STATUS_COLOR = { running: 'var(--dsw-alias-brand-primary, #60a5fa)', pass: 'var(--dsw-alias-state-success-primary, #22c55e)', fail: 'var(--dsw-alias-state-error-primary, #ef4444)', human: 'var(--dsw-alias-state-warn-primary, #f59e0b)' }
     const EDGE_OK = '#2563eb'
     const EDGE_FAIL = 'var(--dsw-alias-state-error-primary, #f87171)'
@@ -558,6 +561,8 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
 
     // ── 拓扑与布局（对应 workflowGraph.ts 的 successTopologyOrder /
     //    deriveEntryCandidateIds / computeBackwardLanes / layoutSuccessPath）──
+    // 两级序号：主序号 = 前向最长路列（横轴 0…n）；同列多节点 = m.1…m.k（纵轴）。
+    // `$human-decision` 为透明跳板：A→HD→B 在排版上等价于前向边 A→B（回退旁路除外）。
     function hasOutcomeField(e) {
       return !!(e && e.outcome !== undefined && e.outcome !== null && e.outcome !== '')
     }
@@ -570,18 +575,69 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       if (e.from === e.to) return true
       return e.countRound !== undefined
     }
+    // 基图邻接（不含 HD）：用于判断 HD 出边是否回指上游（如验收退回→开发）。
+    function buildBaseForwardAdj(dsl, idSet) {
+      const adj = new Map()
+      idSet.forEach(id => adj.set(id, []))
+      ;(dsl.edges || []).forEach(e => {
+        if (!isStructuralEdge(e) || isRollbackEdge(e)) return
+        if (e.from === e.to) return
+        if (e.from === HUMAN_DECISION_ID || e.to === HUMAN_DECISION_ID) return
+        if (!idSet.has(e.from) || !idSet.has(e.to)) return
+        adj.get(e.from).push(e.to)
+      })
+      return adj
+    }
+    function canReachInAdj(adj, from, to) {
+      if (from === to) return true
+      const seen = new Set()
+      const stack = [from]
+      while (stack.length) {
+        const id = stack.pop()
+        if (seen.has(id)) continue
+        seen.add(id)
+        for (const next of (adj.get(id) || [])) {
+          if (next === to) return true
+          if (!seen.has(next)) stack.push(next)
+        }
+      }
+      return false
+    }
+    // 排版用前向边对：真实节点↔真实节点/$end，含 HD 透传；跳过回退与「HD 出边回指上游」。
+    function forEachLayoutForwardPair(dsl, idSet, visit) {
+      const edges = dsl.edges || []
+      const baseAdj = buildBaseForwardAdj(dsl, idSet)
+      const hdOuts = edges.filter(e =>
+        e && e.from === HUMAN_DECISION_ID && isStructuralEdge(e) && !isRollbackEdge(e) && e.to !== HUMAN_DECISION_ID
+      )
+      edges.forEach(e => {
+        if (!isStructuralEdge(e) || isRollbackEdge(e)) return
+        if (e.from === e.to) return
+        if (e.from === HUMAN_DECISION_ID) return
+        if (!idSet.has(e.from)) return
+        if (e.to === HUMAN_DECISION_ID) {
+          hdOuts.forEach(out => {
+            if (out.to === END_NODE) { visit(e.from, out.to, out); return }
+            if (!idSet.has(out.to)) return
+            // 目标能到达起点 ⇒ 回退旁路（退回开发等），不参与主序号前进
+            if (canReachInAdj(baseAdj, out.to, e.from)) return
+            visit(e.from, out.to, out)
+          })
+          return
+        }
+        if (idSet.has(e.to) || e.to === END_NODE) visit(e.from, e.to, e)
+      })
+    }
     function successTopologyOrder(dsl) {
       const ids = (dsl.nodes || []).map(n => n && n.id).filter(Boolean)
       const idSet = new Set(ids)
       const adjacency = new Map()
       const indegree = new Map()
       ids.forEach(id => { adjacency.set(id, []); indegree.set(id, 0) })
-      ;(dsl.edges || []).forEach(e => {
-        if (!isStructuralEdge(e) || isRollbackEdge(e)) return
-        if (e.from === e.to) return
-        if (!idSet.has(e.from) || !idSet.has(e.to)) return
-        adjacency.get(e.from).push(e.to)
-        indegree.set(e.to, (indegree.get(e.to) || 0) + 1)
+      forEachLayoutForwardPair(dsl, idSet, (from, to) => {
+        if (!idSet.has(to)) return
+        adjacency.get(from).push(to)
+        indegree.set(to, (indegree.get(to) || 0) + 1)
       })
       const queued = new Set()
       const queue = []
@@ -615,8 +671,8 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       const incoming = new Set()
       ;(dsl.edges || []).forEach(e => {
         if (!isStructuralEdge(e) || isRollbackEdge(e)) return
-        if (!e.to || e.to === END_NODE || e.to === '$human-decision' || !ids.has(e.to)) return
-        if (!(ids.has(e.from) || e.from === '$human-decision')) return
+        if (!e.to || e.to === END_NODE || e.to === HUMAN_DECISION_ID || !ids.has(e.to)) return
+        if (!(ids.has(e.from) || e.from === HUMAN_DECISION_ID)) return
         incoming.add(e.to)
       })
       return (dsl.nodes || []).map(n => n && n.id).filter(id => Boolean(id) && !incoming.has(id))
@@ -742,7 +798,7 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       return routes
     }
 
-    // 分层布局：success/前向边最长路定 rank，rank 内按拓扑序纵向堆叠并整体居中
+    // 分层布局：前向结构边（含 HD 透传）最长路定主序号；同列按拓扑序定子序号并纵向堆叠
     function layoutGraph(dsl, extraTerminals) {
       const nodeIds = (dsl.nodes || []).map(n => n.id).filter(Boolean)
       const idSet = new Set(nodeIds)
@@ -753,22 +809,26 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       const allIds = nodeIds.concat(terminalIds)
       const sizeOf = (id) => id === END_NODE ? { w: TERM_W, h: TERM_H } : { w: NODE_W, h: NODE_H }
 
-      // rank：前向结构边（success ∪ 非回退 outcome）定最长路；回退/失败边不把目标拉到更右
+      // 主序号（rank）：前向边最长路；回退边 / HD 回指上游不把目标拉到更右
       const rank = {}
       allIds.forEach(id => { rank[id] = 0 })
       let changed = true
       let guard = 0
       while (changed && guard++ < 100) {
         changed = false
-        for (const e of (dsl.edges || [])) {
-          // 自环边（防御脏数据）：不参与最长路 rank，避免自身 rank 无限自增
-          if (e.from === e.to) continue
-          if (!idSet.has(e.from)) continue
-          if (!(idSet.has(e.to) || e.to === END_NODE)) continue
-          if (isRollbackEdge(e) || (!isStructuralEdge(e) && isBackwardEdge(e.from, e.to, order))) continue
-          if (rank[e.from] + 1 > (rank[e.to] || 0)) { rank[e.to] = rank[e.from] + 1; changed = true }
-        }
+        forEachLayoutForwardPair(dsl, idSet, (from, to) => {
+          if (!(idSet.has(to) || to === END_NODE)) return
+          if (rank[from] + 1 > (rank[to] || 0)) { rank[to] = rank[from] + 1; changed = true }
+        })
       }
+      // $end 也可能只被非透传 failure 边指向；补一次直接边（非 rollback 结构边）
+      ;(dsl.edges || []).forEach(e => {
+        if (!e || e.to !== END_NODE || !idSet.has(e.from)) return
+        if (isRollbackEdge(e)) return
+        if (!isStructuralEdge(e) && isBackwardEdge(e.from, e.to, order)) return
+        if (rank[e.from] + 1 > (rank[END_NODE] || 0)) rank[END_NODE] = rank[e.from] + 1
+      })
+
       const layers = new Map()
       allIds.forEach(id => {
         const r = rank[id] || 0
@@ -777,6 +837,17 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       })
       const ranks = Array.from(layers.keys()).sort((a, b) => a - b)
       ranks.forEach(r => layers.get(r).sort((a, b) => (order.get(a) || 0) - (order.get(b) || 0)))
+
+      // 两级序号标签：单列单节点 → "m"；同列多个 → "m.1"…"m.k"（$end 不标业务序号）
+      const seqLabels = {}
+      ranks.forEach(r => {
+        const ids = layers.get(r).filter(id => id !== END_NODE)
+        if (ids.length === 1) {
+          seqLabels[ids[0]] = String(r)
+        } else {
+          ids.forEach((id, i) => { seqLabels[id] = r + '.' + (i + 1) })
+        }
+      })
 
       // 每层高度与整体居中
       const layerHeights = new Map()
@@ -826,7 +897,7 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
         maxRouteY += routeShift
       }
       const contentBottom = Math.max(maxY, maxRouteY > -Infinity ? maxRouteY : maxY)
-      return { pos, W: maxX + MARGIN_X, H: contentBottom + MARGIN_Y, lanes, routes, order }
+      return { pos, W: maxX + MARGIN_X, H: contentBottom + MARGIN_Y, lanes, routes, order, seqLabels, rank }
     }
 
     function uniqueNodeId(dsl, base) {
@@ -902,6 +973,7 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
       const pos = lay.pos
       const W = lay.W
       const H = lay.H
+      const seqLabels = lay.seqLabels || {}
 
       const fitView = React.useCallback(() => {
         const wrap = wrapRef.current
@@ -1169,6 +1241,8 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
           return
         }
         const stroke = isConnectTarget ? ACCENT : selected ? ACCENT : invalid ? 'var(--dsw-alias-state-error-primary, #e5484d)' : status ? STATUS_COLOR[status] : 'var(--dsw-alias-border-l2, #333)'
+        const seq = seqLabels[id]
+        const seqW = seq ? Math.max(22, 8 + String(seq).length * 7) : 0
         nodeEls.push(h('g', {
           key: 'n' + id, 'data-node-id': id, transform: 'translate(' + p.x + ',' + p.y + ')',
           style: { cursor: props.readOnly ? 'default' : 'pointer' },
@@ -1183,6 +1257,10 @@ g:hover > .vwf-handle { opacity:1; pointer-events:auto; fill:var(--dsw-alias-bra
           candidates.indexOf(id) >= 0 ? h('g', { key: 'eb' },
             h('rect', { className: 'vwf-entry-badge', x: -6, y: -9, width: 34, height: 16, rx: 8 }),
             h('text', { className: 'vwf-entry-badge-text', x: 11, y: 3, textAnchor: 'middle' }, t('entryBadge'))
+          ) : null,
+          seq ? h('g', { key: 'seq', 'data-node-seq': seq },
+            h('rect', { className: 'vwf-node-seq-badge', x: 8, y: 8, width: seqW, height: 18, rx: 6 }),
+            h('text', { className: 'vwf-node-seq', x: 8 + seqW / 2, y: 21, textAnchor: 'middle' }, seq)
           ) : null,
           h('text', { className: 'vwf-node-label', x: p.w / 2, y: p.h / 2 - 4, textAnchor: 'middle' }, (node && (node.label || node.id)) || id),
           h('text', { className: 'vwf-node-kind', x: p.w / 2, y: p.h / 2 + 15, textAnchor: 'middle' }, (node && node.kind) || 'worker'),

--- a/packages/dsh-visual-workflow/tests/client.smoke.mjs
+++ b/packages/dsh-visual-workflow/tests/client.smoke.mjs
@@ -792,6 +792,110 @@ test('防重叠：入口变化会触发画布布局重算', async () => {
   assert.ok(yOf('b') < yOf('a'), 'entry 改为 b 后 B 排在 A 上方')
 })
 
+test('两级序号：HD 透传后收口主序号在 UAT 右侧，不再与入口同列', async () => {
+  const hdDsl = {
+    id: 'hd-seq-layout',
+    name: 'HD 序号布局',
+    entry: 'preflight',
+    control: { maxRounds: 3 },
+    nodes: [
+      { id: 'preflight', profile: 'evaluator', label: '实施前检查' },
+      { id: 'dev', profile: 'dev', label: '开发' },
+      { id: 'uat', profile: 'accept', label: 'UAT 准备' },
+      { id: 'closeout', profile: 'closeout', label: '收口' },
+    ],
+    edges: [
+      { from: 'preflight', to: 'dev', outcome: 'PASS' },
+      { from: 'dev', to: 'uat', outcome: 'READY' },
+      { from: 'uat', to: '$human-decision', outcome: 'READY_FOR_HUMAN' },
+      { from: '$human-decision', to: 'closeout', outcome: 'ACCEPT' },
+      { from: '$human-decision', to: 'dev', outcome: 'REJECT' },
+      { from: 'closeout', to: '$end', outcome: 'DELIVERED' },
+    ],
+  }
+  // 为 outcome 边补最小 schema，避免编辑器侧校验干扰画布（本测只关心布局）
+  hdDsl.nodes.forEach((n) => {
+    if (n.id === 'preflight') n.output = { outcomePath: '$.route', schema: { type: 'object', properties: { route: { type: 'string', enum: ['PASS'] } }, required: ['route'], additionalProperties: false } }
+    if (n.id === 'dev') n.output = { outcomePath: '$.route', schema: { type: 'object', properties: { route: { type: 'string', enum: ['READY'] } }, required: ['route'], additionalProperties: false } }
+    if (n.id === 'uat') n.output = { outcomePath: '$.route', schema: { type: 'object', properties: { route: { type: 'string', enum: ['READY_FOR_HUMAN'] } }, required: ['route'], additionalProperties: false } }
+    if (n.id === 'closeout') n.output = { outcomePath: '$.status', schema: { type: 'object', properties: { status: { type: 'string', enum: ['DELIVERED'] } }, required: ['status'], additionalProperties: false } }
+  })
+  await act(async () => {
+    const jsonTab = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'JSON')
+    jsonTab.click()
+    await flush()
+    const textarea = container.querySelector('textarea.vwf-json-edit')
+    const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLTextAreaElement.prototype, 'value').set
+    setter.call(textarea, JSON.stringify(hdDsl, null, 2))
+    textarea.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+    await flush()
+    const canvasTab = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '画布')
+    canvasTab.click()
+    await flush()
+  })
+  const xyOf = (id) => {
+    const g = container.querySelector('g[data-node-id="' + id + '"]')
+    assert.ok(g, '缺少节点 ' + id)
+    const match = /translate\(([-\d.]+),([-\d.]+)\)/.exec(g.getAttribute('transform'))
+    return { x: Number(match[1]), y: Number(match[2]) }
+  }
+  const seqOf = (id) => {
+    const g = container.querySelector('g[data-node-id="' + id + '"]')
+    const badge = g && g.querySelector('[data-node-seq]')
+    return badge ? badge.getAttribute('data-node-seq') : null
+  }
+  const pre = xyOf('preflight')
+  const close = xyOf('closeout')
+  assert.ok(close.x > pre.x + 50, '收口应在实施前检查右侧（HD 透传后主序号前进），got pre.x=' + pre.x + ' close.x=' + close.x)
+  assert.equal(seqOf('preflight'), '0')
+  assert.equal(seqOf('dev'), '1')
+  assert.equal(seqOf('uat'), '2')
+  assert.equal(seqOf('closeout'), '3')
+})
+
+test('两级序号：同列多节点显示 m.1 / m.2 且上小下大', async () => {
+  const parallelDsl = {
+    id: 'parallel-seq',
+    name: '同列序号',
+    entry: 'a',
+    control: { maxRounds: 9 },
+    nodes: [
+      { id: 'a', profile: 'dispatcher', label: 'A' },
+      { id: 'b1', profile: 'dev', label: 'B1' },
+      { id: 'b2', profile: 'review', label: 'B2' },
+    ],
+    edges: [
+      { from: 'a', to: 'b1', on: 'success' },
+      { from: 'a', to: 'b2', on: 'success' },
+      { from: 'b1', to: '$end', on: 'success' },
+      { from: 'b2', to: '$end', on: 'success' },
+    ],
+  }
+  await act(async () => {
+    const jsonTab = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'JSON')
+    jsonTab.click()
+    await flush()
+    const textarea = container.querySelector('textarea.vwf-json-edit')
+    const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLTextAreaElement.prototype, 'value').set
+    setter.call(textarea, JSON.stringify(parallelDsl, null, 2))
+    textarea.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+    await flush()
+    const canvasTab = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '画布')
+    canvasTab.click()
+    await flush()
+  })
+  const yOf = (id) => {
+    const g = container.querySelector('g[data-node-id="' + id + '"]')
+    const match = /translate\(([-\d.]+),([-\d.]+)\)/.exec(g.getAttribute('transform'))
+    return Number(match[2])
+  }
+  const seqOf = (id) => container.querySelector('g[data-node-id="' + id + '"] [data-node-seq]').getAttribute('data-node-seq')
+  assert.equal(seqOf('a'), '0')
+  assert.equal(seqOf('b1'), '1.1')
+  assert.equal(seqOf('b2'), '1.2')
+  assert.ok(yOf('b1') < yOf('b2'), '同列 1.1 应在 1.2 上方')
+})
+
 test('自环边：布局不进入死循环，终点仍在节点左边框垂直居中', async () => {
   const selfLoopDsl = {
     id: 'self-loop',

--- a/templates/dev-workflow-2-0.json
+++ b/templates/dev-workflow-2-0.json
@@ -18,6 +18,10 @@
         "provider": "deepseek-official",
         "model": "deepseek-v4-pro"
       },
+      "dev-2": {
+        "provider": "deepseek-official",
+        "model": "deepseek-v4-pro"
+      },
       "route": {
         "provider": "deepseek-official",
         "model": "deepseek-v4-flash"
@@ -143,6 +147,42 @@
         "successCondition": "$.status == \"completed\"",
         "files": {
           "dev-report.md": "markdown"
+        }
+      }
+    },
+    {
+      "id": "dev-2",
+      "label": "开发 2 号",
+      "profile": "dev",
+      "goal": "（两级序号验证用）与「开发」同级并行节点；在工作分支施工（tdd），本地验证全绿后提交（不推送、不建 PR）；写 `dev-2-report.md` 并更新 STATE.md。环境受阻时 status 报 blocked。",
+      "output": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "completed",
+                "blocked"
+              ]
+            },
+            "summary": {
+              "type": "string"
+            },
+            "self_verify": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "summary",
+            "self_verify"
+          ],
+          "additionalProperties": false
+        },
+        "successCondition": "$.status == \"completed\"",
+        "files": {
+          "dev-2-report.md": "markdown"
         }
       }
     },
@@ -346,7 +386,14 @@
     {
       "from": "dispatch",
       "to": "dev",
-      "on": "success"
+      "on": "success",
+      "when": "$.complete == true"
+    },
+    {
+      "from": "dispatch",
+      "to": "dev-2",
+      "on": "success",
+      "when": "$.complete == true"
     },
     {
       "from": "dispatch",
@@ -360,6 +407,16 @@
     },
     {
       "from": "dev",
+      "to": "$end",
+      "on": "failure"
+    },
+    {
+      "from": "dev-2",
+      "to": "route",
+      "on": "success"
+    },
+    {
+      "from": "dev-2",
       "to": "$end",
       "on": "failure"
     },


### PR DESCRIPTION
## Summary
- 画布节点增加两级序号：横轴主序号 `0…n`，同列多节点 `m.1…m.k`（单列只显示 `m`）
- 人工验收点按透明跳板参与排版，避免「收口」叠到入口列
- 「开发工作流 2.0」临时增加「开发 2 号」与「开发」同列，便于目视核对 `1.1` / `1.2`

## Test plan
- [x] `node --test packages/dsh-visual-workflow/tests/client.smoke.mjs`（含 HD 透传与同列序号用例）
- [ ] 硬刷新 DSH，打开「开发工作流 2.0」：调度为 0，同列见 1.1 开发 / 1.2 开发 2 号
- [ ] 打开「完整功能开发」：收口在主链右侧，不再在实施前检查下方


Made with [Cursor](https://cursor.com)